### PR TITLE
Fixing use_deploy_log and use_runtime_log for real, this time!

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -45,7 +45,7 @@ namespace :deploy do
   task :use_deploy_log do
     on roles(:app), in: :parallel do
       within release_path do
-        execute "ln -nsfT #{shared_path}/deploy_log ./log"
+        execute(*%W(ln -nsfT #{shared_path}/deploy_log ./log))
       end
     end
   end
@@ -53,7 +53,7 @@ namespace :deploy do
   task :use_runtime_log do
     on roles(:app), in: :parallel do
       within release_path do
-        execute "ln -nsfT #{shared_path}/log ./log"
+        execute(*%W(ln -nsfT #{shared_path}/log ./log))
       end
     end
   end


### PR DESCRIPTION
It appears that `execute` doesn't "like" command strings very much...

R: @eapache, @byroot.

I also changed the ownership of `/u/apps/shipit/shared/public/assets` so that deploy user can write into it.
