### PR TITLE
Change walrus to run every hour instead of every 30 minutes

### DIFF
--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -2,7 +2,7 @@ every 1.minute do
   rake 'cron:minutely'
 end
 
-every 30.minutes do
+every 1.hour do
   rake 'cron:send_undeployed_commits_reminders'
 end
 


### PR DESCRIPTION
The Walrus is working well, a little too well. 

This PR calms the walrus and sends reminders every hour instead of every 30 minutes. 

@byroot @fw42 Thoughts?
