### PR TITLE
Generalize gem publishing

### DIFF
--- a/lib/snippets/assert-gem-version-tag
+++ b/lib/snippets/assert-gem-version-tag
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+GEMSPEC=$1
+VERSION=`extract-gem-version $GEMSPEC`
+
+echo -e "\033[0;32mTrying to publish version $VERSION\033[0m"
+
+git tag | grep "^v$VERSION$" > /dev/null
+if [ $? != '0' ]; then
+  echo -e "\033[1;31mYou need to create the \033[0;33mv$VERSION\033[1;31m tag first.\033[0m"
+  exit 1
+fi
+
+TAG_REV=`git rev-parse v$VERSION`
+HEAD_REV=`git rev-parse HEAD`
+
+if [ $TAG_REV != $HEAD_REV ]; then
+  echo -e "\033[1;31mYou're attempting to publish \033[0;33mv$HEAD_REV\033[1;31m as \033[0;33mv$VERSION\033[1;31m but it already points to \033[0;33mv$TAG_REV\033[1;31m.\033[0m"
+  exit 1
+fi
+
+echo -e "\033[0;32mAll clear!\033[0m"
+exit 0

--- a/lib/snippets/extract-gem-version
+++ b/lib/snippets/extract-gem-version
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+
+require 'ostruct'
+
+class FakeSpec < OpenStruct
+  private
+
+  def method_missing(name, *args)
+    super
+  rescue NoMethodError
+  end
+end
+
+module Gem
+  class Specification
+    def self.new
+      spec = FakeSpec.new
+      yield spec
+      print spec.version
+    end
+  end
+end
+
+load ARGV[0]

--- a/lib/stack_commands.rb
+++ b/lib/stack_commands.rb
@@ -9,7 +9,7 @@ class StackCommands < Commands
   def fetch
     create_directories
     if Dir.exists?(@stack.git_path)
-      git('fetch', 'origin', @stack.branch, env: env, chdir: @stack.git_path)
+      git('fetch', 'origin', '--tags', @stack.branch, env: env, chdir: @stack.git_path)
     else
       git('clone', *modern_git_args, '--branch', @stack.branch, @stack.repo_git_url, @stack.git_path, env: env, chdir: @stack.deploys_path)
     end

--- a/test/unit/command_test.rb
+++ b/test/unit/command_test.rb
@@ -1,0 +1,9 @@
+require 'test_helper'
+
+class CommandTest < ActiveSupport::TestCase
+  test 'lib/snippets is added to the PATH when command is run' do
+    out = Command.new('which extract-gem-version', chdir: '/tmp').run
+    script_path = Rails.root.join('lib', 'snippets', 'extract-gem-version').to_s
+    assert_equal "#{script_path}\n", out
+  end
+end

--- a/test/unit/deploy_commands_test.rb
+++ b/test/unit/deploy_commands_test.rb
@@ -17,7 +17,7 @@ class DeployCommandsTest < ActiveSupport::TestCase
   test "#fetch call git fetch if repository cache already exist" do
     Dir.expects(:exists?).with(@stack.git_path).returns(true)
     command = @commands.fetch
-    assert_equal %w(git fetch origin master), command.args
+    assert_equal %w(git fetch origin --tags master), command.args
   end
 
   test "#fetch call git fetch in git_path directory if repository cache already exist" do


### PR DESCRIPTION
I need to add tests but I ran out of time. I'll add them tomorrow.

Gem are now automatically detected by the `*.gemspec` file.

The gem version is parsed in a more robust way, and we now both check that the tag exist and that it match HEAD.

After that bundler aka rake release take care of the rest.

/review @gmalette @EiNSTeiN- 
