### PR TITLE
Fix the gem deploy script

### DIFF
--- a/lib/snippets/assert-gem-version-tag
+++ b/lib/snippets/assert-gem-version-tag
@@ -11,11 +11,11 @@ if [ $? != '0' ]; then
   exit 1
 fi
 
-TAG_REV=`git rev-parse v$VERSION`
+TAG_REV=`git rev-list -n1 v$VERSION`
 HEAD_REV=`git rev-parse HEAD`
 
 if [ $TAG_REV != $HEAD_REV ]; then
-  echo -e "\033[1;31mYou're attempting to publish \033[0;33mv$HEAD_REV\033[1;31m as \033[0;33mv$VERSION\033[1;31m but it already points to \033[0;33mv$TAG_REV\033[1;31m.\033[0m"
+  echo -e "\033[1;31mYou're attempting to publish \033[0;33m$HEAD_REV\033[1;31m as \033[0;33mv$VERSION\033[1;31m but it already points to \033[0;33m$TAG_REV\033[1;31m.\033[0m"
   exit 1
 fi
 


### PR DESCRIPTION
There was a slight problem, doing rev-parse on a tag doesn't point to a commit but rather on the tag itself. So doing rev-list will point to the last commit that is included in that tag, which is what we want here since shipit only knows about commits.

@byroot 
