### PR TITLE
Put the first stone of the API

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -61,3 +61,7 @@ Style/TrailingComma:
 
 Style/ClassAndModuleChildren:
   Enabled: false
+
+Style/PredicateName:
+  Exclude:
+    - app/serializers/**/*

--- a/Gemfile
+++ b/Gemfile
@@ -27,6 +27,7 @@ gem 'ansi_stream', '~> 0.0.4'
 gem 'heroku'
 gem 'faraday'
 gem 'validate_url'
+gem 'active_model_serializers'
 
 group :development do
   gem 'quiet_assets'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,6 +20,8 @@ GEM
       erubis (~> 2.7.0)
       rails-dom-testing (~> 1.0, >= 1.0.5)
       rails-html-sanitizer (~> 1.0, >= 1.0.1)
+    active_model_serializers (0.9.3)
+      activemodel (>= 3.2)
     activejob (4.2.0)
       activesupport (= 4.2.0)
       globalid (>= 0.3.0)
@@ -306,6 +308,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
+  active_model_serializers
   airbrake (~> 3.1.5)
   ansi_stream (~> 0.0.4)
   byebug

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -1,0 +1,20 @@
+module Api
+  class BaseController < ActionController::Base
+    before_action :authenticate_api_client
+
+    def index
+      render json: {stacks_url: api_stacks_url}
+    end
+
+    private
+
+    def authenticate_api_client
+      @current_api_client = authenticate_with_http_basic do |token|
+        ApiClient.authenticate(token)
+      end
+      return if @current_api_client
+      headers['WWW-Authenticate'] = 'Basic realm="Authentication token"'
+      render json: {message: 'Bad credentials'}, status: :unauthorized
+    end
+  end
+end

--- a/app/controllers/api/stacks_controller.rb
+++ b/app/controllers/api/stacks_controller.rb
@@ -1,0 +1,7 @@
+module Api
+  class StacksController < BaseController
+    def index
+      render json: Stack.all
+    end
+  end
+end

--- a/app/models/api_client.rb
+++ b/app/models/api_client.rb
@@ -1,0 +1,22 @@
+class ApiClient < ActiveRecord::Base
+  belongs_to :creator, class_name: 'User'
+
+  validates :creator, presence: true
+
+  serialize :permissions, Array
+
+  class << self
+    def authenticate(token)
+      find_by_id(message_verifier.verify(token).to_i)
+    rescue SimpleMessageVerifier::InvalidSignature
+    end
+
+    def message_verifier
+      @message_verifier ||= SimpleMessageVerifier.new(Shipit.api_clients_secret)
+    end
+  end
+
+  def authentication_token
+    self.class.message_verifier.generate(id)
+  end
+end

--- a/app/serializers/concerns/conditional_attributes.rb
+++ b/app/serializers/concerns/conditional_attributes.rb
@@ -1,0 +1,20 @@
+module ConditionalAttributes
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def inclusion_method_for(attribute)
+      @inclusion_cache ||= {}
+      @inclusion_cache.fetch(attribute) do
+        method = "include_#{attribute}?"
+        method_defined?(method) && method
+      end
+    end
+  end
+
+  def filter(*)
+    super.reject do |attribute|
+      method = self.class.inclusion_method_for(attribute)
+      method && !send(method)
+    end
+  end
+end

--- a/app/serializers/stack_serializer.rb
+++ b/app/serializers/stack_serializer.rb
@@ -1,0 +1,21 @@
+class StackSerializer < ActiveModel::Serializer
+  include ConditionalAttributes
+
+  attributes :id, :repo_owner, :repo_name, :environment, :html_url, :url, :is_locked, :lock_reason
+
+  def url
+    api_stacks_url(object)
+  end
+
+  def html_url
+    stacks_url(object)
+  end
+
+  def is_locked
+    object.locked?
+  end
+
+  def include_lock_reason?
+    object.locked?
+  end
+end

--- a/config/application.rb
+++ b/config/application.rb
@@ -21,7 +21,11 @@ module Shipit
     # config.i18n.default_locale = :de
 
     # Autoload lib/
-    config.autoload_paths += Dir["#{config.root}/lib", "#{config.root}/lib/**/"]
+    config.autoload_paths += Dir[*%W(
+      #{config.root}/lib
+      #{config.root}/lib/**/
+      #{config.root}/app/serializers/**/
+    )]
 
     # Compile the correct assets
     config.assets.precompile += %w(master.css)
@@ -32,5 +36,8 @@ module Shipit
     config.active_record.raise_in_transactional_callbacks = true
 
     Rails.application.routes.default_url_options[:host] = Rails.application.secrets.host
