### PR TITLE
Fix lock not updating DOM

### DIFF
--- a/app/assets/javascripts/application/stacks.js.coffee
+++ b/app/assets/javascripts/application/stacks.js.coffee
@@ -68,7 +68,7 @@ jQuery ($) ->
 
   onStackUpdate = (message) ->
     json = JSON.parse(message.data)
-    $('[data-stack-locked]').data('stack-locked', json.locked)
+    $('[data-stack-locked]').attr('data-stack-locked', json.locked)
     $('.lock-reason p').text(json.lock_reason)
     $('.lock-reason').toggle(json.locked)
 


### PR DESCRIPTION
`$().data` doesn't update the DOM so CSS selectors aren't kicking in. 
