### PR TITLE
Store a cached version of the deploy spec in the stack

### DIFF
--- a/app/jobs/cache_deploy_spec_job.rb
+++ b/app/jobs/cache_deploy_spec_job.rb
@@ -1,0 +1,11 @@
+class CacheDeploySpecJob < BackgroundJob
+  @queue = :default
+
+  extend BackgroundJob::StackExclusive
+
+  def perform(params)
+    stack = Stack.find(params[:stack_id])
+    commands = StackCommands.new(stack)
+    @stack.update!(cached_deploy_spec: commands.build_cacheable_deploy_spec)
+  end
+end

--- a/app/jobs/deploy_job.rb
+++ b/app/jobs/deploy_job.rb
@@ -18,7 +18,7 @@ class DeployJob < BackgroundJob
     capture commands.clone
     capture commands.checkout(@deploy.until_commit)
 
-    record_deploy_spec_abilities
+    record_deploy_spec!
 
     Bundler.with_clean_env do
       capture_all commands.install_dependencies
@@ -49,13 +49,8 @@ class DeployJob < BackgroundJob
     @deploy.write("\n")
   end
 
-  def record_deploy_spec_abilities
-    spec = DeploySpec::FileSystem.new(@deploy.working_directory, @deploy.stack.environment)
-
-    @deploy.stack.update(
-      supports_rollback: spec.supports_rollback?,
-      supports_fetch_deployed_revision: spec.supports_fetch_deployed_revision?
-    )
+  def record_deploy_spec!
+    @deploy.stack.update(cached_deploy_spec: @deploy.spec)
   end
 
 end

--- a/app/jobs/fetch_deployed_revision_job.rb
+++ b/app/jobs/fetch_deployed_revision_job.rb
@@ -12,9 +12,7 @@ class FetchDeployedRevisionJob < BackgroundJob
 
     begin
       sha = commands.fetch_deployed_revision
-    rescue Command::Error, DeploySpec::Error
-      stack.update!(supports_fetch_deployed_revision: false)
-      raise
+    rescue DeploySpec::Error
     end
 
     return unless sha.present?

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -45,6 +45,10 @@ class Deploy < ActiveRecord::Base
   before_create :denormalize_commit_stats
   after_create :broadcast_deploy
 
+  def spec
+    @spec ||= DeploySpec::FileSystem.new(working_directory, stack.environment)
+  end
+
   def build_rollback(user=nil)
     Rollback.new(
       user_id: user.try!(:id),

--- a/app/models/stack.rb
+++ b/app/models/stack.rb
@@ -21,8 +21,11 @@ class Stack < ActiveRecord::Base
 
   scope :with_reminder_webhook, -> { where.not(reminder_url: '') }
 
+  serialize :cached_deploy_spec, DeploySpec
+  delegate :supports_rollback?, :supports_fetch_deployed_revision?, to: :cached_deploy_spec, allow_nil: true
+
   def self.refresh_deployed_revisions
-    where(supports_fetch_deployed_revision: true).find_each(&:async_refresh_deployed_revision)
+    find_each.select(&:supports_fetch_deployed_revision?).each(&:async_refresh_deployed_revision)
   end
 
   def self.send_undeployed_commits_reminders

--- a/db/migrate/20141024144848_add_deploy_spec_to_stack.rb
+++ b/db/migrate/20141024144848_add_deploy_spec_to_stack.rb
@@ -1,0 +1,7 @@
+class AddDeploySpecToStack < ActiveRecord::Migration
+  def change
+    add_column :stacks, :cached_deploy_spec, :text
+    remove_column :stacks, :supports_fetch_deployed_revision, :boolean
+    remove_column :stacks, :supports_rollback, :boolean
+  end
+end

--- a/db/migrate/20141024180015_rebuild_stacks_cached_deploy_spec.rb
+++ b/db/migrate/20141024180015_rebuild_stacks_cached_deploy_spec.rb
@@ -1,0 +1,10 @@
+class RebuildStacksCachedDeploySpec < ActiveRecord::Migration
+  def up
+    Stack.pluck(:id).each do |id|
+      Resque.enqueue(CacheDeploySpecJob, stack_id: id)
+    end
+  end
+
+  def down
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20141021183625) do
+ActiveRecord::Schema.define(version: 20141024180015) do
 
   create_table "commits", force: true do |t|
     t.integer  "stack_id",                                null: false
