### PR TITLE
Make deploy bot more aggressive

### DIFF
--- a/app/models/stack.rb
+++ b/app/models/stack.rb
@@ -202,7 +202,7 @@ class Stack < ActiveRecord::Base
     self.class.where(id: id).update_all("undeployed_commits_count = (#{undeployed_commits.to_sql})")
   end
 
-  def old_undeployed_commits(long_time_ago = 30.minutes.ago)
+  def old_undeployed_commits(long_time_ago = 20.minutes.ago)
     undeployed_commits? ? commits.newer_than(last_deployed_commit).where("created_at < ?", long_time_ago) : commits.none
   end
 

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -2,7 +2,7 @@ every 1.minute do
   rake 'cron:minutely'
 end
 
-every 1.hour do
+every 30.minutes do
   rake 'cron:send_undeployed_commits_reminders'
 end
 


### PR DESCRIPTION
Based on ~~two~~ three considerations:
- CI is ~10 minutes now, with many fewer leaky failures, so deploys can happen
  much more reliably
- no more flowdock notification when CI passes, so people have been forgetting
  to deploy more
- fewer false positive alerts as the notification is now skipped when there is a deploy in-progress

@byroot @ibawt @burke I'm happy to negotiate times other than the ones I chose for this PR, but I do feel the current times are too long.
