### PR TITLE
Add "git remote prune origin" command to deploy job

### DIFF
--- a/app/jobs/deploy_job.rb
+++ b/app/jobs/deploy_job.rb
@@ -16,6 +16,7 @@ class DeployJob < BackgroundJob
 
     capture commands.fetch
     capture commands.clone
+    capture commands.remote_prune
     capture commands.checkout(@deploy.until_commit)
     Bundler.with_clean_env do
       capture_all commands.install_dependencies

--- a/lib/deploy_commands.rb
+++ b/lib/deploy_commands.rb
@@ -29,6 +29,10 @@ class DeployCommands < Commands
     end
   end
 
+  def remote_prune
+    git("remote", "prune", "origin", chdir: @deploy.working_directory)
+  end
+
   def checkout(commit)
     git("checkout", "-q", commit.sha, chdir: @deploy.working_directory)
   end

--- a/test/unit/jobs/deploy_job_test.rb
+++ b/test/unit/jobs/deploy_job_test.rb
@@ -15,6 +15,7 @@ class DeployJobTest < ActiveSupport::TestCase
 
     @commands.expects(:fetch).once
     @commands.expects(:clone).once
+    @commands.expects(:remote_prune).once
     @commands.expects(:checkout).with(@deploy.until_commit).once
     @commands.expects(:install_dependencies).returns([]).once
     @commands.expects(:deploy).with(@deploy.until_commit).returns([]).once


### PR DESCRIPTION
https://shipit2.shopify.com/shopify/brochure2/production/deploys/3041

Deploy failed because of this:

```
** [brochure-app4.ec2.shopify.com :: err] error: 'refs/remotes/origin/feature/craig-ama' exists; cannot create 'refs/remotes/origin/feature/craig-ama/main'

 ** [brochure-app4.ec2.shopify.com :: err] error: some local refs could not be updated; try running
 ** 'git remote prune origin' to remove any old, conflicting branches
```

This adds a "git remote prune origin" command per default before every checkout command.

(Also fixes a few cases of french english ;-))

@byroot @gmalette / cc @stevenmichaelthomas 
