### PR TITLE
Allow to include images or iframes on the deploy page for monitoring

### DIFF
--- a/app/helpers/deploys_helper.rb
+++ b/app/helpers/deploys_helper.rb
@@ -3,4 +3,19 @@ module DeploysHelper
     return '' unless stack.checklist?
     render 'deploys/checklist', stack: stack
   end
+
+  def render_monitoring(stack)
+    return '' unless stack.monitoring?
+    render 'deploys/monitoring', stack: stack
+  end
+
+  def render_monitoring_panel(panel_spec)
+    if url = panel_spec['image']
+      image_tag(url, panel_spec.slice('height', 'width', 'alt'))
+    elsif url = panel_spec['iframe']
+      content_tag(:iframe, panel_spec.slice('height', 'width').merge('src' => url))
+    else
+      content_tag(:span, "#{panel_spec.inspect} is not a valid monitoring panel spec")
+    end
+  end
 end

--- a/app/models/stack.rb
+++ b/app/models/stack.rb
@@ -173,6 +173,15 @@ class Stack < ActiveRecord::Base
     ).first!
   end
 
+  def monitoring?
+    monitoring.present?
+  end
+
+  def monitoring
+    return [] unless cached_deploy_spec
+    cached_deploy_spec.review_monitoring.select(&:present?)
+  end
+
   def checklist?
     checklist.present?
   end

--- a/app/views/deploys/_monitoring.html.erb
+++ b/app/views/deploys/_monitoring.html.erb
@@ -1,0 +1,13 @@
+<section>
+  <header class="section-header">
+    <h2>Monitoring</h2>
+  </header>
+
+  <div class="monitoring">
+    <%- stack.monitoring.each do |panel_spec| -%>
+      <div class="monitoring-panel">
+        <%= render_monitoring_panel panel_spec %>
+      </div>
+    <%- end -%>
+  </div>
+</section>

--- a/app/views/deploys/new.html.erb
+++ b/app/views/deploys/new.html.erb
@@ -23,6 +23,8 @@
     </section>
   <% end %>
 
+  <%= render_monitoring @stack %>
+
   <%= render_checklist @stack %>
 
   <section class="submit-section">

--- a/app/views/deploys/rollback.html.erb
+++ b/app/views/deploys/rollback.html.erb
@@ -19,6 +19,8 @@
     <%= render 'deploys/summary', commits: @rollback.commits %>
   </section>
 
+  <%= render_monitoring @stack %>
+
   <%= render_checklist @stack %>
 
   <section class="submit-section">

--- a/lib/deploy_spec.rb
+++ b/lib/deploy_spec.rb
@@ -87,6 +87,10 @@ class DeploySpec
     config('review', 'checklist') || discover_review_checklist || []
   end
 
+  def review_monitoring
+    config('review', 'monitoring') || []
+  end
+
   private
 
   def coerce_task_definition(config)

--- a/test/fixtures/stacks.yml
+++ b/test/fixtures/stacks.yml
@@ -8,7 +8,12 @@ shipit:
   cached_deploy_spec: >
     {
       "machine": {"environment": {}},
-      "review": {"checklist": ["foo", "bar", "baz"]},
+      "review": {
+        "checklist": ["foo", "bar", "baz"],
+        "monitoring": [
+          {"image": "https://example.com/monitor.png", "width": 200, "height": 300}
+        ]
+      },
       "dependencies": {"override": []},
       "deploy": {"override": null},
       "rollback": {"override": ["echo 'Rollback!'"]},

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -271,4 +271,13 @@ class StacksTest < ActiveSupport::TestCase
     Resque.expects(:enqueue).with(UndeployedCommitsWebhookJob, stack_id: @stack.id).never
     Stack.send_undeployed_commits_reminders
   end
+
+  test "#monitoring is empty if cached_deploy_spec is blank" do
+    @stack.cached_deploy_spec = nil
+    assert_equal [], @stack.monitoring
+  end
+
+  test "#monitoring returns deploy_spec's content" do
+    assert_equal [{'image' => 'https://example.com/monitor.png', 'width' => 200, 'height' => 300}], @stack.monitoring
+  end
 end

--- a/test/unit/deploy_spec_test.rb
+++ b/test/unit/deploy_spec_test.rb
@@ -209,4 +209,19 @@ class DeploySpecTest < ActiveSupport::TestCase
   test "#review_checklist returns an empty array if the section is missing" do
     assert_equal [], @spec.review_checklist
   end
+
+  test "#review_monitoring returns an array" do
+    @spec.expects(:load_config).returns('review' => {'checklist' => [
+      {'image' => 'http://example.com/foo.png', 'width' => 200, 'height' => 400},
+      {'iframe' => 'http://example.com/', 'width' => 200, 'height' => 400},
+    ]})
+    assert_equal [
+      {'image' => 'http://example.com/foo.png', 'width' => 200, 'height' => 400},
+      {'iframe' => 'http://example.com/', 'width' => 200, 'height' => 400},
+    ], @spec.review_checklist
+  end
+
+  test "#review_monitoring returns an empty array if the section is missing" do
+    assert_equal [], @spec.review_monitoring
+  end
 end


### PR DESCRIPTION
Ref: https://github.com/Shopify/shipit2/pull/286

![capture d ecran 2015-01-08 a 16 08 20](https://cloud.githubusercontent.com/assets/44640/5670727/9999232c-9750-11e4-90c7-f539c479eb48.png)

See https://github.com/Shopify/shopify/blob/d5d3f04ab088f4022f98a1858cbca14927961478/shipit.yml#L15-L16 for usage example.

@dwradcliffe @gmalette @Shopify/dev-tools for review.
