### PR TITLE
Display the exception that cause the deploy to error in the output.

### DIFF
--- a/app/jobs/perform_task_job.rb
+++ b/app/jobs/perform_task_job.rb
@@ -26,9 +26,9 @@ class PerformTaskJob < BackgroundJob
     @task.complete!
   rescue Command::Error
     @task.failure!
-  rescue StandardError
+  rescue StandardError => error
+    @task.write("#{error.class}: #{error.message}\n\t#{error.backtrace.join("\t")}\n")
     @task.error!
-    raise
   ensure
     Resque.enqueue(FetchDeployedRevisionJob, stack_id: @task.stack_id)
     @task.clear_working_directory

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -56,7 +56,7 @@ class Task < ActiveRecord::Base
   end
 
   def chunk_output
-    chunks.pluck(:text).join("\n")
+    chunks.pluck(:text).join
   end
 
   def rollback?


### PR DESCRIPTION
Fixes https://github.com/Shopify/shipit2/issues/272

Starscream `shipit.yml` was trying to execute a script that was missing the `+x` permission. The deploy was just erroring without anything to debug.

This should help people debug their shipit.yml.

@airhorns @gmalette @eapache for review please.
