### PR TITLE
Locking a stack prevent continious deployment

### DIFF
--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -95,7 +95,7 @@ class Commit < ActiveRecord::Base
 
   def schedule_continuous_delivery
     return unless state == 'success' && stack.continuous_deployment?
-    return if deploy_in_progress? || newer_commit_deployed?
+    return if stack_locked? || deploy_in_progress? || newer_commit_deployed?
     stack.trigger_deploy(self, committer)
   end
 
@@ -108,6 +108,8 @@ class Commit < ActiveRecord::Base
     non_success_statuses = statuses.reject(&:success?)
     non_success_statuses.reject(&:pending?).first || non_success_statuses.first || UnknownStatus.new(self)
   end
+
+  delegate :locked?, to: :stack, prefix: true
 
   def deploy_in_progress?
     stack.deploying?

--- a/test/models/commits_test.rb
+++ b/test/models/commits_test.rb
@@ -60,7 +60,16 @@ class CommitsTest < ActiveSupport::TestCase
     @stack.trigger_deploy(@commit, @commit.committer)
 
     assert_no_difference "Deploy.count" do
-      @commit.statuses.create!(state: 'success')
+      @commit.statuses.create!(state: 'success', context: 'ci/travis')
+    end
+  end
+
+  test "updating state to success skips deploy when stack has CD but the stack is locked" do
+    @stack.deploys.destroy_all
+    @stack.reload.update!(continuous_deployment: true, lock_reason: "Maintenance ongoing")
+
+    assert_no_difference "Deploy.count" do
+      @commit.statuses.create!(state: 'success', context: 'ci/travis')
     end
   end
 


### PR DESCRIPTION
Fixes: https://github.com/Shopify/shipit2/issues/279

@airhorns for review.
