### PR TITLE
Multi-CI support

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -11,4 +11,4 @@ require File.expand_path('../config/application', __FILE__)
 
 Shipit::Application.load_tasks
 
-task default: %i(rubocop test)
+task default: %i(test rubocop)

--- a/app/controllers/stacks_controller.rb
+++ b/app/controllers/stacks_controller.rb
@@ -16,7 +16,7 @@ class StacksController < ApplicationController
     return unless stale?(last_modified: @stack.updated_at)
 
     @deploys = @stack.deploys.order(id: :desc).preload(:since_commit, :until_commit, :user).limit(10)
-    @commits = @stack.commits.reachable.preload(:author).order(id: :desc)
+    @commits = @stack.commits.reachable.preload(:author, :statuses).order(id: :desc)
     if deployed_commit = @stack.last_deployed_commit
       @commits = @commits.where('id > ?', deployed_commit.id)
     end

--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -16,7 +16,10 @@ class WebhooksController < ActionController::Base
 
   def state
     commit = stack.commits.find_by_sha!(params['sha'])
-    attributes = params.permit(:description, :context, :state, :target_url, :created_at, :updated_at)
+    attributes = params.permit(:description, :context, :state, :target_url)
+    %i(created_at updated_at).each do |attr|
+      attributes[attr] = DateTime.iso8601(params[attr])
+    end
     commit.statuses.create!(attributes)
     head :ok
   end

--- a/app/jobs/refresh_statuses_job.rb
+++ b/app/jobs/refresh_statuses_job.rb
@@ -5,7 +5,7 @@ class RefreshStatusesJob < BackgroundJob
 
   def perform(params)
     stack = Stack.find(params[:stack_id])
-    stack.commits.order(id: :desc).limit(30).each(&:refresh_status)
+    stack.commits.order(id: :desc).limit(30).each(&:refresh_statuses)
   end
 
 end

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -1,12 +1,12 @@
 class Commit < ActiveRecord::Base
+  UNKNOWN_STATE = 'unknown'.freeze
   belongs_to :stack, touch: true
   has_many :deploys
-  has_many :statuses
+  has_many :statuses, -> { order(created_at: :desc) }
 
   after_create  { broadcast_event('create') }
   after_destroy { broadcast_event('remove') }
   after_update  { broadcast_update }
-  after_update :schedule_continuous_delivery
   after_create { stack.update_undeployed_commits_count }
 
   belongs_to :author, class_name: "User"
