### PR TITLE
Allow stacks to define a checklist

### DIFF
--- a/app/assets/javascripts/checklist.js.coffee
+++ b/app/assets/javascripts/checklist.js.coffee
@@ -1,0 +1,10 @@
+$document = $(document)
+
+toggleDeployButton = ->
+  $('.trigger-deploy').toggleClass('disabled', !!$(':checkbox[name=checklist]:not(:checked)').length)
+
+if $('html[data-controller=deploys][data-action=new]').length
+  $document.on('change', ':checkbox[name=checklist]', toggleDeployButton)
+
+jQuery ($) ->
+  toggleDeployButton()

--- a/app/assets/stylesheets/_pages/_settings.scss
+++ b/app/assets/stylesheets/_pages/_settings.scss
@@ -1,0 +1,6 @@
+.setting-section {
+  textarea {
+    width: 800px;
+    height: 200px;
+  }
+}

--- a/app/assets/stylesheets/master.scss
+++ b/app/assets/stylesheets/master.scss
@@ -2,3 +2,4 @@
 @import "_structure/_main";
 @import "_structure/_sidebar";
 @import "_pages/_commits";
+@import "_pages/_settings";

--- a/app/controllers/stacks_controller.rb
+++ b/app/controllers/stacks_controller.rb
@@ -1,5 +1,5 @@
 class StacksController < ApplicationController
-  before_action :load_stack, only: %i(destroy settings sync_webhooks sync_commits clear_git_cache)
+  before_action :load_stack, only: %i(update destroy settings sync_webhooks sync_commits clear_git_cache)
 
   def new
     @stack = Stack.new
@@ -32,6 +32,11 @@ class StacksController < ApplicationController
   end
 
   def settings
+  end
+
+  def update
+    @stack.update(params.require(:stack).permit(:checklist))
+    redirect_to settings_stack_path(@stack)
   end
 
   def sync_commits

--- a/app/models/stack.rb
+++ b/app/models/stack.rb
@@ -86,6 +86,10 @@ class Stack < ActiveRecord::Base
     ).first!
   end
 
+  def checks
+    checklist.to_s.lines.map(&:strip).select(&:present?)
+  end
+
   private
 
   def setup_webhooks

--- a/app/views/deploys/new.html.erb
+++ b/app/views/deploys/new.html.erb
@@ -35,14 +35,30 @@
 
   </section>
 
+  <%- if @stack.checklist? -%>
+    <section>
+      <header class="section-header">
+        <h2>Checklist</h2>
+      </header>
+
+      <ul class="checklist">
+        <%- @stack.checks.each do |check| -%>
+          <li>
+            <label>
+              <%= check_box_tag :checklist %>
+              <%= sanitize(check, tags: %w(a strong), attributes: %w(href target)) %>
+            </label>
+          </li>
+        <%- end -%>
+      </ul>
+    </section>
+  <%- end -%>
 
   <section class="submit-section">
     <%= form_for [@stack, @deploy] do |f| %>
       <%= f.hidden_field :until_commit_id %>
-      <%= f.submit :class => ['btn', 'primary'] %>
+      <%= f.submit :class => ['btn', 'primary', 'trigger-deploy'] %>
     <% end %>
   </section>
-
-
 
 </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html data-controller="<%= controller_name %>" data-action="<%= action_name %>">
 <head>
   <title>Shipit</title>
   <%= stylesheet_link_tag "master", media: "all" %>

--- a/app/views/stacks/settings.html.erb
+++ b/app/views/stacks/settings.html.erb
@@ -17,6 +17,14 @@
       <h2>Settings</h2>
     </header>
     <div class="setting-section">
+      <%= form_for @stack do |f| %>
+        <p>Checklist (Leave a blank line between items, HTML &lt;a&gt; and &lt;strong&gt; elements are authorized)</p>
+        <p><%= f.text_area :checklist %></p>
+        <p><%= f.submit class: "btn" %></p>
+      <%- end -%>
+    </div>
+
+    <div class="setting-section">
       <h5>Resynchronize this stack</h5>
       <p>Ensure that all required webhooks have been created.</p>
       <%= button_to "Webhooks", sync_webhooks_stack_path(@stack), class: "btn", method: "post" %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -19,7 +19,7 @@ Shipit::Application.routes.draw do
   end
 
   # Humans
-  resources :stacks, :path => "/", :id => %r{[^/]+/[^/]+/[^/]+}, :only => [:show, :destroy] do
+  resources :stacks, :path => "/", :id => %r{[^/]+/[^/]+/[^/]+}, only: %i(show destroy update) do
     member do
       get :settings
       post :sync_commits

--- a/db/migrate/20140325152725_add_checklist_to_stack.rb
+++ b/db/migrate/20140325152725_add_checklist_to_stack.rb
@@ -1,0 +1,5 @@
+class AddChecklistToStack < ActiveRecord::Migration
+  def change
+    add_column :stacks, :checklist, :text, default: nil, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -64,6 +64,7 @@ ActiveRecord::Schema.define(version: 20140325173951) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "branch",      default: "master",     null: false
+    t.text     "checklist"
   end
 
   add_index "stacks", ["repo_owner", "repo_name", "environment"], name: "stack_unicity", unique: true


### PR DESCRIPTION
Add a textarea in settings.

Each check have to be separated by a blank line.

Checks can contain simple <a> and <strong> html elements.

a JS disable the deploy button until all checks have been toggled
