### PR TITLE
Stop Wrapping Command Output

### DIFF
--- a/app/assets/stylesheets/_pages/_deploy.scss
+++ b/app/assets/stylesheets/_pages/_deploy.scss
@@ -34,3 +34,7 @@
   30% {  left: 0%; }
   100% { width: 50%; left: 100%; }
 }
+
+pre.nowrap {
+  white-space: 'pre';
+}

--- a/app/views/deploys/show.html.erb
+++ b/app/views/deploys/show.html.erb
@@ -9,6 +9,6 @@
   </div>
 </div>
 
-<pre>
+<pre class="nowrap">
   <code data-next-chunks-url="<%= next_chunks_url %>"><%= @deploy.chunk_output %></code>
 </pre>


### PR DESCRIPTION
@byroot and @EiNSTeiN- for review

Super-complicated version of the word-wrap fix :smile:

When playing around in the inspector, some words seemed to be broken apart, but I think that might be just a redraw thing. Once this is deployed, we can check out https://shipit2.shopify.com/shopify/shipit2/production/deploys/1497 to see the result.

It's at least a step in the right direction
# Before

![screen shot 2014-06-05 at 2 01 58 pm](https://cloud.githubusercontent.com/assets/4748863/3191487/8cdc14d4-ecdb-11e3-9b55-ad6405e3b8ad.png)
# After

![screen shot 2014-06-05 at 1 57 20 pm](https://cloud.githubusercontent.com/assets/4748863/3191478/713bac94-ecdb-11e3-8f38-4c376304997a.png)
