### PR TITLE
Get rid of deploys.user_email and user_name and rely only on Users

### DIFF
--- a/app/models/anonymous_user.rb
+++ b/app/models/anonymous_user.rb
@@ -3,6 +3,10 @@ class AnonymousUser
     'anonymous@example.com'
   end
 
+  def login
+    'anonymous'
+  end
+
   def name
     'Anonymous'
   end

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -37,6 +37,10 @@ class Deploy < ActiveRecord::Base
 
   after_create :broadcast_deploy
 
+  def author
+    user || AnonymousUser.new
+  end
+
   def finished?
     !pending? && !running?
   end

--- a/app/models/stack.rb
+++ b/app/models/stack.rb
@@ -19,8 +19,6 @@ class Stack < ActiveRecord::Base
     since_commit = last_deployed_commit
 
     deploy = deploys.create(
-      user_email: user.email,
-      user_name: user.name,
       user_id: user.id,
       until_commit: until_commit,
       since_commit: since_commit

--- a/app/views/deploys/_deploy.html.erb
+++ b/app/views/deploys/_deploy.html.erb
@@ -5,7 +5,7 @@
   </div>
   <div class="event">
     <span class="event-meta">
-      <a href="#" class="user main-user disabled"><%= deploy.user_name %></a>
+      <a href="#" class="user main-user disabled"><%= deploy.author.name %></a>
       deployed <%= timeago_tag(deploy.created_at, force: true) %>
     </span>
     <span class="event-title">

--- a/db/migrate/20140512170113_remove_deploys_user_data.rb
+++ b/db/migrate/20140512170113_remove_deploys_user_data.rb
@@ -1,0 +1,6 @@
+class RemoveDeploysUserData < ActiveRecord::Migration
+  def change
+    remove_column :deploys, :user_email
+    remove_column :deploys, :user_name
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140506140931) do
+ActiveRecord::Schema.define(version: 20140512170113) do
 
   create_table "commits", force: true do |t|
     t.integer  "stack_id",                                    null: false
@@ -33,14 +33,12 @@ ActiveRecord::Schema.define(version: 20140506140931) do
   add_index "commits", ["stack_id"], name: "index_commits_on_stack_id"
 
   create_table "deploys", force: true do |t|
-    t.integer  "stack_id",                                          null: false
-    t.integer  "since_commit_id",                                   null: false
-    t.integer  "until_commit_id",                                   null: false
-    t.string   "status",          default: "pending",               null: false
+    t.integer  "stack_id",                            null: false
+    t.integer  "since_commit_id",                     null: false
+    t.integer  "until_commit_id",                     null: false
+    t.string   "status",          default: "pending", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "user_name",       default: "Anonymous",             null: false
-    t.string   "user_email",      default: "anonymous@example.com", null: false
     t.integer  "user_id"
   end
 

--- a/lib/deploy_commands.rb
+++ b/lib/deploy_commands.rb
@@ -16,12 +16,12 @@ class DeployCommands < Commands
   end
 
   def deploy(commit)
-    normalized_name = ActiveSupport::Inflector.transliterate(@deploy.user_name)
+    normalized_name = ActiveSupport::Inflector.transliterate(@deploy.author.name)
     env = self.env.merge(
       'SHA' => commit.sha,
       'ENVIRONMENT' => @stack.environment,
-      'USER' => "#{normalized_name} via Shipit 2",
-      'EMAIL' => @deploy.user_email,
+      'USER' => "#{@deploy.author.login} (#{normalized_name}) via Shipit 2",
+      'EMAIL' => @deploy.author.email,
     ).merge(deploy_spec.machine_env)
     deploy_spec.deploy_steps.map do |command_line|
       Command.new(command_line, env: env, chdir: @deploy.working_directory)

--- a/test/unit/deploy_commands_test.rb
+++ b/test/unit/deploy_commands_test.rb
@@ -93,11 +93,11 @@ class DeployCommandsTest < ActiveSupport::TestCase
   end
 
   test "#deploy transliterates the user name" do
-    @deploy.user_name = "Simon Hørup Eskildsen"
+    @deploy.user = User.new(login: 'Sirupsen', name: "Simon Hørup Eskildsen")
     commands = @commands.deploy(@deploy.until_commit)
     assert_equal 1, commands.length
     command = commands.first
-    assert_equal "Simon Horup Eskildsen via Shipit 2", command.env['USER']
+    assert_equal "Sirupsen (Simon Horup Eskildsen) via Shipit 2", command.env['USER']
   end
 
   test "#deploy call cap $environment deploy with the ENVIRONMENT in the environment" do


### PR DESCRIPTION
Fixes #119 

These columns have no reasons to exists anymore anyway.

/review @gmalette @davidcornu @berkcaputcu 
