### PR TITLE
Display commit stats

### DIFF
--- a/app/assets/stylesheets/_pages/_commits.scss
+++ b/app/assets/stylesheets/_pages/_commits.scss
@@ -110,6 +110,20 @@
       color: #BBB;
     }
 
+    .event-stats {
+      display: inline-block;
+      margin-left: 3px;
+      font-weight: bold;
+    }
+
+    .event-additions {
+      color: #55a532; // From GitHub CSS
+    }
+
+    .event-deletions {
+      color: #bd2c00; // From GitHub CSS
+    }
+
   .deploy-action {
     margin: 0;
     float: right;
@@ -129,6 +143,7 @@
       font-size: 1rem;
       font-weight: normal;
     }
+
     .accessory {
       float: right;
       font-size: .875rem;

--- a/app/jobs/github_sync_job.rb
+++ b/app/jobs/github_sync_job.rb
@@ -17,7 +17,8 @@ class GithubSyncJob < BackgroundJob
     @stack.transaction do
       shared_parent.try(:detach_children!)
       new_commits.each do |gh_commit|
-        commit = @stack.commits.from_github(gh_commit)
+        full_commit = gh_commit.rels[:self].get.data # Sadly necessary to access commit stats
+        commit = @stack.commits.from_github(full_commit)
         commit.save!
         commit.refresh_statuses
       end

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -43,6 +43,8 @@ class Commit < ActiveRecord::Base
       committer: User.find_or_create_from_github(commit.committer || commit.commit.committer),
       committed_at: commit.commit.committer.date,
       authored_at: commit.commit.author.date,
+      additions: commit.stats.additions,
+      deletions: commit.stats.deletions,
     )
   end
 

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -42,6 +42,7 @@ class Deploy < ActiveRecord::Base
     after_transition to: :success, do: :update_undeployed_commits_count
   end
 
+  before_create :denormalize_commit_stats
   after_create :broadcast_deploy
 
   def build_rollback(user=nil)
@@ -142,6 +143,11 @@ class Deploy < ActiveRecord::Base
   end
 
   private
+
+  def denormalize_commit_stats
+    self.additions = commits.map(&:additions).sum
+    self.deletions = commits.map(&:deletions).sum
+  end
 
   def schedule_continuous_delivery
     return unless stack.continuous_deployment?

--- a/app/views/commits/_commit.html.erb
+++ b/app/views/commits/_commit.html.erb
@@ -8,6 +8,10 @@
       </a>
       merged <%= render_commit_id_link(commit) %> <%= timeago_tag(commit.committed_at, force: true) %>
       <span class="event-time">at <%= commit.committed_at %></span>
+      <span class="event-stats">
+        <span class="event-additions">+<%= commit.additions %></span>
+        <span class="event-deletions">-<%= commit.deletions %></span>
+      </span>
     </span>
     <span class="event-title">
       <%= render_commit_message_with_link commit %>

--- a/app/views/deploys/_deploy.html.erb
+++ b/app/views/deploys/_deploy.html.erb
@@ -18,6 +18,10 @@
 
       <%= link_to_github_deploy(deploy) %> <%= timeago_tag(deploy.created_at, force: true) %>
       <span class="event-time">at <%= deploy.created_at %></span>
+      <span class="event-stats">
+        <span class="event-additions">+<%= deploy.additions %></span>
+        <span class="event-deletions">-<%= deploy.deletions %></span>
+      </span>
     </span>
     <span class="event-title">
       <a href="<%= stack_deploy_path(@stack, deploy) %>">

--- a/app/views/deploys/_summary.html.erb
+++ b/app/views/deploys/_summary.html.erb
@@ -10,6 +10,10 @@
         </span>
       </div>
       <a href="<%= github_commit_url(commit) %>" target="_blank" class="accessory subdued number" data-tooltip="View on GitHub">
+        <span class="event-stats">
+          <span class="event-additions">+<%= commit.additions %></span>
+          <span class="event-deletions">-<%= commit.deletions %></span>
+        </span>
         <i class="ico-<%= commit.state %>-small"></i> <%= commit.short_sha %>
       </a>
     </li>

--- a/db/migrate/20141021181259_add_commit_stats.rb
+++ b/db/migrate/20141021181259_add_commit_stats.rb
@@ -1,0 +1,6 @@
+class AddCommitStats < ActiveRecord::Migration
+  def change
+    add_column :commits, :additions, :integer, default: 0
+    add_column :commits, :deletions, :integer, default: 0
+  end
+end

--- a/db/migrate/20141021183625_denormalize_deploy_stats.rb
+++ b/db/migrate/20141021183625_denormalize_deploy_stats.rb
@@ -1,0 +1,6 @@
+class DenormalizeDeployStats < ActiveRecord::Migration
+  def change
+    add_column :deploys, :additions, :integer, default: 0
+    add_column :deploys, :deletions, :integer, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141007172501) do
+ActiveRecord::Schema.define(version: 20141021183625) do
 
   create_table "commits", force: true do |t|
     t.integer  "stack_id",                                null: false
