### PR TITLE
More refactoring to bring one off commands.

### DIFF
--- a/app/controllers/stacks_controller.rb
+++ b/app/controllers/stacks_controller.rb
@@ -15,7 +15,7 @@ class StacksController < ApplicationController
     @stack = Stack.from_param(params[:id])
     return unless stale?(last_modified: @stack.updated_at)
 
-    @deploys = @stack.deploys.order(id: :desc).preload(:since_commit, :until_commit, :user).limit(10)
+    @tasks = @stack.tasks.order(id: :desc).preload(:since_commit, :until_commit, :user).limit(10)
     @commits = @stack.commits.reachable.preload(:author, :statuses).order(id: :desc)
     if deployed_commit = @stack.last_deployed_commit
       @commits = @commits.where('id > ?', deployed_commit.id)

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,0 +1,24 @@
+class TasksController < ApplicationController
+  before_action :load_stack
+
+  def new
+    @definition = @stack.find_task_definition(params[:definition_id])
+    @task = @stack.tasks.build(definition: @definition)
+  end
+
+  def show
+    @task = @stack.tasks.find(params[:id])
+  end
+
+  def create
+    @task = @stack.trigger_task(params[:definition_id], current_user)
+    redirect_to [@stack, @task]
+  end
+
+  private
+
+  def load_stack
+    @stack ||= Stack.from_param(params[:stack_id])
+  end
+
+end

--- a/app/jobs/cache_deploy_spec_job.rb
+++ b/app/jobs/cache_deploy_spec_job.rb
@@ -6,6 +6,6 @@ class CacheDeploySpecJob < BackgroundJob
   def perform(params)
     stack = Stack.find(params[:stack_id])
     commands = StackCommands.new(stack)
-    @stack.update!(cached_deploy_spec: commands.build_cacheable_deploy_spec)
+    stack.update!(cached_deploy_spec: commands.build_cacheable_deploy_spec)
   end
 end

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -1,8 +1,6 @@
 require 'fileutils'
 
 class Deploy < Task
-  belongs_to :since_commit, class_name: 'Commit'
-
   state_machines[:status].tap do |status|
     status.after_transition :broadcast_deploy
     status.after_transition to: :success, do: :schedule_continuous_delivery

--- a/app/models/rollback.rb
+++ b/app/models/rollback.rb
@@ -10,4 +10,8 @@ class Rollback < Deploy
     @commits ||= stack.commits.reachable.newer_than(until_commit_id).until(since_commit_id).order(id: :asc)
   end
 
+  def to_partial_path
+    'deploys/deploy'
+  end
+
 end

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,7 +2,11 @@ class Task < ActiveRecord::Base
   belongs_to :user
   belongs_to :stack, touch: true, counter_cache: true
   belongs_to :until_commit, class_name: 'Commit'
+  belongs_to :since_commit, class_name: 'Commit'
+
   has_many :chunks, -> { order(:id) }, class_name: 'OutputChunk'
+
+  serialize :definition, TaskDefinition
 
   scope :success,   -> { where(status: 'success') }
   scope :completed, -> { where(status: %w(success error failed)) }

--- a/app/models/task_definition.rb
+++ b/app/models/task_definition.rb
@@ -1,0 +1,37 @@
+class TaskDefinition
+  NotFound = Class.new(StandardError)
+
+  class << self
+
+    def load(payload)
+      return unless payload.present?
+      json = JSON.parse(payload)
+      new(json.delete('id'), json)
+    end
+
+    def dump(definition)
+      return unless definition.present?
+      JSON.dump(definition.as_json)
+    end
+
+  end
+
+  attr_reader :id, :action, :description, :steps
+
+  def initialize(id, config)
+    @id = id
+    @action = config['action']
+    @description = config['description'] || ''
+    @steps = config['steps'] || []
+  end
+
+  def as_json
+    {
+      id: id,
+      action: action,
+      description: description,
+      steps: steps,
+    }
+  end
+
+end

