### PR TITLE
Highlight the deploys rollbacked by each button on mouseover

### DIFF
--- a/app/assets/javascripts/application/stacks.js.coffee
+++ b/app/assets/javascripts/application/stacks.js.coffee
@@ -1,3 +1,21 @@
+class RollbackPreview
+  @for: (element) ->
+    $element = $(element)
+    unless instance = $element.data('rollback-preview')
+      instance = new RollbackPreview($element)
+      $element.data('rollback-preview', instance)
+    instance
+
+  constructor: (@$button) ->
+    $rollbackable = @$button.closest('[data-rollbackable]')
+    @$scope = $rollbackable.add($rollbackable.prevAll('[data-rollbackable]'))
+
+  toggle: (show) ->
+    @$scope.toggleClass('rolling-back', show)
+
+$(document).on 'mouseenter mouseleave', '.rollback-action', (event) ->
+  RollbackPreview.for(this).toggle(event.type == 'mouseenter')
+
 jQuery ($) ->
   displayConfigureCiMessage = ->
     commits = $('.commit')

--- a/app/assets/stylesheets/_base/_base.scss
+++ b/app/assets/stylesheets/_base/_base.scss
@@ -9,6 +9,7 @@ $blue: #248af2;
 $green: #67ca8b;
 $red: #f39494;
 $bright-red: #f37272;
+$light-red: lighten($bright-red, 10%);
 $slate: #2e343a;
 
 @mixin clearfix {

--- a/app/assets/stylesheets/_pages/_deploy.scss
+++ b/app/assets/stylesheets/_pages/_deploy.scss
@@ -1,3 +1,7 @@
+.rolling-back {
+  background-color: $light-red;
+}
+
 .deploy-abort {
   display: none;
   &[data-deploy-status="running"] { display: block; }

--- a/app/views/deploys/_deploy.html.erb
+++ b/app/views/deploys/_deploy.html.erb
@@ -1,4 +1,4 @@
-<li class="deploy" id="deploy-<%= deploy.id %>" data-deploy-status="<%= deploy.status %>">
+<li class="deploy" id="deploy-<%= deploy.id %>" data-deploy-status="<%= deploy.status %>" data-rollbackable>
   <div class="status <%= deploy.status %>" data-tooltip="<%= deploy.status.capitalize %>">
     <%= link_to stack_deploy_path(@stack, deploy) do %>
       <i><%= deploy.status %></i>
@@ -35,7 +35,7 @@
     <% if deploy.stack.deploying? %>
       <%= link_to 'Deploy in progress...', '#', class: 'btn disabled deploy-action' %>
     <% else %>
-      <%= link_to 'Rollback', rollback_stack_deploy_path(@stack, deploy), class: 'btn delete deploy-action' %>
+      <%= link_to "Rollback to #{deploy.since_commit.short_sha}", rollback_stack_deploy_path(@stack, deploy), class: 'btn delete deploy-action rollback-action' %>
     <% end %>
   <% end %>
 </li>


### PR DESCRIPTION
## Problem

Which rollback button rollback what is confusing. People either understand it as "rollback **that deploy**" or "rollback **until that deploy**".

This question is often asked over ~~flowdock~~ slack, and often because there is an urgent need to rollback.

Example:

![capture d ecran 2014-12-16 a 19 59 25](https://cloud.githubusercontent.com/assets/44640/5464996/46023130-855e-11e4-8c4c-00e133ee14c8.png)
## Solution

When you put your mouse over the rollback button it highlight in red the deploys that will be rollbacked.

![capture d ecran 2014-12-16 a 19 54 12](https://cloud.githubusercontent.com/assets/44640/5465014/6c9b3c24-855e-11e4-910c-ae6b9ce98337.png)

@celsodantas since you were confused by it today, do you think this UI change would have helped?
## Review

I think it is time for shipit to end up in @Shopify/dev-tools territory, don't hesitate to ask question if you need a walkthrough. 

cc @gmalette @davidcornu 
