### PR TITLE
prevent going to undefined stack

### DIFF
--- a/app/assets/javascripts/search.js.coffee
+++ b/app/assets/javascripts/search.js.coffee
@@ -51,8 +51,7 @@ class StackSearch
     $previous.addClass('selected')
 
   goToSelectedStack: ->
-    stack = @$items.filter('.selected').filter(':not(.not-matching)').find('.commits-path').attr('href')
-    if stack
+    if stack = @$items.filter('.selected').filter(':not(.not-matching)').find('.commits-path').attr('href')
       window.location = stack
 
 search = new StackSearch(document)


### PR DESCRIPTION
@byroot this change will prevent going to a stack named 'undefined' when you type 'enter' without searching for anything. Also prevent getting an old selection which is no longer matching in your current search.
