### PR TITLE
Render nicer messages for "Previous Deploys"

### DIFF
--- a/app/views/deploys/_deploy.html.erb
+++ b/app/views/deploys/_deploy.html.erb
@@ -17,7 +17,7 @@
     </span>
     <span class="event-title">
       <a href="<%= stack_deploy_path(@stack, deploy) %>">
-        <%= deploy.until_commit.message %>
+        <%= render_commit_message deploy.until_commit %>
       </a>
       <span class="event-number"></span>
     </span>


### PR DESCRIPTION
Something that's been bugging me for a while is that the "Previous deploys" list
always starts with
  "Merge pull request ##### from Shopify/some-useless-branch-name"
and then the useful part of the title gets elided and it becomes impossible to
match up the deploys with actual PRs (in particular, it becomes impossible to
tell, if a deploy is "in progress" where in the "Undeployed Commits" list is
actually being deployed).

Hopefully this fixes that, though I'm having trouble testing locally for various
reasons.

@byroot @gmalette 