@@ -36,7 +36,6 @@ class Commit < ActiveRecord::Base
   def self.from_github(commit, status)
     new(
       sha: commit.sha,
-      state: status.try(:state) || 'unknown',
       target_url: fetch_target_url(status),
       message: commit.commit.message,
       author: User.find_or_create_from_github(commit.author || commit.commit.author),
@@ -50,15 +49,22 @@ class Commit < ActiveRecord::Base
     status && status.rels.try(:[], :target).try(:href)
   end
 
-  def refresh_status
-    if status = Shipit.github_api.statuses(stack.github_repo_name, sha).first
-      update(state: status.try(:state) || 'unknown')
+  def refresh_statuses
+    Shipit.github_api.statuses(stack.github_repo_name, sha).each do |status|
+      statuses.replicate_from_github!(status)
     end
   end
 
-  def denormalize_state
-    latest_status = statuses.order(:created_at => :desc).first
-    update!(state: latest_status.state)
+  def state
+    significant_status.try!(:state) || read_attribute(:state) || UNKNOWN_STATE
+  end
+
+  def target_url
+    significant_status.try!(:target_url) || read_attribute(:target_url)
+  end
+
+  def last_statuses
+    statuses.each_with_object({}) { |s, h| h[s.context] ||= s }.values.sort_by(&:context)
   end
 
   def children
@@ -93,12 +99,20 @@ class Commit < ActiveRecord::Base
     @parsed ||= message.match(/\AMerge pull request #(?<pr_id>\d+) from [\w\-\_\/]+\n\n(?<pr_title>.*)/)
   end
 
-  private
-
   def schedule_continuous_delivery
     return unless state == 'success' && stack.continuous_deployment?
     return if deploy_in_progress? || newer_commit_deployed?
     stack.trigger_deploy(self, committer)
+  end
+
+  private
+
+  def significant_status
+    statuses = last_statuses
+    return nil if statuses.empty?
+    return statuses.first if statuses.all?(&:success?)
+    non_success_statuses = statuses.reject(&:success?)
+    non_success_statuses.reject(&:pending?).first || non_success_statuses.first
   end
 
   def deploy_in_progress?

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -1,8 +1,26 @@
 class Status < ActiveRecord::Base
-  belongs_to :commit
-  after_save :update_commit_state
+  STATES = %w(pending success failure error).freeze
+  enum state: STATES.zip(STATES).to_h
 
-  def update_commit_state
-    commit.denormalize_state
+  belongs_to :commit, touch: true
+
+  validates :state, inclusion: {in: STATES, allow_blank: true}, presence: true
+
+  after_commit :schedule_continuous_delivery, on: :create
+
+  def self.replicate_from_github!(github_status)
+    find_or_create_by!(
+      state: github_status.state,
+      description: github_status.description,
+      target_url: github_status.target_url,
+      context: github_status.context,
+      created_at: DateTime.iso8601(github_status.created_at),
+    )
+  end
+
+  private
+
+  def schedule_continuous_delivery
+    commit.schedule_continuous_delivery
   end
 end

--- a/db/migrate/20141003140924_create_statuses.rb
+++ b/db/migrate/20141003140924_create_statuses.rb
@@ -4,7 +4,7 @@ class CreateStatuses < ActiveRecord::Migration
       t.string :state
       t.string :target_url
       t.text :description
-      t.string :context
+      t.string :context, default: 'default', null: false
       t.references :commit, index: true
 
       t.timestamps

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -85,7 +85,7 @@ ActiveRecord::Schema.define(version: 20141003140924) do
     t.string   "state"
     t.string   "target_url"
     t.text     "description"
-    t.string   "context"
+    t.string   "context",     default: "default", null: false
     t.integer  "commit_id"
     t.datetime "created_at"
     t.datetime "updated_at"

--- a/test/controllers/webhooks_controller_test.rb
+++ b/test/controllers/webhooks_controller_test.rb
@@ -31,22 +31,18 @@ class WebhooksControllerTest < ActionController::TestCase
 
     request.headers['X-Github-Event'] = 'status'
     params = {"sha" => commit.sha, "state" => "pending", "target_url" => "https://ci.example.com/1000/output",
-      "description" => "This is a description", "context" => "Context", "created_at" => 10.days.ago.to_json, "updated_at" => 10.days.ago.to_json}
+      "description" => "This is a description", "context" => "Context", "created_at" => 10.days.ago.as_json, "updated_at" => 10.days.ago.as_json}
 
     assert_difference 'commit.statuses.count', +1 do
       post :state, { stack_id: @stack.id }.merge(params)
     end
 
-    status = Status.last()
+    status = Status.last
     assert_equal 'pending', status.state
     assert_equal 'https://ci.example.com/1000/output', status.target_url
     assert_equal "This is a description", status.description
     assert_equal "Context", status.context
     assert_equal 10.days.ago.to_s, status.created_at.to_s
-
-    # commit.reload
-    assert_equal 'pending', commit.state
-    # assert_equal "https://ci.example.com/1000/output", commit.target_url
   end
 
   test ":state with a unexisting commit trows ActiveRecord::RecordNotFound" do

--- a/test/fixtures/commits.yml
+++ b/test/fixtures/commits.yml
@@ -7,7 +7,6 @@ first:
   committer: walrus
   authored_at: <%= 10.days.ago.to_s(:db) %>
   committed_at: <%= 9.days.ago.to_s(:db) %>
-  state: pending
 
 second:
   id: 2

--- a/test/fixtures/statuses.yml
+++ b/test/fixtures/statuses.yml
@@ -2,8 +2,72 @@
 
 first_pending:
   commit_id: 1 # first
-  description: "lets go"
-  context: "shipit"
+  description: lets go
+  context: ci/travis
   created_at: <%= 10.days.ago.to_s(:db) %>
   state: pending
+  target_url: "http://www.example.com"
+
+second_pending_travis:
+  commit_id: 2 # second
+  description: lets go
+  context: ci/travis
+  created_at: <%= 10.days.ago.to_s(:db) %>
+  state: pending
+  target_url: "http://www.example.com"
+
+second_pending_coveralls:
+  commit_id: 2 # second
+  description: lets go
+  context: metrics/coveralls
+  created_at: <%= 10.days.ago.to_s(:db) %>
+  state: pending
+  target_url: "http://www.example.com"
+
+second_success_travis:
+  commit_id: 2 # second
+  description: lets go
+  context: ci/travis
+  created_at: <%= 9.days.ago.to_s(:db) %>
+  state: success
+  target_url: "http://www.example.com"
+
+second_failure_coveralls:
+  commit_id: 2 # second
+  description: lets go
+  context: metrics/coveralls
+  created_at: <%= 9.days.ago.to_s(:db) %>
+  state: failure
+  target_url: "http://www.example.com"
+
+third_success_travis:
+  commit_id: 3 # third
+  description: lets go
+  context: ci/travis
+  created_at: <%= 9.days.ago.to_s(:db) %>
+  state: success
+  target_url: "http://www.example.com"
+
+third_success_coveralls:
+  commit_id: 3 # third
+  description: lets go
+  context: metrics/coveralls
+  created_at: <%= 9.days.ago.to_s(:db) %>
+  state: success
+  target_url: "http://www.example.com"
+
+fourth_pending_travis:
+  commit_id: 4 # fourth
+  description: lets go
+  context: ci/travis
+  created_at: <%= 9.days.ago.to_s(:db) %>
+  state: pending
+  target_url: "http://www.example.com"
+
+fourth_success_coveralls:
+  commit_id: 4 # fourth
+  description: lets go
+  context: metrics/coveralls
+  created_at: <%= 9.days.ago.to_s(:db) %>
+  state: success
   target_url: "http://www.example.com"

--- a/test/models/status_test.rb
+++ b/test/models/status_test.rb
@@ -1,19 +1,20 @@
 require 'test_helper'
 
 class StatusTest < ActiveSupport::TestCase
-
   setup do
     @commit = commits(:first)
+    @stack = @commit.stack
   end
 
-  test "commit's state has changed after new status received" do
+  test ".replicate_from_github! is idempotent" do
+    status = OpenStruct.new(state: 'success', description: 'This is a description', context: 'default', target_url: 'http://example.com', created_at: 1.day.ago.as_json)
 
-     @commit.statuses.create!(:state => "failure")
-     assert_equal "failure", @commit.state
-   end
+    assert_difference '@commit.statuses.count', +1 do
+      @commit.statuses.replicate_from_github!(status)
+    end
 
-  test "commit only updates state for status with newest 'created_at' received" do
-    @commit.statuses.create!(:state => "failure", :created_at => 12.days.ago.to_s(:db))
-    assert_equal "pending", @commit.state
+    assert_no_difference '@commit.statuses.count' do
+      @commit.statuses.replicate_from_github!(status)
+    end
   end
 end

--- a/test/unit/jobs/refresh_status_job_test.rb
+++ b/test/unit/jobs/refresh_status_job_test.rb
@@ -7,7 +7,7 @@ class RefreshStatusesJobTest < ActiveSupport::TestCase
   end
 
   test "#perform call #refresh_status on the last 30 commits of the stack" do
-    Commit.any_instance.expects(:refresh_status).times(@stack.commits.count)
+    Commit.any_instance.expects(:refresh_statuses).times(@stack.commits.count)
 
     @job.perform(stack_id: @stack.id)
   end


### PR DESCRIPTION
Initially paired with @danieltremblay.

This is the first step toward supporting multiple CI.

We record all github statuses, and emulate compute on the fly the legacy `Commit#state` so that we don't have to change the UI yet nor migrate any data.

We'll do that in a followup.
