### PR TITLE
S3 upload widget

### DIFF
--- a/app/assets/javascripts/application/capistrano_parser.js.coffee
+++ b/app/assets/javascripts/application/capistrano_parser.js.coffee
@@ -1,6 +1,6 @@
 class @CapistranoParser
   LOG_PATTERN = /^\s*\*+ +\[(\w+) :: ([a-zA-Z\d\.]+)\] (.*)$/gm
-  TASK_START_PATTERN = /^\s*\* executing `([^']+)'\s*$/gm
+  TASK_START_PATTERN = /^\s*\* executing `([^']+)'\s*$|^.*\*+ Execute (\S+)/gm
   TASK_END_PATTERN = /^\s*triggering after callbacks for `([^']+)'\s*$|^\s*\* Finished (\S+) in /gm
   lastIndex: 0
 
@@ -24,7 +24,7 @@ class @CapistranoParser
   findTaskStart: (task) ->
     found = false
     @matchPattern TASK_START_PATTERN,(match) ->
-      if match[1] == task
+      if match[1] == task || match[2] == task
         found = true
         return false
     found

--- a/app/assets/stylesheets/plugins/borg.scss
+++ b/app/assets/stylesheets/plugins/borg.scss
@@ -4,6 +4,22 @@
   margin-bottom: 5px;
 }
 
+.section-bottom {
+  clear: both;
+}
+
+.task-progress-container {
+  height: 20px;
+  background-color: #424E5A;
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.task-progress-bar {
+  background-color: #19AD42;
+  height: 100%;
+}
+
 .task-lights {
   float: left;
   background-color: #424E5A;
@@ -66,8 +82,4 @@
     height: 6px;
     margin: 2px;
   }
-}
-
-.section-bottom {
-  clear: both;
 }


### PR DESCRIPTION
Shows a sidebar widget for S3 asset upload progress. Also adds infrastructure for other progress bar widgets and does some refactoring.

I've tested this with copy-pasted deploy logs and it works, including testing the updating of the bar as chunks stream to the browser.

Here's a screenshot, I faked it to mid-way with dev tools so that's why there's a check mark:
![screen shot 2014-08-25 at 4 47 15 pm](https://cloud.githubusercontent.com/assets/887610/4036378/3acf82fe-2c99-11e4-937c-d0bd0b2cbb9a.png)

@byroot @gmalette 
