### PR TITLE
Pre-interpolate environment variables to avoid spawning a subshell that prevent the abort button from working properly

### DIFF
--- a/test/unit/command_test.rb
+++ b/test/unit/command_test.rb
@@ -6,4 +6,19 @@ class CommandTest < ActiveSupport::TestCase
     script_path = Rails.root.join('lib', 'snippets', 'extract-gem-version').to_s
     assert_equal "#{script_path}\n", out
   end
+
+  test "#interpolate_environment_variables replace environment variables by their value" do
+    command = Command.new('cap $ENVIRONMENT deploy', env: {'ENVIRONMENT' => 'production'}, chdir: '.')
+    assert_equal [%(cap production deploy)], command.interpolated_arguments
+  end
+
+  test "#interpolate_environment_variables coerce nil to empty string" do
+    command = Command.new('cap $FOO deploy', env: {'ENVIRONMENT' => 'production'}, chdir: '.')
+    assert_equal [%(cap '' deploy)], command.interpolated_arguments
+  end
+
+  test "#interpolate_environment_variables fallback to ENV" do
+    command = Command.new('cap $LANG deploy', env: {'ENVIRONMENT' => 'production'}, chdir: '.')
+    assert_equal [%(cap #{ENV['LANG']} deploy)], command.interpolated_arguments
+  end
 end


### PR DESCRIPTION
I need to ship that immediately to test in real conditions, but if you have concern I'll fix them in a follow-up.

See https://github.com/Shopify/shipit2/issues/253#issuecomment-61141250 for context.

@gmalette @davidcornu @eapache 
