### PR TITLE
Allow to define custon environment variables in shipit.yml

### DIFF
--- a/lib/deploy_commands.rb
+++ b/lib/deploy_commands.rb
@@ -9,6 +9,7 @@ class DeployCommands < Commands
   end
 
   def install_dependencies
+    env = self.env.merge(deploy_spec.machine_env)
     deploy_spec.dependencies_steps.map do |command_line|
       Command.new(command_line, env: env, chdir: @deploy.working_directory)
     end
@@ -20,7 +21,7 @@ class DeployCommands < Commands
       'ENVIRONMENT' => @stack.environment,
       'USER' => "#{@deploy.user_name} via Shipit 2",
       'EMAIL' => @deploy.user_email,
-    )
+    ).merge(deploy_spec.machine_env)
     deploy_spec.deploy_steps.map do |command_line|
       Command.new(command_line, env: env, chdir: @deploy.working_directory)
     end

--- a/lib/deploy_spec.rb
+++ b/lib/deploy_spec.rb
@@ -14,6 +14,10 @@ class DeploySpec
     keys.flatten.reduce(@config) { |h, k| h[k] if h.respond_to?(:[]) }
   end
 
+  def machine_env
+    config('machine', 'environment') || {}
+  end
+
   def dependencies_steps
     config('dependencies', 'override') || discover_bundler || []
   end

--- a/test/unit/deploy_commands_test.rb
+++ b/test/unit/deploy_commands_test.rb
@@ -8,6 +8,7 @@ class DeployCommandsTest < ActiveSupport::TestCase
     @deploy_spec = stub(
       dependencies_steps: ['bundle install --some-args'],
       deploy_steps: ['bundle exec cap $ENVIRONMENT deploy'],
+      machine_env: {'GLOBAL' => '1'},
     )
     @commands.stubs(:deploy_spec).returns(@deploy_spec)
     StackCommands.stubs(git_version: Gem::Version.new('1.8.4.3'))
@@ -104,6 +105,11 @@ class DeployCommandsTest < ActiveSupport::TestCase
     assert_equal 5, command.env["SPECIFIC_CONFIG"]
   end
 
+  test "#deploy merges shipit.yml machine_env in ENVIRONMENT" do
+    command = @commands.deploy(@deploy.until_commit).first
+    assert_equal '1', command.env['GLOBAL']
+  end
+
   test "#install_dependencies call bundle install" do
     commands = @commands.install_dependencies
     assert_equal 1, commands.length
@@ -114,6 +120,11 @@ class DeployCommandsTest < ActiveSupport::TestCase
     Settings.stubs(:[]).with('env').returns("SPECIFIC_CONFIG" => 5)
     command = @commands.install_dependencies.first
     assert_equal 5, command.env["SPECIFIC_CONFIG"]
+  end
+
+  test "#install_dependencies merges machine_env in ENVIRONMENT" do
+    command = @commands.install_dependencies.first
+    assert_equal '1', command.env['GLOBAL']
   end
 
 end

--- a/test/unit/deploy_spec_test.rb
+++ b/test/unit/deploy_spec_test.rb
@@ -60,4 +60,9 @@ class DeploySpecTest < ActiveSupport::TestCase
     end
   end
 
+  test '#machine_env return an environment hash' do
+    @spec.stubs(:load_config).returns('machine' => {'environment' => {'GLOBAL' => '1'}})
+    assert_equal({'GLOBAL' => '1'}, @spec.machine_env)
+  end
+
 end


### PR DESCRIPTION
eg:

``` yaml
environment:
  FOO: 1
dependencies:
  environment:
    EGG: 1
deploy:
  environment:
    BAR: 1
```

/review @gmalette 
