### PR TITLE
Change size limit for OutputChunk#text to 1 megabyte

### DIFF
--- a/db/migrate/20140415142820_change_output_chunk_text_type.rb
+++ b/db/migrate/20140415142820_change_output_chunk_text_type.rb
@@ -1,0 +1,5 @@
+class ChangeOutputChunkTextType < ActiveRecord::Migration
+  def change
+    change_column :output_chunks, :text, :text, limit: 1.megabyte
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140415010655) do
+ActiveRecord::Schema.define(version: 20140415142820) do
 
   create_table "commits", force: true do |t|
     t.integer  "stack_id",                                    null: false
@@ -51,7 +51,7 @@ ActiveRecord::Schema.define(version: 20140415010655) do
 
   create_table "output_chunks", force: true do |t|
     t.integer  "deploy_id"
-    t.text     "text"
+    t.text     "text",       limit: 1048576
     t.datetime "created_at"
     t.datetime "updated_at"
   end


### PR DESCRIPTION
`ChunkRollupJob` is having issues as the combined logs are sometimes too big for the column (Rails sets the maximum size for `TEXT` columns to 65k by default).

https://shipit2.shopify.com/resque/failed?start=840