--- a/app/views/stacks/show.html.erb
+++ b/app/views/stacks/show.html.erb
@@ -1,3 +1,15 @@
+<% unless @stack.task_definitions.empty? %>
+  <% content_for :inner_sidebar do %>
+    <div class="stack-actions">
+      <ul>
+        <% @stack.task_definitions.each do |definition| %>
+          <%= link_to definition.action, new_stack_tasks_path(@stack, definition_id: definition.id), class: %w(btn trigger-deploy) %>
+        <% end %>
+      </ul>
+    </div>
+  <% end %>
+<% end %>
+
 <%= render partial: "stacks/header", locals: { stack: @stack } %>
 
 <section>
@@ -32,6 +44,6 @@
     <header class="section-header">
       <h2>Previous Deploys</h2>
     </header>
-    <ul class="deploy-lst"><%= render partial: "deploys/deploy", collection: @deploys %></ul>
+    <ul class="deploy-lst"><%= render @tasks %></ul>
   </section>
 </div>

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -1,0 +1,24 @@
+<li class="deploy" id="deploy-<%= task.id %>" data-deploy-status="<%= task.status %>">
+  <div class="status <%= task.status %>" data-tooltip="<%= task.status.capitalize %>">
+    <%= link_to stack_task_path(@stack, task) do %>
+      <i><%= task.status %></i>
+    <% end %>
+  </div>
+  <div class="event">
+    <span class="event-meta">
+      <a href="<%= github_user_url(task.author.login) %>" class="user main-user">
+        <%= github_avatar task.user, size: 20 %>
+        <%= task.author.name %>
+      </a>
+      ran a command
+      <%= timeago_tag(task.created_at, force: true) %>
+      <span class="event-time">at <%= task.created_at %></span>
+    </span>
+    <span class="event-title">
+      <a href="<%= stack_task_path(@stack, task) %>">
+        <%= task.definition.action %>
+      </a>
+      <span class="event-number"></span>
+    </span>
+  </div>
+</li>

--- a/app/views/tasks/new.html.erb
+++ b/app/views/tasks/new.html.erb
@@ -1,0 +1,19 @@
+<%= render partial: "stacks/header", locals: { stack: @stack } %>
+
+<div class="wrapper">
+  <section>
+    <header class="section-header">
+      <p><%= @task.definition.description %></p>
+    </header>
+  </section>
+
+  <section>
+    <pre class="nowrap"><code><%= @task.definition.steps.join("\n") %></code></pre>
+  </section>
+
+  <section class="submit-section">
+    <%= form_for @task, url: stack_tasks_path(@stack, definition_id: @task.definition.id) do |f| %>
+      <%= f.submit @task.definition.action, :class => ['btn', 'primary', 'trigger-deploy'] %>
+    <% end %>
+  </section>
+</div>

--- a/app/views/tasks/show.html.erb
+++ b/app/views/tasks/show.html.erb
@@ -1,0 +1,16 @@
+<%= render partial: "stacks/header", locals: { stack: @stack } %>
+
+<span class="deploy-tasks"></span>
+<div class="deploy-banner <%= @task.status %>" data-deploy-status="<%= @task.status %>">
+  <div class="wrapper">
+    <a href="#" class="user main-user disabled"><%= @task.author.name %></a>
+    <span class="deploy-status">
+      executing <%= @task.definition.id %>
+      <%= timeago_tag(@task.created_at, force: true) %> at <%= @task.created_at %>
+    </span>
+  </div>
+</div>
+
+<pre class="nowrap">
+  <code data-next-chunks-url="<%= next_chunks_url(@task) %>"><%= @task.chunk_output %></code>
+</pre>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,12 @@ Shipit::Application.routes.draw do
     resources :commits, only: :show
 
     resources :rollbacks, only: %i(create)
-    resources :tasks, only: [] do
+    resources :tasks, only: %i(show) do
+      collection do
+        get ':definition_id/new' => 'tasks#new', as: :new
+        post ':definition_id' => 'tasks#create', as: ''
+      end
+
       resources :chunks, only:  %i(index), defaults: {format: :json} do
         collection do
           get :tail

--- a/lib/deploy_spec.rb
+++ b/lib/deploy_spec.rb
@@ -77,6 +77,14 @@ class DeploySpec
     fetch_deployed_revision_steps || cant_detect!(:fetch)
   end
 