@@ -64,21 +64,20 @@ ActiveRecord::Schema.define(version: 20141021183625) do
   add_index "output_chunks", ["deploy_id"], name: "index_output_chunks_on_deploy_id", using: :btree
 
   create_table "stacks", force: true do |t|
-    t.string   "repo_name",                                               null: false
-    t.string   "repo_owner",                                              null: false
-    t.string   "environment",                      default: "production", null: false
+    t.string   "repo_name",                                       null: false
+    t.string   "repo_owner",                                      null: false
+    t.string   "environment",              default: "production", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string   "branch",                           default: "master",     null: false
+    t.string   "branch",                   default: "master",     null: false
     t.text     "checklist"
     t.string   "deploy_url"
     t.string   "lock_reason"
-    t.integer  "deploys_count",                    default: 0,            null: false
-    t.boolean  "continuous_deployment",            default: false,        null: false
-    t.integer  "undeployed_commits_count",         default: 0,            null: false
+    t.integer  "deploys_count",            default: 0,            null: false
+    t.boolean  "continuous_deployment",    default: false,        null: false
+    t.integer  "undeployed_commits_count", default: 0,            null: false
     t.string   "reminder_url"
-    t.boolean  "supports_fetch_deployed_revision", default: false,        null: false
-    t.boolean  "supports_rollback",                default: false,        null: false
+    t.text     "cached_deploy_spec"
   end
 
   add_index "stacks", ["repo_owner", "repo_name", "environment"], name: "stack_unicity", unique: true, using: :btree

--- a/lib/deploy_commands.rb
+++ b/lib/deploy_commands.rb
@@ -10,7 +10,7 @@ class DeployCommands < Commands
 
   def install_dependencies
     env = self.env.merge(deploy_spec.machine_env)
-    deploy_spec.dependencies_steps.map do |command_line|
+    deploy_spec.dependencies_steps!.map do |command_line|
       Command.new(command_line, env: env, chdir: @deploy.working_directory)
     end
   end
@@ -26,7 +26,7 @@ class DeployCommands < Commands
       'BUNDLE_PATH' => BUNDLE_PATH,
     ).merge(deploy_spec.machine_env)
 
-    steps = @deploy.rollback? ? deploy_spec.rollback_steps : deploy_spec.deploy_steps
+    steps = @deploy.rollback? ? deploy_spec.rollback_steps! : deploy_spec.deploy_steps!
     steps.map do |command_line|
       Command.new(command_line, env: env, chdir: @deploy.working_directory)
     end

--- a/lib/deploy_spec/file_system.rb
+++ b/lib/deploy_spec/file_system.rb
@@ -9,7 +9,21 @@ class DeploySpec
       @env = env
     end
 
+    def cacheable
+      DeploySpec.new(cacheable_config)
+    end
+
     private
+
+    def cacheable_config
+      (config || {}).deep_merge(
+        'machine' => {'environment' => machine_env},
+        'dependencies' => {'override' => dependencies_steps},
+        'deploy' => {'override' => deploy_steps},
+        'rollback' => {'override' => rollback_steps},
+        'fetch' => fetch_deployed_revision_steps,
+      )
+    end
 
     def config(*)
       @config ||= load_config

--- a/lib/stack_commands.rb
+++ b/lib/stack_commands.rb
@@ -26,6 +26,12 @@ class StackCommands < Commands
     end
   end
 
+  def build_cacheable_deploy_spec
+    with_temporary_working_directory do |dir|
+      DeploySpec::FileSystem.new(dir, @stack.environment).cacheable
+    end
+  end
+
   def with_temporary_working_directory
     fetch.run!
     git('checkout', '--force', "origin/#{@stack.branch}", env: env, chdir: @stack.git_path).run!

--- a/test/fixtures/stacks.yml
+++ b/test/fixtures/stacks.yml
@@ -6,5 +6,4 @@ shipit:
   deploys_count: 3
   undeployed_commits_count: 3
   checklist: "foo\n\nbar\n\nbaz"
-  supports_fetch_deployed_revision: true
-  supports_rollback: true
+  cached_deploy_spec: '{"machine":{"environment":{}},"dependencies":{"override":[]},"deploy":{"override":null},"rollback":{"override":["echo \"Rollback!\""]},"fetch":["echo \"42\""]}'

