### PR TITLE
Better widgets

### DIFF
--- a/app/assets/javascripts/application.js.coffee
+++ b/app/assets/javascripts/application.js.coffee
@@ -24,7 +24,6 @@ ChunkPoller.appendFormatter (chunk) ->
   stream.process(chunk)
 
 jQuery ->
-  Sidebar.init($(window), $('.sidebar-plugins'))
   ChunkPoller.init()
 
 $(document).on 'click', 'a.disabled', (event) ->

--- a/app/assets/javascripts/application/sidebar.js.coffee
+++ b/app/assets/javascripts/application/sidebar.js.coffee
@@ -1,23 +1,24 @@
 class @Sidebar
-  PLUGINS = []
+  INSTANCE = null
 
-  @registerPlugin: (plugin) ->
-    PLUGINS.push(plugin)
+  @instance: ->
+    INSTANCE ||= new this($(window), $('.sidebar-plugins'))
 
-  @init: ($window, $container) ->
-    new this($window, $container)
+  @newWidgetContainer: ->
+    Sidebar.instance().newWidgetContainer()
 
   constructor: (@$window, @$container) ->
     @saveMinTop()
     @$window.scroll(@updatePosition)
-    for plugin in PLUGINS
-      plugin.appendTo(@appendPluginContainer())
+    @$window.resize(@updatePosition)
+    @$outerContainer = @$container.parent()
 
   updatePosition: =>
-    @$container.toggleClass('fixed', @$window.scrollTop() > @minTop)
+    @$outerContainer.toggleClass('fixed', @$window.scrollTop() > @minTop)
+    @$container.height($(window).height() - @$container[0].getBoundingClientRect().top)
 
-  appendPluginContainer: ->
-    $('<div>').addClass('sidebar-plugin').appendTo(@$container)
+  newWidgetContainer: ->
+    $('<div>').addClass('sidebar-plugin').prependTo(@$container)
 
   saveMinTop: ->
     @minTop = @$container.position()?.top || 0

--- a/app/assets/javascripts/plugins/borg.js.coffee
+++ b/app/assets/javascripts/plugins/borg.js.coffee
@@ -4,8 +4,6 @@ class RestartTaskWidget
   constructor: ->
     @tasks = {}
 
-  appendTo: (@$container) ->
-
   createTask: (host) ->
     new LightsTaskView(@$container, host)
 
@@ -18,6 +16,7 @@ class RestartTaskWidget
 
   activate: ->
     return if @active
+    @$container = Sidebar.newWidgetContainer()
     @addHeading()
     @$headingEl.text(@heading)
     @active = true
@@ -170,6 +169,3 @@ ChunkPoller.prependFormatter (chunk) ->
   restartWidget.update(chunk)
   jobRestartWidget.update(chunk)
   false
-
-Sidebar.registerPlugin(restartWidget)
-Sidebar.registerPlugin(jobRestartWidget)

--- a/app/assets/stylesheets/_structure/_sidebar.scss
+++ b/app/assets/stylesheets/_structure/_sidebar.scss
@@ -1,6 +1,8 @@
+$sidebar-width: 300px;
+
 .sidebar {
   background-color: #2e343a;
-  width: 300px;
+  width: $sidebar-width;
   box-sizing: border-box;
   @include flex(0 0 300px);
   @include order(-1);
@@ -52,8 +54,21 @@
   + .stack { border-top: 1px solid rgba(#fff, .1); }
 }
 
+.sidebar-plugins-outer {
+  width: $sidebar-width;
+  overflow: hidden;
+}
 
-.sidebar-plugins.fixed {
+.sidebar-plugins {
+  width: $sidebar-width + 15px;
+  overflow-y: auto;
+}
+
+.sidebar-plugins::-webkit-scrollbar { 
+  display: none; 
+}
+
+.sidebar-plugins-outer.fixed {
   position: fixed;
   top: 0px;
 }

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -27,7 +27,9 @@
           <%= link_to "Login with Github", authentication_path(:github, origin: request.original_url) %>
         <% end %>
       </div>
-      <div class="sidebar-plugins"></div>
+      <div class="sidebar-plugins-outer">
+        <div class="sidebar-plugins"></div>
+      </div>
     </header>
     <div class="main">
       <%= yield %>


### PR DESCRIPTION
Changes the widget sidebar into a dynamic stream, new widgets are inserted on top of old ones. The event stream can hold more widgets than fit on the screen, and can scroll (with a hidden scrollbar).

Also fixes a bug I introduced in #204 where if it didn't get the number of job services coffeescripts reverse ranges would add a whole bunch of neutral dots because it had a negative number of things left to do.

Todo:
- [x] Figure out good way to hide scrollbar in firefox, currently only works in Webkit

@byroot @gmalette 
