### PR TITLE
symlink the asset folder

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -28,7 +28,7 @@ set :deploy_to, '/u/apps/shipit'
 set :linked_files, %w(config/database.yml config/secrets.yml config/settings.yml)
 
 # Default value for linked_dirs is []
-set :linked_dirs, %w(bin data log tmp vendor/bundle public/system)
+set :linked_dirs, %w(bin data log tmp vendor/bundle public/system public/assets)
 
 # Default value for default_env is {}
 # set :default_env, { path: "/opt/ruby/bin:$PATH" }


### PR DESCRIPTION
i tested the asset compilation with the shared folder last week and it worked nicely

https://github.com/Shopify/cookbooks/pull/3535

/cc @byroot @pallan 

as a side-note, i added log-rotation in the pr and i saw that shipit is logging in debugging mode in production. could we change that to something less verbose?