+  def task_definitions
+    (config('tasks') || {}).map { |name, definition| TaskDefinition.new(name, definition) }
+  end
+
+  def find_task_definition(id)
+    TaskDefinition.new(id, config('tasks', id) || task_not_found!(id))
+  end
+
   private
 
   def discover_dependencies_steps
@@ -89,6 +97,10 @@ class DeploySpec
   end
 
   def discover_fetch_deployed_revision_steps
+  end
+
+  def task_not_found!(id)
+    raise TaskDefinition::NotFound.new("No definition for task #{id.inspect}")
   end
 
   def cant_detect!(type)

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+class TasksControllerTest < ActionController::TestCase
+
+  setup do
+    @stack = stacks(:shipit)
+    @definition = @stack.find_task_definition('restart')
+    @task = tasks(:shipit_restart)
+    @commit = commits(:second)
+    session[:user_id] = users(:walrus).id
+  end
+
+  test "tasks defined in the shipit.yml can be displayed" do
+    get :new, stack_id: @stack, definition_id: @definition.id
+    assert_response :ok
+  end
+
+  test "tasks defined in the shipit.yml can be triggered" do
+    assert_difference '@stack.tasks.count', +1 do
+      post :create, stack_id: @stack, definition_id: @definition.id
+    end
+    assert_redirected_to stack_task_path(@stack, Task.last)
+  end
+
+  test "triggered tasks can be observed" do
+    get :show, stack_id: @stack, id: @task.id
+    assert_response :ok
+  end
+
+end

--- a/test/fixtures/tasks.yml
+++ b/test/fixtures/tasks.yml
@@ -16,6 +16,22 @@ shipit2:
   additions: 12
   deletions: 64
 
+shipit_restart:
+  since_commit_id: 2 # second
+  until_commit_id: 2 # second
+  type: Task
+  stack: shipit
+  status: success
+  definition: >
+    {
+      "id": "restart",
+      "action": "Restart application",
+      "description": "Restart app and job servers",
+      "steps": [
+        "cap $ENVIRONMENT deploy:restart"
+      ]
+    }
+
 shipit_pending:
   since_commit_id: 2 # second
   until_commit_id: 4 # fourth

--- a/test/models/task_definitions_test.rb
+++ b/test/models/task_definitions_test.rb
@@ -1,0 +1,28 @@
+require 'test_helper'
+
+class TaskDefinitionsTest < ActiveSupport::TestCase
+
+  setup do
+    @definition = TaskDefinition.new(
+      'restart',
+      'action' => 'Restart application',
+      'description' => 'Restart app and job servers',
+      'steps' => ['touch tmp/restart'],
+    )
+  end
+
+  test ".load returns nil if payload is nil or blank" do
+    assert_nil TaskDefinition.load('')
+    assert_nil TaskDefinition.load(nil)
+  end
+
+  test ".dump returns nil if given nil" do
+    assert_nil TaskDefinition.dump(nil)
+  end
+
+  test "serialization works" do
+    as_json = {id: 'restart', action: 'Restart application', description: 'Restart app and job servers', steps: ['touch tmp/restart']}
+    assert_equal(as_json, TaskDefinition.load(TaskDefinition.dump(@definition)).as_json)
+  end
+
+end


### PR DESCRIPTION
Fixes: https://github.com/Shopify/shipit2/issues/256
Fixes: https://github.com/Shopify/shipit2/issues/182

Each defined task appear on the stack's sidebar:

![capture d ecran 2014-10-27 a 14 47 01](https://cloud.githubusercontent.com/assets/44640/4797189/c0c3d83c-5e09-11e4-920c-cb10eb89e0a2.png)

Clicking the button, bring you to a summary page where you need to confirm:

![capture d ecran 2014-10-27 a 14 47 11](https://cloud.githubusercontent.com/assets/44640/4797199/cec7bf3e-5e09-11e4-9844-dddb3f003bd7.png)

Things that should be improved / figured out in a followup:
- [ ] Some tasks should have a stack exclusive lock, others not, it should be defined in the shipit.yml
- [ ] Tasks should have an optional checklist like regular deploys.
- [ ] The UI sucks.
