### PR TITLE
avoid showing circleci message when commit is errored out

### DIFF
--- a/app/assets/javascripts/stacks.js.coffee
+++ b/app/assets/javascripts/stacks.js.coffee
@@ -13,7 +13,7 @@ jQuery ($) ->
 
   displayConfigureCiMessage = ->
     commits = $('.commit')
-    ciConfigured = !commits.length || commits.length != commits.find('a.unknown').length
+    ciConfigured = !commits.length || commits.length != commits.find('div.unknown').length
     $('.configure-ci').toggleClass('hidden', ciConfigured)
     return
 


### PR DESCRIPTION
This should avoid showing the circleci message when commits are just errored out.
@byroot @JasonMWhite 
