### PR TITLE
Parse both deployify and sv-rollout output

### DIFF
--- a/app/assets/javascripts/plugins/borg.js.coffee
+++ b/app/assets/javascripts/plugins/borg.js.coffee
@@ -114,15 +114,17 @@ class ContainersRestartWidget extends RestartTaskWidget
 
   parse: (parser) ->
     parser.eachMessage (log) =>
-      if match = log.output.match(/\[(\d+)\/(\d+)\] Restarting/)
+      if match = log.output.match(/\[(\d+)\/(\d+)\].* restarting/i)
         @getTask(log.host).update
           numPending: match[1]
           numLights: match[2]
-      else if match = log.output.match(/\[(\d+)\/(\d+)\] Successfully Restarted/)
+      else if match = log.output.match(/\[(\d+)\/(\d+)\].* successfully restarted/i)
         @getTask(log.host).update
           numDone: match[1]
           numLights: match[2]
-      else if match = log.output.match(/\[(\d+)\/(\d+)\] Unable to restart/)
+      else if match = log.output.match(/\[(\d+)\/(\d+)\].* did not restart in time/i)
+        @getTask(log.host).update(numPending: match[1], numLights: match[2]).fail()
+      else if match = log.output.match(/\[(\d+)\/(\d+)\].* (failed to restart|unable to restart)/i)
         @getTask(log.host).update(numPending: match[1], numLights: match[2]).fail()
     null
 


### PR DESCRIPTION
@byroot @Sirupsen 

I merged cap changes to deploy shopify via sv-rollout, but the output format is different. This changes shipit to understand both output formats. 

Example of new output:

```
*** [out :: sb96.chi.shopify.com] [chi]2015/01/15 19:20:09 [3/5] (borg-shopify-unicorn-3) successfully restarted
*** [out :: sb96.chi.shopify.com] 2015/01/15 19:20:09 [4/5] (borg-shopify-unicorn-4) restarting
*** [out :: sb76.chi.shopify.com] [chi]2015/01/15 19:20:09 [3/5] (borg-shopify-unicorn-3) successfully restarted
*** [out :: sb76.chi.shopify.com] 2015/01/15 19:20:09 [4/5] (borg-shopify-unicorn-4) restarting
*** [out :: sb9.chi.shopify.com] [chi]2015/01/15 19:20:09 [3/5] (borg-shopify-unicorn-3) successfully restarted
*** [out :: sb9.chi.shopify.com] 2015/01/15 19:20:09 [4/5] (borg-shopify-unicorn-4) restarting
```
