### PR TITLE
add New Relic chart to pre-deploy screen

### DIFF
--- a/app/views/deploys/_newrelic.html.erb
+++ b/app/views/deploys/_newrelic.html.erb
@@ -1,0 +1,8 @@
+<% if @stack.repo_name == 'shopify' %>
+  <section>
+    <header class="section-header">
+      <h2>New Relic</h2>
+    </header>
+    <%= image_tag "https://shopify-snap.herokuapp.com/image.png?width=600&height=300&url=#{URI.escape('https://rpm.newrelic.com/public/charts/7JGEJ0rfzWw')}", alt: 'New Relic image' %>
+  </section>
+<% end %>

--- a/app/views/deploys/new.html.erb
+++ b/app/views/deploys/new.html.erb
@@ -23,6 +23,8 @@
     </section>
   <% end %>
 
+  <%= render 'deploys/newrelic' %>
+
   <%= render_checklist @stack %>
 
   <section class="submit-section">


### PR DESCRIPTION
Every deploy starts with checking New Relic in chat, so it might be nice to see the chart right inline with the deploy checklist.

This is the simplest implementation, and only works for the core app. It could be expanded to work with any of the apps we have New Relic setup for.

![shipit 2014-12-19 14-47-26](https://cloud.githubusercontent.com/assets/118850/5510240/1833711a-878e-11e4-86c3-9b6bd0e4782d.png)

r: @fw42 @wvanbergen @Thibaut @arthurnn @byroot 