+
+    ActiveModel::Serializer._root = false
+    ActiveModel::ArraySerializer._root = false
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,4 +56,10 @@ Shipit::Application.routes.draw do
       end
     end
   end
+
+  # API
+  namespace :api do
+    root to: 'base#index'
+    resources :stacks
+  end
 end

--- a/db/migrate/20150212155406_create_api_clients.rb
+++ b/db/migrate/20150212155406_create_api_clients.rb
@@ -1,0 +1,10 @@
+class CreateApiClients < ActiveRecord::Migration
+  def change
+    create_table :api_clients do |t|
+      t.text :permissions
+      t.references :creator, index: true
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,16 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150201214637) do
+ActiveRecord::Schema.define(version: 20150212155406) do
+
+  create_table "api_clients", force: :cascade do |t|
+    t.text     "permissions", limit: 65535
+    t.integer  "creator_id",  limit: 4
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
+  end
+
+  add_index "api_clients", ["creator_id"], name: "index_api_clients_on_creator_id", using: :btree
 
   create_table "commits", force: :cascade do |t|
     t.integer  "stack_id",     limit: 4,                     null: false

--- a/lib/shipit/config.rb
+++ b/lib/shipit/config.rb
@@ -4,6 +4,10 @@ module Shipit::Config
     @github_api ||= Octokit::Client.new(credentials.symbolize_keys)
   end
 
+  def api_clients_secret
+    Rails.application.secrets.api_clients_secret || ''
+  end
+
   delegate :authentication, :github, :host, to: :secrets
 
   def github_required?

--- a/lib/simple_message_verifier.rb
+++ b/lib/simple_message_verifier.rb
@@ -1,0 +1,27 @@
+class SimpleMessageVerifier < ActiveSupport::MessageVerifier
+  def initialize(secret, options = {})
+    options[:serializer] ||= ToS
+    secret += Rails.application.secrets.secret_key_base
+    super(secret, options)
+  end
+
+  private
+
+  def encode(data)
+    data.to_s
+  end
+
+  def decode(data)
+    data
+  end
+
+  module ToS
+    def self.dump(object)
+      object.to_s
+    end
+
+    def self.load(payload)
+      payload
+    end
+  end
+end

--- a/test/controllers/api/base_controller_test.rb
+++ b/test/controllers/api/base_controller_test.rb
@@ -1,0 +1,30 @@
+require 'test_helper'
+
+class Api::BaseControllerTest < ActionController::TestCase
+  setup do
+    @client = api_clients(:spy)
+  end
+
+  test "authentication is required" do
+    get :index
+    assert_response :unauthorized
+    assert_equal({message: 'Bad credentials'}.to_json, response.body)
+  end
+
+  test "with proper credentials the request is processed" do
+    authenticate!
+    assert_response :ok
+  end
+
+  test "#index respond with a list of endpoints" do
+    authenticate!
+    get :index, format: :json
+    assert_equal({stacks_url: api_stacks_url}.to_json, response.body)
+  end
+
+  private
+
+  def authenticate!
+    request.headers['Authorization'] = "Basic #{Base64.encode64(@client.authentication_token)}"
+  end
+end

--- a/test/fixtures/api_clients.yml
+++ b/test/fixtures/api_clients.yml
@@ -1,0 +1,2 @@
+spy:
+  creator: walrus

--- a/test/models/api_client_test.rb
+++ b/test/models/api_client_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+class ApiClientTest < ActiveSupport::TestCase
+  setup do
+    @client = api_clients(:spy)
+  end
+
+  test "#authentication_token is the signed id" do
+    assert_match(/^\d+--[\da-f]{40}$/, @client.authentication_token)
+  end
+
+  test "#authentication_token casted as integer is the client id" do
+    assert_equal @client.id, @client.authentication_token.to_i
+  end
+
+  test ".authenticate returns nil if the signature is invalid" do
+    assert_nil ApiClient.authenticate("#{@client.id}--foobar")
+  end
+
+  test ".authenticate returns nil if the api client do not exists" do
+    assert_nil ApiClient.authenticate(ApiClient.new(id: 42).authentication_token)
+  end
+
+  test ".authenticate returns the matching ApiClient record if the token is valid" do
+    assert_equal @client, ApiClient.authenticate(@client.authentication_token)
+  end
+end


### PR DESCRIPTION
@EiNSTeiN- I'd like your thoughts on the API Authentication.
- It use basic auth with the password being empty and the login being the api client token.
- The token is just the `ApiClient` id, but signed with `MessageVerifier`
- All the api tokens can be revoked by simply changing a key in the settings
- An individual client can be revoked by deleting the record in the DB.

Do that sounds good to you or do you have any concern?
