### PR TITLE
Use ellipsis for actions that don't happen immediately

### DIFF
--- a/app/views/stacks/settings.html.erb
+++ b/app/views/stacks/settings.html.erb
@@ -54,7 +54,7 @@
     <div class="setting-section">
       <h5>Delete this stack</h5>
       <p>This action will delete the stack from Ship it permanently. Be careful.</p>
-      <%= button_to "Delete", stack_path(@stack), :class => "btn delete", :method => :delete, :confirm => "Are you sure?" %>
+      <%= button_to "Delete…", stack_path(@stack), :class => "btn delete", :method => :delete, :confirm => "Are you sure?" %>
     </div>
 
   </section>

--- a/app/views/stacks/show.html.erb
+++ b/app/views/stacks/show.html.erb
@@ -4,7 +4,7 @@
       <ul>
         <% @stack.task_definitions.each do |definition| %>
           <li class="stack-action">
-            <%= link_to definition.action, new_stack_tasks_path(@stack, definition_id: definition.id), class: %w(btn trigger-deploy) %>
+            <%= link_to "#{definition.action}…", new_stack_tasks_path(@stack, definition_id: definition.id), class: %w(btn trigger-deploy) %>
           </li>
         <% end %>
       </ul>


### PR DESCRIPTION
Not added to the omnipresent Rollback button, but for some actions where the action does not happen immediately but after a confirmation, I thought it would be less scary and a [usual affordance](http://uxmovement.com/buttons/how-to-use-arrow-and-ellipsis-affordances/). 

@vernalkick 
