### PR TITLE
Use session_user[:email] instead of session[:email]

### DIFF
--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -26,7 +26,7 @@ class DeploysController < ApplicationController
     {
       user_email: session_user[:email] || 'anonymous@example.com',
       user_name: session_user[:name] || 'Anonymous',
-      user: session_user[:email] && User.find_by_email(session[:email])
+      user: session_user[:email] && User.find_by_email(session_user[:email])
     }
   end
 


### PR DESCRIPTION
@gmalette @byroot 

Maybe we were getting Adrian's user back because his email is `nil` for some reason? Not too sure — should probably check that. In any case, `session[:email]` doesn't seem to be set anywhere and `session_user[:email]` seems more logical.

To be honest, I'm not too sure if this fixes the issue entirely or not. It seems like it should, but it's hard to test locally without having a bunch of users.

I've gotta leave right after lunch today. Could someone look into this a bit? Or at least see if we actually have the correct users assigned to deploys. Otherwise, I can revert my previous PR for the time being to prevent some confusion / hilarity.
