### PR TITLE
Let a chance to the subprocess to cleanly exit

### DIFF
--- a/test/unit/jobs/deploy_job_test.rb
+++ b/test/unit/jobs/deploy_job_test.rb
@@ -55,6 +55,7 @@ class DeployJobTest < ActiveSupport::TestCase
 
   test "mark deploy as error if a command timeout" do
     Timeout.expects(:timeout).raises(Timeout::Error.new)
+    Command.any_instance.expects(:terminate!)
     assert_raises(Timeout::Error) do
       @job.perform(deploy_id: @deploy.id)
     end


### PR DESCRIPTION
This let several changes to the subprocess to exit cleanly.

Capistrano should run deploy:unlock for example.
If after several attempts the process is still not exiting, then SIGKILL is sent.

/review @gmalette @davidcornu @wisq @csfrancis @skingry
