### PR TITLE
[WIP] Use combined commit status API

### DIFF
--- a/app/jobs/github_sync_job.rb
+++ b/app/jobs/github_sync_job.rb
@@ -37,7 +37,7 @@ class GithubSyncJob < BackgroundJob
   protected
 
   def fetch_status(commit)
-    Shipit.github_api.statuses(@stack.github_repo_name, commit.sha).first
+    Shipit.github_api.combined_status(@stack.github_repo_name, commit.sha)
   end
 
   def lookup_commit(sha)

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -41,9 +41,8 @@ class Commit < ActiveRecord::Base
   end
 
   def refresh_status
-    if status = Shipit.github_api.statuses(stack.github_repo_name, sha).first
-      update(state: status.try(:state) || 'unknown')
-    end
+    status = Shipit.github_api.combined_status(stack.github_repo_name, sha)
+    update(state: status.try(:state) || 'unknown')
   end
 
   def children

--- a/test/models/commits_test.rb
+++ b/test/models/commits_test.rb
@@ -121,7 +121,7 @@ class CommitsTest < ActiveSupport::TestCase
 
   test "refresh_status pull state from github" do
     status = mock(state: 'success')
-    Shipit.github_api.expects(:statuses).with(@stack.github_repo_name, @commit.sha).returns([status])
+    Shipit.github_api.expects(:combined_status).with(@stack.github_repo_name, @commit.sha).returns(status)
     @commit.refresh_status
     assert_equal 'success', @commit.state
   end


### PR DESCRIPTION
We're adding Borg builds as a commit status, so querying statuses.first is no longer going to be sufficient.

One notable difference here is that the Combined Status API will return "pending" even if no statuses have been submitted yet. I think that's probably okay, thoughts?

/cc @Shopify/stack
