### PR TITLE
Run cron tasks as shipit user not deploy

### DIFF
--- a/config/deploy.rb
+++ b/config/deploy.rb
@@ -60,7 +60,9 @@ namespace :deploy do
     on roles(:db) do
       within release_path do
         with rails_env: fetch(:rails_env) do
-          execute 'whenever', '--write-crontab'
+          as 'shipit' do
+            execute 'whenever', '--update-crontab'
+          end
         end
       end
     end


### PR DESCRIPTION
@ibawt @grollest for review please.

``` shell
$ cap production deploy:cron
DEBUG[0c36ec32] Running /usr/bin/env if test ! -d /u/apps/shipit/current; then echo "Directory does not exist '/u/apps/shipit/current'" 1>&2; false; fi on shipit2.chi.shopify.com
DEBUG[0c36ec32] Command: if test ! -d /u/apps/shipit/current; then echo "Directory does not exist '/u/apps/shipit/current'" 1>&2; false; fi
DEBUG[0c36ec32] Finished in 1.302 seconds with exit status 0 (successful).
DEBUG[0afbde0c] Running /usr/bin/env if ! sudo -u shipit whoami > /dev/null; then echo "You cannot switch to user 'shipit' using sudo, please check the sudoers file" 1>&2; false; fi on shipit2.chi.shopify.com
DEBUG[0afbde0c] Command: if ! sudo -u shipit whoami > /dev/null; then echo "You cannot switch to user 'shipit' using sudo, please check the sudoers file" 1>&2; false; fi
DEBUG[0afbde0c] Finished in 0.182 seconds with exit status 0 (successful).
INFO[a69a82f5] Running bundle exec whenever --update-crontab on shipit2.chi.shopify.com
DEBUG[a69a82f5] Command: cd /u/apps/shipit/current && ( RAILS_ENV=production sudo -u shipit RAILS_ENV=production -- sh -c 'bundle exec whenever --update-crontab' )
DEBUG[a69a82f5]     [write] crontab file updated
INFO[a69a82f5] Finished in 0.576 seconds with exit status 0 (successful).
```