@@ -24,6 +24,8 @@ ActiveRecord::Schema.define(version: 20141007172501) do
     t.boolean  "detached",                default: false, null: false
     t.datetime "authored_at",                             null: false
     t.datetime "committed_at",                            null: false
+    t.integer  "additions",               default: 0
+    t.integer  "deletions",               default: 0
   end
 
   add_index "commits", ["author_id"], name: "index_commits_on_author_id", using: :btree
@@ -42,6 +44,8 @@ ActiveRecord::Schema.define(version: 20141007172501) do
     t.string   "type",            default: "Deploy",  null: false
     t.integer  "parent_id"
     t.boolean  "rolled_up",       default: false,     null: false
+    t.integer  "additions",       default: 0
+    t.integer  "deletions",       default: 0
   end
 
   add_index "deploys", ["rolled_up", "created_at", "status"], name: "index_deploys_on_rolled_up_and_created_at_and_status", using: :btree

--- a/test/fixtures/commits.yml
+++ b/test/fixtures/commits.yml
@@ -7,6 +7,8 @@ first:
   committer: walrus
   authored_at: <%= 10.days.ago.to_s(:db) %>
   committed_at: <%= 9.days.ago.to_s(:db) %>
+  additions: 42
+  deletions: 24
 
 second:
   id: 2
@@ -17,6 +19,8 @@ second:
   committer: walrus
   authored_at: <%= 8.days.ago.to_s(:db) %>
   committed_at: <%= 7.days.ago.to_s(:db) %>
+  additions: 1
+  deletions: 1
 
 third:
   id: 3
@@ -27,6 +31,8 @@ third:
   committer: walrus
   authored_at: <%= 6.days.ago.to_s(:db) %>
   committed_at: <%= 5.days.ago.to_s(:db) %>
+  additions: 12
+  deletions: 64
 
 fourth:
   id: 4
@@ -37,6 +43,8 @@ fourth:
   committer: walrus
   authored_at: <%= 4.days.ago.to_s(:db) %>
   committed_at: <%= 3.days.ago.to_s(:db) %>
+  additions: 420
+  deletions: 342
 
 fifth:
   id: 5
@@ -47,3 +55,5 @@ fifth:
   committer: walrus
   authored_at: <%= 2.days.ago.to_s(:db) %>
   committed_at: <%= 1.days.ago.to_s(:db) %>
+  additions: 1
+  deletions: 24

--- a/test/fixtures/deploys.yml
+++ b/test/fixtures/deploys.yml
@@ -3,27 +3,37 @@ shipit:
   until_commit_id: 2 # second
   stack: shipit
   status: success
+  additions: 1
+  deletions: 1
 
 shipit2:
   since_commit_id: 2 # second
   until_commit_id: 3 # third
   stack: shipit
   status: failed
+  additions: 12
+  deletions: 64
 
 shipit_pending:
   since_commit_id: 2 # second
   until_commit_id: 4 # fourth
   stack: shipit
   status: pending
+  additions: 432
+  deletions: 406
 
 shipit_running:
   since_commit_id: 3
   until_commit_id: 4
   stack: shipit
   status: running
+  additions: 420
+  deletions: 342
 
 shipit_complete:
   since_commit_id: 3
   until_commit_id: 4
   stack: shipit
   status: complete
+  additions: 420
+  deletions: 342

--- a/test/models/deploys_test.rb
+++ b/test/models/deploys_test.rb
@@ -45,6 +45,20 @@ class DeploysTest < ActiveSupport::TestCase
     assert_equal [], @deploy.commits
   end
 
+  test "additions and deletions are denormalized on before create" do
+    stack = stacks(:shipit)
+    first = commits(:first)
+    third  = commits(:third)
+
+    deploy = stack.deploys.create!(
+      :since_commit => first,
+      :until_commit => third
+    )
+
+    assert_equal 13, deploy.additions
+    assert_equal 65, deploy.deletions
+  end
+
   test "#commits returns the commits in the id range" do
     stack = stacks(:shipit)
     first = commits(:first)


### PR DESCRIPTION
A friend who work for Compose.io showcased me their Shipit equivalent (named Kevin), and I though their idea of displaying commit stats like that was great.

![capture d ecran 2014-10-21 a 14 29 50](https://cloud.githubusercontent.com/assets/44640/4724423/9179df8a-5950-11e4-83ae-383d9972443b.png)

![capture d ecran 2014-10-21 a 14 30 26](https://cloud.githubusercontent.com/assets/44640/4724426/9469a9c8-5950-11e4-840e-914681ec4260.png)

@gmalette @davidcornu @eapache thoughts? (Beside my lack of CSS skills)