--- a/test/unit/deploy_commands_test.rb
+++ b/test/unit/deploy_commands_test.rb
@@ -6,9 +6,9 @@ class DeployCommandsTest < ActiveSupport::TestCase
     @deploy = deploys(:shipit_pending)
     @commands = DeployCommands.new(@deploy)
     @deploy_spec = stub(
-      dependencies_steps: ['bundle install --some-args'],
-      deploy_steps: ['bundle exec cap $ENVIRONMENT deploy'],
-      rollback_steps: ['bundle exec cap $ENVIRONMENT deploy:rollback'],
+      dependencies_steps!: ['bundle install --some-args'],
+      deploy_steps!: ['bundle exec cap $ENVIRONMENT deploy'],
+      rollback_steps!: ['bundle exec cap $ENVIRONMENT deploy:rollback'],
       machine_env: {'GLOBAL' => '1'},
     )
     @commands.stubs(:deploy_spec).returns(@deploy_spec)

--- a/test/unit/deploy_spec_test.rb
+++ b/test/unit/deploy_spec_test.rb
@@ -41,9 +41,9 @@ class DeploySpecTest < ActiveSupport::TestCase
     assert_equal :bundle_install, @spec.dependencies_steps
   end
 
-  test '#fetch_deployed_revision_steps is unknown by default' do
+  test '#fetch_deployed_revision_steps! is unknown by default' do
     assert_raises DeploySpec::Error do
-      @spec.fetch_deployed_revision_steps
+      @spec.fetch_deployed_revision_steps!
     end
   end
 
@@ -102,10 +102,10 @@ class DeploySpecTest < ActiveSupport::TestCase
     assert_equal ['bundle exec cap $ENVIRONMENT deploy'], @spec.deploy_steps
   end
 
-  test '#deploy_steps raise a DeploySpec::Error if it dont know how to deploy the app' do
+  test '#deploy_steps raise a DeploySpec::Error! if it dont know how to deploy the app' do
     @spec.expects(:capistrano?).returns(false)
     assert_raise DeploySpec::Error do
-      @spec.deploy_steps
+      @spec.deploy_steps!
     end
   end
 
@@ -168,6 +168,19 @@ class DeploySpecTest < ActiveSupport::TestCase
     @spec.stubs(:gemspec).returns('/tmp/shipit.gemspec')
     refute @spec.capistrano?
     assert_equal ['assert-gem-version-tag /tmp/shipit.gemspec', 'bundle exec rake release'], @spec.deploy_steps
+  end
+
+  test '#cacheable returns a DeploySpec instance that can be serialized' do
+    assert_instance_of DeploySpec::FileSystem, @spec
+    assert_instance_of DeploySpec, @spec.cacheable
+    config = {
+      'machine' => {'environment' => {}},
+      'dependencies' => {'override' => []},
+      'deploy' => {'override' => nil},
+      'rollback' => {'override' => nil},
+      'fetch' => nil
+    }
+    assert_equal config, @spec.cacheable.config
   end
 
 end

--- a/test/unit/jobs/deploy_job_test.rb
+++ b/test/unit/jobs/deploy_job_test.rb
@@ -87,7 +87,7 @@ class DeployJobTest < ActiveSupport::TestCase
     DeploySpec.any_instance.expects(:supports_fetch_deployed_revision?).returns(true)
     DeploySpec.any_instance.expects(:supports_rollback?).returns(true)
 
-    @stack.update!(supports_rollback: false, supports_fetch_deployed_revision: false)
+    @stack.update!(cached_deploy_spec: nil)
 
     refute @stack.supports_rollback?
     refute @stack.supports_fetch_deployed_revision?

--- a/test/unit/jobs/fetch_deployed_revision_job_test.rb
+++ b/test/unit/jobs/fetch_deployed_revision_job_test.rb
@@ -28,16 +28,4 @@ class FetchDeployedRevisionJobTest < ActiveSupport::TestCase
     @job.perform(stack_id: @stack.id)
   end
 
-  test 'the job disabled revision fetching if the #fetch_deployed_revision raise a Command::Error' do
-    Stack.any_instance.expects(:deploying?).returns(false)
-    StackCommands.any_instance.expects(:fetch_deployed_revision).raises(Command::Error.new("Missing arguments"))
-    Stack.any_instance.expects(:update_deployed_revision).never
-
-    assert_raises Command::Error do
-      @job.perform(stack_id: @stack.id)
-    end
-
-    refute @stack.reload.supports_fetch_deployed_revision?
-  end
-
 end


### PR DESCRIPTION
Followup of https://github.com/Shopify/shipit2/pull/258

Now we have access to `Stack#cached_deploy_spec`, which will allow us to make UI changes based on the content fo the `shipit.yml`.
