### PR TITLE
Optimize widgets

### DIFF
--- a/app/assets/javascripts/plugins/borg.js.coffee
+++ b/app/assets/javascripts/plugins/borg.js.coffee
@@ -10,7 +10,7 @@ class RestartTaskWidget
   getTask: (host) ->
     @tasks[host] ||= @createTask(host)
 
-  updateTasksDOM: ->
+  refresh: ->
     for _, task of @tasks
       task.updateDOM()
     null
@@ -47,7 +47,7 @@ class RestartTaskWidget
       @activate()
 
     @parse(parser)
-    @updateTasksDOM()
+    @refresh()
 
     if parser.findTaskEnd(@capistranoTask)
       @finish()


### PR DESCRIPTION
Fixes DOM thrashing that made widgets really slow, now they are quite fast even for massive Shopify deploy spew.

Also changes the behaviour on double content from #206 to reuse the previous instance of the widget.

@byroot @gmalette 
