### PR TITLE
catch error better when version number is not valid

### DIFF
--- a/lib/snippets/push-to-heroku
+++ b/lib/snippets/push-to-heroku
@@ -11,7 +11,7 @@ function yellow() {
 }
 
 HEROKU_APP=$1
-HEROKU_RELEASE=`heroku releases --app $HEROKU_APP 2>/dev/null | head -n2 | tail -n1 | cut -d" " -f1`
+HEROKU_RELEASES=`heroku releases --app $HEROKU_APP 2>/dev/null`
 GIT_COMMAND=${GIT_COMMAND:="git push git@heroku.com:$HEROKU_APP.git $SHA:master $GIT_FLAGS"}
 
 if [ -z $HEROKU_APP ]; then
@@ -22,12 +22,16 @@ if [ -z $HEROKU_APP ]; then
   exit 1;
 fi
 
-if [ -z $HEROKU_RELEASE ]; then
-  red "Error detecting current heroku release."
+echo "$HEROKU_RELEASES" | head -n2 | tail -n1 | grep '^\(v[0-9]\+\)' >/dev/null
+
+if [ $? -ne 0 ]; then
+  red "Error detecting current heroku release. Message from 'heroku releases':"
+  echo "$HEROKU_RELEASES"
   exit 1;
 fi
 
-green "Current heroku release: $HEROKU_RELEASE"
+HEROKU_LAST_GOOD_RELEASE=`echo "$HEROKU_RELEASES" | head -n2 | tail -n1 | sed -e 's/^\(v[0-9]\+\).*/\1/'`
+green "Current heroku release: $HEROKU_LAST_GOOD_RELEASE"
 
 green "Pushing to heroku."
 $GIT_COMMAND
@@ -50,8 +54,8 @@ if [ "$MIGRATIONS" != "" ]; then
     red "Migration failed! This is bad."
     red "Please contact a heroku collaborator for $HEROKU_APP:"
     heroku sharing --app $HEROKU_APP
-    red "The app $HEROKU_APP will now be reverted to its last working version $HEROKU_RELEASE."
-    heroku releases:rollback $HEROKU_RELEASE --app $HEROKU_APP
+    red "The app $HEROKU_APP will now be reverted to its last working version $HEROKU_LAST_GOOD_RELEASE."
+    heroku releases:rollback $HEROKU_LAST_GOOD_RELEASE --app $HEROKU_APP
     red "Abort."
     exit 1
   fi


### PR DESCRIPTION
This validates that the release version can be found in the output of `heroku releases` with grep, and shows the output of `heroku releases` if the release version cannot be found (because it's probably an error message).

@byroot @nickhoffman for review
