### PR TITLE
Remove extra scrollbar at right on logs

### DIFF
--- a/app/assets/stylesheets/_structure/_main.scss
+++ b/app/assets/stylesheets/_structure/_main.scss
@@ -42,7 +42,7 @@
 
 pre {
   background-color: #272c30;
-  overflow: scroll;
+  overflow-x: auto;
   color: #fff;
   padding: 1.5rem;
   line-height: 1.5em;


### PR DESCRIPTION
The `overflow:scroll` added an unnecessary extra scrollbar to the right of logs. This fixes it.

@byroot 
## Before

![screen shot 2014-08-21 at 2 39 05 pm](https://cloud.githubusercontent.com/assets/887610/4001293/86c14f1a-2962-11e4-9388-64a3a4a202ba.png)
## After

![screen shot 2014-08-21 at 2 39 22 pm](https://cloud.githubusercontent.com/assets/887610/4001298/8beede62-2962-11e4-8d50-1501d911a638.png)
