### PR TITLE
Refactor DeploySpec to separate all the discovery mechanics

### DIFF
--- a/app/jobs/deploy_job.rb
+++ b/app/jobs/deploy_job.rb
@@ -50,7 +50,7 @@ class DeployJob < BackgroundJob
   end
 
   def record_deploy_spec_abilities
-    spec = DeploySpec.new(@deploy.working_directory, @deploy.stack.environment)
+    spec = DeploySpec::FileSystem.new(@deploy.working_directory, @deploy.stack.environment)
 
     @deploy.stack.update(
       supports_rollback: spec.supports_rollback?,

--- a/lib/deploy_commands.rb
+++ b/lib/deploy_commands.rb
@@ -41,7 +41,7 @@ class DeployCommands < Commands
   end
 
   def deploy_spec
-    @deploy_spec ||= DeploySpec.new(@deploy.working_directory, @stack.environment)
+    @deploy_spec ||= DeploySpec::FileSystem.new(@deploy.working_directory, @stack.environment)
   end
 
   def stack_commands

--- a/lib/deploy_spec/bundler_discovery.rb
+++ b/lib/deploy_spec/bundler_discovery.rb
@@ -1,0 +1,41 @@
+class DeploySpec
+  module BundlerDiscovery
+    DEFAULT_BUNDLER_WITHOUT = %w(default production development test staging benchmark debug)
+
+    def discover_dependencies_steps
+      discover_bundler || super
+    end
+
+    def discover_bundler
+      bundle_install if bundler?
+    end
+
+    def bundle_exec(command)
+      return command unless bundler?
+      "bundle exec #{command}"
+    end
+
+    def bundle_install
+      bundle = %(bundle check --path=#{BUNDLE_PATH} || bundle install #{frozen_flag} --path=#{BUNDLE_PATH} --retry=2)
+      bundle += " --without=#{bundler_without.join(':')}" unless bundler_without.empty?
+      [bundle]
+    end
+
+    def frozen_flag
+      '--frozen' if has_gemfile_lock?
+    end
+
+    def bundler_without
+      config('dependencies', 'bundler', 'without') || (gem? ? [] : DEFAULT_BUNDLER_WITHOUT)
+    end
+
+    def bundler?
+      file('Gemfile').exist?
+    end
+
+    def has_gemfile_lock?
+      file('Gemfile.lock').exist?
+    end
+
+  end
+end

--- a/lib/deploy_spec/capistrano_discovery.rb
+++ b/lib/deploy_spec/capistrano_discovery.rb
@@ -1,0 +1,29 @@
+class DeploySpec
+  module CapistranoDiscovery
+
+    def discover_deploy_steps
+      discover_capistrano || super
+    end
+
+    def discover_rollback_steps
+      discover_capistrano_rollback || super
+    end
+
+    def discover_capistrano
+      [cap('deploy')] if capistrano?
+    end
+
+    def discover_capistrano_rollback
+      [cap('deploy:rollback')] if capistrano?
+    end
+
+    def cap(command)
+      bundle_exec("cap $ENVIRONMENT #{command}")
+    end
+
+    def capistrano?
+      file('Capfile').exist?
+    end
+
+  end
+end

--- a/lib/deploy_spec/file_system.rb
+++ b/lib/deploy_spec/file_system.rb
@@ -1,0 +1,32 @@
+class DeploySpec
+  class FileSystem < DeploySpec
+    include BundlerDiscovery
+    include CapistranoDiscovery
+    include RubygemsDiscovery
+
+    def initialize(app_dir, env)
+      @app_dir = Pathname(app_dir)
+      @env = env
+    end
+
+    private
+
+    def config(*)
+      @config ||= load_config
+      super
+    end
+
+    def load_config
+      read_config(file("shipit.#{@env}.yml")) || read_config(file("shipit.yml"))
+    end
+
+    def read_config(path)
+      SafeYAML.load(path.read) if path.exist?
+    end
+
+    def file(path)
+      @app_dir.join(path)
+    end
+
+  end
+end

--- a/lib/deploy_spec/rubygems_discovery.rb
+++ b/lib/deploy_spec/rubygems_discovery.rb
@@ -1,0 +1,25 @@
+class DeploySpec
+  module RubygemsDiscovery
+
+    def discover_deploy_steps
+      discover_gem || super
+    end
+
+    def discover_gem
+      publish_gem if gem?
+    end
+
+    def gem?
+      !!gemspec
+    end
+
+    def gemspec
+      Dir[file('*.gemspec').to_s].first
+    end
+
+    def publish_gem
+      ["assert-gem-version-tag #{gemspec}", 'bundle exec rake release']
+    end
+
+  end
+end

--- a/lib/stack_commands.rb
+++ b/lib/stack_commands.rb
@@ -18,7 +18,7 @@ class StackCommands < Commands
 
   def fetch_deployed_revision
     with_temporary_working_directory do |dir|
-      spec = DeploySpec.new(dir, @stack.environment)
+      spec = DeploySpec::FileSystem.new(dir, @stack.environment)
       outputs = spec.fetch_deployed_revision_steps.map do |command_line|
         Command.new(command_line, env: env, chdir: dir).run!
       end

--- a/test/unit/deploy_spec_test.rb
+++ b/test/unit/deploy_spec_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class DeploySpecTest < ActiveSupport::TestCase
 
   setup do
-    @spec = DeploySpec.new('/tmp/', 'env')
+    @spec = DeploySpec::FileSystem.new('/tmp/', 'env')
     @spec.stubs(:load_config).returns({})
   end
 
@@ -129,8 +129,8 @@ class DeploySpecTest < ActiveSupport::TestCase
     config = {}
     config.expects(:exist?).returns(true)
     config.expects(:read).returns({'dependencies' => {'override' => %w(foo bar baz)}}.to_yaml)
-    spec = DeploySpec.new('.', 'staging')
-    spec.expects(:shipit_env_yml).twice.returns(config)
+    spec = DeploySpec::FileSystem.new('.', 'staging')
+    spec.expects(:file).with('shipit.staging.yml').returns(config)
     assert_equal %w(foo bar baz), spec.dependencies_steps
   end
 
@@ -142,14 +142,14 @@ class DeploySpecTest < ActiveSupport::TestCase
     config.expects(:exist?).returns(true)
     config.expects(:read).returns({'dependencies' => {'override' => %w(foo bar baz)}}.to_yaml)
 
-    spec = DeploySpec.new('.', 'staging')
-    spec.expects(:shipit_env_yml).once.returns(not_config)
-    spec.expects(:shipit_yml).twice.returns(config)
+    spec = DeploySpec::FileSystem.new('.', 'staging')
+    spec.expects(:file).with('shipit.staging.yml').returns(not_config)
+    spec.expects(:file).with('shipit.yml').returns(config)
     assert_equal %w(foo bar baz), spec.dependencies_steps
   end
 
   test '#gemspec gives the path of the repo gemspec if present' do
-    spec = DeploySpec.new('foobar/', 'production')
+    spec = DeploySpec::FileSystem.new('foobar/', 'production')
     Dir.expects(:[]).with('foobar/*.gemspec').returns(['foobar/foobar.gemspec'])
     assert_equal 'foobar/foobar.gemspec', spec.gemspec
   end


### PR DESCRIPTION
To support https://github.com/Shopify/shipit2/issues/256 / https://github.com/Shopify/shipit2/issues/182 we need to fully cache the shipit.yml in database.

But `DeploySpec` depends on the repository to be able to discover things like bundler or capistrano.

The idea then is to cache a deploy spec that do not need discovery any more. SO the first step is to extract all of that. Please believe me this will make sense very soon.

@gmalette @eapache @davidcornu for review please.
