### PR TITLE
remove misconfigured webhooks

### DIFF
--- a/app/jobs/github_teardown_webhooks_job.rb
+++ b/app/jobs/github_teardown_webhooks_job.rb
@@ -4,6 +4,15 @@ class GithubTeardownWebhooksJob < BackgroundJob
   extend BackgroundJob::StackExclusive
 
   def perform(params)
+    Shipit.github_api.hooks(params[:github_repo_name]).each do |hook|
+      if hook.last_response.status == 'misconfigured'
+        Rails.logger.info "removing misconfigured #{hook.id}"
+        Shipit.github_api.remove_hook(params[:github_repo_name], hook.id)
+      else
+        Rails.logger.info "everything is fine with #{hook.id}"
+      end
+    end
+
     Webhook.where(stack_id: params[:stack_id]).each do |webhook|
       begin
         Shipit.github_api.remove_hook(params[:github_repo_name], webhook.github_id)

--- a/lib/tasks/webhook.rake
+++ b/lib/tasks/webhook.rake
@@ -1,0 +1,8 @@
+namespace :webhook do
+  desc "get all the webhooks back in sync"
+  task sync_all: [:environment] do
+    Stack.all.each do |stack|
+      GithubTeardownWebhooksJob.new.perform(stack_id: stack.id, github_repo_name: stack.github_repo_name)
+    end
+  end
+end

--- a/test/unit/jobs/github_setup_webhooks_job_test.rb
+++ b/test/unit/jobs/github_setup_webhooks_job_test.rb
@@ -18,6 +18,8 @@ class GithubSetupWebhooksJobTest < ActiveSupport::TestCase
   test "#perform creates webhooks for push and status" do
     @stack.webhooks.destroy_all
 
+    Shipit.github_api.expects(:hooks).with('shopify/shipit2').returns([])
+
     Shipit.github_api.expects(:create_hook).with('shopify/shipit2', 'web', {
       url: "https://example.com/stacks/#{@stack.id}/webhooks/push",
       content_type: 'json',

--- a/test/unit/jobs/github_teardown_webhooks_job_test.rb
+++ b/test/unit/jobs/github_teardown_webhooks_job_test.rb
@@ -8,6 +8,9 @@ class GithubTeardownWebhooksJobTest < ActiveSupport::TestCase
   end
 
   test "#perform destroys stack webhooks" do
+    hooks = [Hashie::Mash.new(id: 666, last_response: {status: 'misconfigured'})]
+    Shipit.github_api.expects(:hooks).with('Shopify/shipit2').returns(hooks)
+    Shipit.github_api.expects(:remove_hook).with('Shopify/shipit2', 666)
     Shipit.github_api.expects(:remove_hook).with('Shopify/shipit2', 13)
     Shipit.github_api.expects(:remove_hook).with('Shopify/shipit2', 23)
 


### PR DESCRIPTION
the `GithubTeardownWebhooksJob` is now making sure to remove orphaned hooks on the go. those kept piling up in several shopify repositories.

added a `rake webhook:sync_all` for maintenance (myself).

/cc @byroot @gmalette 
