### PR TITLE
failed vs error deploys

### DIFF
--- a/app/jobs/background_job.rb
+++ b/app/jobs/background_job.rb
@@ -6,4 +6,8 @@ class BackgroundJob
 
     new.perform(*args)
   end
+
+  def logger
+    Rails.logger
+  end
 end

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -18,10 +18,15 @@ class Deploy < ActiveRecord::Base
       transition running: :success
     end
 
+    event :error do
+      transition running: :error
+    end
+
     state :pending
     state :running
     state :failed
     state :success
+    state :error
   end
 
   def commits


### PR DESCRIPTION
Add a new error status for deploys.

If any commands return an error code, we mark the deploy as `failed`.
If anything is raised from shipit, we mark the deploy as `error`
If the deploy is in any other state than `pending` when we start the deploy job, then we bail out.

/review @gmalette 
