### PR TITLE
Sticky deploy scrolling

### DIFF
--- a/app/assets/javascripts/deploy.js.coffee
+++ b/app/assets/javascripts/deploy.js.coffee
@@ -17,7 +17,7 @@ class ChunkPoller
     @$code = $body.find('code')
     @$body = $body
     @$window = $(window)
-    @initial_scroll = true
+    @initialScroll = true
 
   poll: =>
     jQuery.ajax @pollUrl,
@@ -44,8 +44,8 @@ class ChunkPoller
       @$window.scrollTop(@codeBottomPosition() - @$window.height() + 50)
 
   isScrolledToBottom: ->
-    if @initial_scroll
-      @initial_scroll = (window.scrollY == 0)
+    if @initialScroll
+      @initialScroll = (window.scrollY == 0)
       true
     else
       @viewportBottomPosition() >= @codeBottomPosition() - STICKY_SCROLL_TOLERENCE and \


### PR DESCRIPTION
Auto-scrolling on the deploy window was broken because we have so many stacks that the side bar makes the bottom of `$@body` always below the bottom of the deploy window, so it takes a while before the auto-scrolling kicks in, and it's easy to loose it because of the crap "springy scrolling/bounce back" on macos.

So this PR introduce a new behavior: when the page is loaded, the code will start auto scrolling unless you start scrolling manually. After the first manual scroll (i.e. as soon as `window.scrollY != 0`, it will go back to auto-scrolling only if the bottom of the code area is within +/- 200 pixels of the bottom of the viewport.

@byroot @gmalette 
