### PR TITLE
Clear deploys working directory once completed

### DIFF
--- a/app/jobs/deploy_job.rb
+++ b/app/jobs/deploy_job.rb
@@ -26,6 +26,8 @@ class DeployJob < BackgroundJob
   rescue StandardError
     @deploy.error!
     raise
+  ensure
+    @deploy.clear_working_directory
   end
 
   def capture_all(commands)

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -1,3 +1,5 @@
+require 'fileutils'
+
 class Deploy < ActiveRecord::Base
   belongs_to :user
   belongs_to :stack, touch: true, counter_cache: true
@@ -7,6 +9,7 @@ class Deploy < ActiveRecord::Base
   has_many :chunks, -> { order(:id) }, class_name: 'OutputChunk'
 
   scope :success, -> { where(status: 'success') }
+  scope :completed, -> { where(status: %w(success error failed)) }
 
   state_machine :status, initial: :pending do
     event :run do
@@ -62,6 +65,10 @@ class Deploy < ActiveRecord::Base
 
   def working_directory
     File.join(stack.deploys_path, id.to_s)
+  end
+
+  def clear_working_directory
+    FileUtils.rm_rf(working_directory)
   end
 
   def write(text)

--- a/db/migrate/20140521193738_clear_old_deploys_working_directories.rb
+++ b/db/migrate/20140521193738_clear_old_deploys_working_directories.rb
@@ -1,0 +1,5 @@
+class ClearOldDeploysWorkingDirectories < ActiveRecord::Migration
+  def change
+    Deploy.completed.find_each(&:clear_working_directory)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140520150101) do
+ActiveRecord::Schema.define(version: 20140521193738) do
 
   create_table "commits", force: true do |t|
     t.integer  "stack_id",                                    null: false

--- a/test/unit/jobs/deploy_job_test.rb
+++ b/test/unit/jobs/deploy_job_test.rb
@@ -10,6 +10,7 @@ class DeployJobTest < ActiveSupport::TestCase
   test "#perform fetch commits from the API" do
     @job.stubs(:capture)
     @commands = stub(:commands)
+    Deploy.expects(:find).with(@deploy.id).returns(@deploy)
     DeployCommands.expects(:new).with(@deploy).returns(@commands)
 
     @commands.expects(:fetch).once
@@ -17,6 +18,8 @@ class DeployJobTest < ActiveSupport::TestCase
     @commands.expects(:checkout).with(@deploy.until_commit).once
     @commands.expects(:install_dependencies).returns([]).once
     @commands.expects(:deploy).with(@deploy.until_commit).returns([]).once
+
+    @deploy.expects(:clear_working_directory)
 
     @job.perform(deploy_id: @deploy.id)
   end


### PR DESCRIPTION
Fixes issues like: https://github.com/Shopify/ops/issues/992

Now the working directory is properly deleted once the deploy is done (either success or error)

/review @gmalette @skingry 
