### PR TITLE
Shipit yml

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -14,6 +14,7 @@ gem 'faker'
 gem 'settingslogic'
 gem 'omniauth'
 gem 'omniauth-google-apps'
+gem 'safe_yaml', require: 'safe_yaml/load'
 
 group :production do
   gem 'mysql2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,7 @@ GEM
     ruby-openid (2.3.0)
     ruby-openid-apps-discovery (1.2.0)
       ruby-openid (>= 2.1.7)
+    safe_yaml (1.0.1)
     sass (3.2.14)
     sass-rails (4.0.1)
       railties (>= 4.0.0, < 5.0)
@@ -219,6 +220,7 @@ DEPENDENCIES
   rails!
   resque (= 1.26.pre.0)
   resque-lock
+  safe_yaml
   sass-rails (~> 4.0.0)
   settingslogic
   sqlite3

--- a/app/jobs/deploy_job.rb
+++ b/app/jobs/deploy_job.rb
@@ -15,8 +15,8 @@ class DeployJob < BackgroundJob
     capture commands.clone
     capture commands.checkout(@deploy.until_commit)
     Bundler.with_clean_env do
-      capture commands.bundle_install
-      capture commands.deploy(@deploy.until_commit)
+      capture_all commands.install_dependencies
+      capture_all commands.deploy(@deploy.until_commit)
     end
     @deploy.complete!
   rescue Command::Error
@@ -24,6 +24,10 @@ class DeployJob < BackgroundJob
   rescue StandardError
     @deploy.error!
     raise
+  end
+
+  def capture_all(commands)
+    commands.map { |c| capture(c) }
   end
 
   def capture(command)

--- a/config/initializers/safe_yaml.rb
+++ b/config/initializers/safe_yaml.rb
@@ -1,0 +1,2 @@
+SafeYAML::OPTIONS[:default_mode] = :safe
+SafeYAML::OPTIONS[:deserialize_symbols] = false

