### PR TITLE
Wrap wide pre tags to avoid horizontal scrolling

### DIFF
--- a/app/assets/stylesheets/_structure/_main.scss
+++ b/app/assets/stylesheets/_structure/_main.scss
@@ -47,7 +47,7 @@ pre {
   padding: 1.5rem;
   line-height: 1.5em;
   margin-top: -.25rem;
-  font-family: "Source Code Pro"
+  font-family: "Source Code Pro";
   white-space: pre-wrap;
 }
 


### PR DESCRIPTION
Not sure if this was done on purpose, but the deploy output pre scrolls really really far to the right, which is hard to use on smaller screens. If that was the intended behaviour, feel free to disregard/close this PR.
