### PR TITLE
Fix missing text in deploy log from lines starting with the letter 'm'.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,7 +21,7 @@ gem 'airbrake', '~> 3.1.5'
 gem 'pubsubstub', '~> 0.0.7'
 gem 'securecompare', '~>1.0'
 gem 'rails-timeago', '~> 2.0'
-gem 'ansi_stream', '~> 0.0.2'
+gem 'ansi_stream', '~> 0.0.3'
 gem 'heroku', '~> 3.8.2'
 
 group :production do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -31,7 +31,7 @@ GEM
     airbrake (3.1.16)
       builder
       multi_json
-    ansi_stream (0.0.2)
+    ansi_stream (0.0.3)
     arel (5.0.1.20140414130214)
     builder (3.2.2)
     byebug (2.7.0)
@@ -251,7 +251,7 @@ PLATFORMS
 
 DEPENDENCIES
   airbrake (~> 3.1.5)
-  ansi_stream (~> 0.0.2)
+  ansi_stream (~> 0.0.3)
   byebug
   capistrano-bundler
   capistrano-rails


### PR DESCRIPTION
@gmalette, @EiNSTeiN- for review

I wanted to provide more context for pull request https://github.com/gmalette/ansi_stream/pull/1
## Problem

Look at the top of the deploy log for https://shipit2.shopify.com/shopify/starscream/production/deploys/3451, which starts with

```
 essage': u'flow cdn-facts removed from Schedules.', u'status': u'success'}
[spark-etl1.chi.shopify.com] out: {u'message': u'flow phone-agent-dimension removed from Schedules.',
[spark-etl1.chi.shopify.com] out:  u'status': u'success'}
```

Now disable javascript and view the page again and you will see a much longer deploy log.  If you try to find `essage': u'flow cdn-facts removed from Schedules.', u'status': u'success'}` on the page you will find it most of the way down the page, looking like

```
[spark-etl1.chi.shopify.com] out: {u'
message': u'flow cdn-facts removed from Schedules.', u'status': u'success'}
[spark-etl1.chi.shopify.com] out: {u'message': u'flow phone-agent-dimension removed from Schedules.',
```

The problem happens for any line starting with `m` that occurs before an ansi escape sequence in the chunk of text.  It is most noticeable when looking at the deploy logs for a finished deploy that doesn't have any colour codes, since it is all one chunk of text where there is a higher probability that a line with start with `m`.
## Solution

See the fix in https://github.com/gmalette/ansi_stream/pull/1.  After that gets ~~merged~~ released I can reference the new version in the Gemfile instead of ~~my fork~~ the git repo.
