### PR TITLE
[Hack] Make networking jobs timeout to workaround the SSL issue

### DIFF
--- a/app/jobs/background_job.rb
+++ b/app/jobs/background_job.rb
@@ -1,10 +1,26 @@
 class BackgroundJob
-  def self.perform(*args)
-    if options = args.extract_options!
-      args = [*args, options.with_indifferent_access]
+
+  class << self
+
+    attr_accessor :timeout
+
+    def self.perform(*args)
+      if options = args.extract_options!
+        args = [*args, options.with_indifferent_access]
+      end
+
+      with_timeout do
+        new.perform(*args)
+      end
     end
 
-    new.perform(*args)
+    private
+
+    def with_timeout(&block)
+      return yield unless timeout
+      Timeout.timeout(timeout, &block)
+    end
+
   end
 
   def logger

--- a/app/jobs/github_sync_job.rb
+++ b/app/jobs/github_sync_job.rb
@@ -1,6 +1,8 @@
 class GithubSyncJob < BackgroundJob
   @queue = :default
 
+  self.timeout = 60
+
   extend Resque::Plugins::Workers::Lock
 
   def self.lock_workers(params)

--- a/app/jobs/refresh_statuses_job.rb
+++ b/app/jobs/refresh_statuses_job.rb
@@ -1,6 +1,8 @@
 class RefreshStatusesJob < BackgroundJob
   @queue = :default
 
+  self.timeout = 60
+
   def perform(params)
     stack = Stack.find(params[:stack_id])
     stack.commits.order(id: :desc).limit(30).each(&:refresh_status)


### PR DESCRIPTION
I'm creating the PR just for the record.

I know this is a terrible bandaid, but it's basically what we are already doing manually, so at least this will save @dalehamel some time.

I think we should revert once the SSL situation is over.

/cc @gmalette @csfrancis  
