### PR TITLE
pimp the deploy page

### DIFF
--- a/app/assets/stylesheets/_structure/_main.scss
+++ b/app/assets/stylesheets/_structure/_main.scss
@@ -41,7 +41,7 @@
   }
 
 pre {
-  background-color: rgba(#2E343A, .9);
+  background-color: rgba(#101010, .9);
   overflow: scroll;
   color: #fff;
   padding: 1.5rem;
@@ -88,4 +88,21 @@ pre {
   p.deploy-url {
     color: white;
   }
+
+  p.deploy-sha {
+    color: white;
+    font-size: larger;
+    margin-top: 10px;
+  }
+
+  hr {
+    background-color: rgba(#000, .4);;
+    border: 0;
+    height: 1px;
+  }
+
+  .status {
+    margin-top: 1rem;
+  }
 }
+

--- a/app/views/deploys/show.html.erb
+++ b/app/views/deploys/show.html.erb
@@ -1,16 +1,18 @@
-<section>
-
-<div class="wrapper">
-  <header class="section-header">
+<header class="repo-header">
+  <div class="wrapper">
     <div class="status" data-deploy-status="<%= @deploy.status %>">
       <i></i>
     </div>
-    <h1>Deploying <%= @deploy.until_commit.short_sha %></h1>
-  </header>
-
+    <div class="repo-name">
+      <p>Repo owned by <%= @stack.repo_owner %></p>
+      <h1><a href="<%= stack_path(@stack) %>"><%= @stack.repo_name %> <small><%= @stack.environment %></small></a></h1>
+      <hr />
+      <p class="deploy-sha">Deploying <%= @deploy.until_commit.short_sha %></p>
+    </div>
+  </div>
+</header>
+<div class="deploy-status">
+  <pre>
+    <code data-next-chunks-url="<%= next_chunks_url %>"><%= @deploy.chunk_output %></code>
+  </pre>
 </div>
-
-<pre>
-  <code data-next-chunks-url="<%= next_chunks_url %>"><%= @deploy.chunk_output %></code>
-</pre>
-</section>


### PR DESCRIPTION
I am mildly annoyed that there is no quick way to go back to the stack from the deploy page, so I added the same header that is on every other page.

![screen shot 2014-05-12 at 12 38 27 pm](https://cloud.githubusercontent.com/assets/2053039/2947228/e068f34c-d9f3-11e3-8604-f94f0313c67e.png)

Also I made the background darker to remind me of my sweet console. This page could use a review from a real designer but in the meantime at least I have a back button :)

@byroot @gmalette @kevinfinlayson @vernalkick 
