### PR TITLE
Let's use `release_path`.

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -44,7 +44,7 @@ after 'deploy:publishing', 'deploy:restart'
 namespace :deploy do
   task :use_deploy_log do
     on roles(:app), in: :parallel do
-      within fetch(:latest_release_directory) do
+      within release_path do
         execute "ln -nsfT #{shared_path}/deploy_log ./log"
       end
     end
@@ -52,7 +52,7 @@ namespace :deploy do
 
   task :use_runtime_log do
     on roles(:app), in: :parallel do
-      within fetch(:latest_release_directory) do
+      within release_path do
         execute "ln -nsfT #{shared_path}/log ./log"
       end
     end


### PR DESCRIPTION
The variable `latest_release_directory` appears only in what looks like outdated documentation on the upgrade path from Capistrano 2.\* to 3.\* (http://capistranorb.com/documentation/upgrading/).

This should fix the permission problems (and eventually show other issues hidden until now).

R: @eapache, @byroot.