--- a/lib/deploy_spec.rb
+++ b/lib/deploy_spec.rb
@@ -1,0 +1,67 @@
+require 'pathname'
+
+class DeploySpec
+  BUNDLE_PATH = File.join(Rails.root, "data", "bundler")
+  DEFAULT_BUNDLER_WITHOUT = %w(developement test benchmark debug)
+  Error = Class.new(StandardError)
+
+  def initialize(app_dir)
+    @app_dir = Pathname(app_dir)
+  end
+
+  def config(*keys)
+    @config ||= load_config
+    keys.flatten.reduce(@config) { |h, k| h[k] if h.respond_to?(:[]) }
+  end
+
+  def dependencies_steps
+    config('dependencies', 'override') || discover_bundler || []
+  end
+
+  def deploy_steps
+    config('deploy', 'override') || discover_capistrano || cant_detect_deploy_steps
+  end
+
+  def discover_bundler
+    bundle_install if bundler?
+  end
+
+  def bundle_install
+    [%Q(bundle install --frozen --path=#{BUNDLE_PATH} --retry=2 --without=#{bundler_without.join(':')})]
+  end
+
+  def bundler_without
+    config('dependencies', 'bundler', 'without') || DEFAULT_BUNDLER_WITHOUT
+  end
+
+  def discover_capistrano
+    bundle_exec = ''
+    bundle_exec = 'bundle exec ' if bundler?
+    ["#{bundle_exec}cap $ENVIRONMENT deploy"] if capistrano?
+  end
+
+  def capistrano?
+    @app_dir.join('Capfile').exist?
+  end
+
+  def bundler?
+    @app_dir.join('Gemfile').exist?
+  end
+
+  def cant_detect_deploy_steps
+    raise DeploySpec::Error, 'Impossible to detect how to deploy this application. Please define `deploy.override` in your shipit.yml'
+  end
+
+  def load_config
+    if shipit_yml.exist?
+      SafeYAML.load(shipit_yml.read)
+    else
+      {}
+    end
+  end
+
+  def shipit_yml
+    @app_dir.join('shipit.yml')
+  end
+
+end

--- a/shipit.yml
+++ b/shipit.yml
@@ -1,0 +1,10 @@
+dependencies:
+  bundler:
+    without:
+      - default
+      - production
+      - development
+      - test
+      - staging
+      - benchmark
+      - debug

--- a/test/unit/deploy_spec_test.rb
+++ b/test/unit/deploy_spec_test.rb
@@ -1,0 +1,61 @@
+require 'test_helper'
+
+class DeploySpecTest < ActiveSupport::TestCase
+
+  setup do
+    @spec = DeploySpec.new('.')
+    @spec.stubs(:load_config).returns({})
+  end
+
+  test '#dependencies_steps returns `dependencies.override` if present' do
+    @spec.stubs(:load_config).returns('dependencies' => {'override' => %w(foo bar baz)})
+    assert_equal %w(foo bar baz), @spec.dependencies_steps
+  end
+
+  test '#dependencies_steps returns `bundle install` if a `Gemfile` is present' do
+    @spec.expects(:bundler?).returns(true)
+    @spec.expects(:bundle_install).returns(:bundle_install)
+    assert_equal :bundle_install, @spec.dependencies_steps
+  end
+
+  test '#bundle_install return a sane default bundle install command' do
+    command = %Q(
+      bundle install
+      --frozen
+      --path=#{DeploySpec::BUNDLE_PATH}
+      --retry=2
+      --without=developement:test:benchmark:debug
+    ).gsub(/\s+/, ' ').strip
+    assert_equal command, @spec.bundle_install.first
+  end
+
+  test '#bundle_install use `dependencies.bundler.without` if present to build the --without argument' do
+    @spec.stubs(:load_config).returns('dependencies' => {'bundler' => {'without' => %w(some custom groups)}})
+    command = %Q(
+      bundle install
+      --frozen
+      --path=#{DeploySpec::BUNDLE_PATH}
+      --retry=2
+      --without=some:custom:groups
+    ).gsub(/\s+/, ' ').strip
+    assert_equal command, @spec.bundle_install.first
+  end
+
+  test '#deploy_steps returns `deploy.override` if present' do
+    @spec.stubs(:load_config).returns('deploy' => {'override' => %w(foo bar baz)})
+    assert_equal %w(foo bar baz), @spec.deploy_steps
+  end
+
+  test '#deploy_steps returns `cap $ENVIRONMENT deploy` if a `Capfile` is present' do
+    @spec.expects(:capistrano?).returns(true)
+    assert_equal ['bundle exec cap $ENVIRONMENT deploy'], @spec.deploy_steps
+  end
+
+  test '#deploy_steps raise a DeploySpec::Error if it dont know how to deploy the app' do
+    @spec.expects(:capistrano?).returns(false)
+    assert_raise DeploySpec::Error do
+      @spec.deploy_steps
+    end
+  end
+
+end

--- a/test/unit/jobs/deploy_job_test.rb
+++ b/test/unit/jobs/deploy_job_test.rb
@@ -15,14 +15,15 @@ class DeployJobTest < ActiveSupport::TestCase
     @commands.expects(:fetch).once
     @commands.expects(:clone).once
     @commands.expects(:checkout).with(@deploy.until_commit).once
-    @commands.expects(:bundle_install).once
-    @commands.expects(:deploy).with(@deploy.until_commit).once
+    @commands.expects(:install_dependencies).returns([]).once
+    @commands.expects(:deploy).with(@deploy.until_commit).returns([]).once
 
     @job.perform(deploy_id: @deploy.id)
   end
 
   test "marks deploy as successful" do
     Dir.stubs(:chdir).yields
+    DeployCommands.any_instance.stubs(:deploy).returns([])
     @job.stubs(:capture)
 
     @job.perform(deploy_id: @deploy.id)


### PR DESCRIPTION
Shipit now
- Look for a shipit.yml file.
- Parse it with YAMLSafe
- Use it's config if present
- Detect capistrano usage
- Detect bundler usage

YAMLSafe prevent arbitrary object deserialization and symbol deserialization.
It should be enought to limit the attack vector.

We do allow the execuction of arbitrary commands by the application anyway...

PS: The diff is bigger than it should because the PR also include #25.
So look at f6dfecb for review.

/review @gmalette @wisq.

@wisq what do you think about allowing custom commands inside `shipit.yml`? I do agree that it's a huge attack vector but... It's so flexible.
