### PR TITLE
Trigger deploy api

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,6 +30,7 @@ gem 'faraday'
 gem 'faraday-http-cache'
 gem 'validate_url'
 gem 'active_model_serializers'
+gem 'explicit-parameters'
 
 group :development do
   gem 'quiet_assets'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -47,6 +47,10 @@ GEM
     ast (2.0.0)
     astrolabe (1.3.0)
       parser (>= 2.2.0.pre.3, < 3.0)
+    axiom-types (0.1.1)
+      descendants_tracker (~> 0.0.4)
+      ice_nine (~> 0.11.0)
+      thread_safe (~> 0.3, >= 0.3.1)
     bugsnag (2.8.1)
       multi_json (~> 1.0)
     builder (3.2.2)
@@ -66,6 +70,8 @@ GEM
       capistrano-bundler (~> 1.1)
     chronic (0.10.2)
     coderay (1.1.0)
+    coercible (1.0.0)
+      descendants_tracker (~> 0.0.1)
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -77,15 +83,22 @@ GEM
     columnize (0.9.0)
     daemons (1.1.9)
     debugger-linecache (1.2.0)
+    descendants_tracker (0.0.4)
+      thread_safe (~> 0.3, >= 0.3.1)
     docile (1.1.5)
     dotenv (1.0.2)
     em-hiredis (0.3.0)
       eventmachine (~> 1.0)
       hiredis (~> 0.5.0)
+    equalizer (0.0.9)
     erubis (2.7.0)
     eventmachine (1.0.7)
     excon (0.44.4)
     execjs (2.4.0)
+    explicit-parameters (0.0.2)
+      actionpack (~> 4.0)
+      activemodel (~> 4.0)
+      virtus (~> 1.0)
     faker (1.4.3)
       i18n (~> 0.5)
     faraday (0.9.1)
@@ -110,6 +123,7 @@ GEM
     hike (1.2.3)
     hiredis (0.5.2)
     i18n (0.7.0)
+    ice_nine (0.11.1)
     jquery-rails (4.0.3)
       rails-dom-testing (~> 1.0)
       railties (>= 4.2.0)
@@ -304,6 +318,11 @@ GEM
       addressable
     vegas (0.1.11)
       rack (>= 1.0.0)
+    virtus (1.0.4)
+      axiom-types (~> 0.1)
+      coercible (~> 1.0)
+      descendants_tracker (~> 0.0, >= 0.0.3)
+      equalizer (~> 0.0, >= 0.0.9)
     whenever (0.9.4)
       chronic (>= 0.6.3)
 
@@ -320,6 +339,7 @@ DEPENDENCIES
   capistrano-bundler
   capistrano-rails
   coffee-rails
+  explicit-parameters
   faker
   faraday
   faraday-http-cache

--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -19,5 +19,16 @@ module Api
       headers['WWW-Authenticate'] = 'Basic realm="Authentication token"'
       render json: {message: 'Bad credentials'}, status: :unauthorized
     end
+
+    attr_reader :current_api_client
+
+    def current_user
+      @current_user ||= identify_user || AnonymousUser.new
+    end
+
+    def identify_user
+      user_login = request.headers['X-Shipit-User'].presence
+      User.find_by(login: user_login) if user_login
+    end
   end
 end

--- a/app/controllers/api/deploys_controller.rb
+++ b/app/controllers/api/deploys_controller.rb
@@ -1,0 +1,18 @@
+module Api
+  class DeploysController < BaseController
+    params do
+      requires :sha, String
+      validates :sha, length: {in: 6..40}
+    end
+    def create
+      commit = stack.commits.by_sha(params.sha) || param_error!(:sha, 'Unknown revision')
+      render json: stack.trigger_deploy(commit, current_user), status: :accepted
+    end
+
+    private
+
+    def stack
+      @stack ||= Stack.from_param!(params[:stack_id])
+    end
+  end
+end

--- a/app/controllers/api/stacks_controller.rb
+++ b/app/controllers/api/stacks_controller.rb
@@ -5,7 +5,13 @@ module Api
     end
 
     def show
-      render json: Stack.from_param!(params[:id])
+      render json: stack
+    end
+
+    private
+
+    def stack
+      @stack ||= Stack.from_param!(params[:id])
     end
   end
 end

--- a/app/models/api_client.rb
+++ b/app/models/api_client.rb
@@ -1,7 +1,7 @@
 class ApiClient < ActiveRecord::Base
   belongs_to :creator, class_name: 'User'
 
-  validates :creator, presence: true
+  validates :creator, :name, presence: true
 
   serialize :permissions, Array
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,10 +64,12 @@ Shipit::Application.routes.draw do
     scope '/stacks/*id', id: %r{[^/]+/[^/]+/[^/]+}, as: :stack do
       get '/' => 'stacks#show'
     end
+
     scope '/stacks/*stack_id', stack_id: %r{[^/]+/[^/]+/[^/]+}, as: :stack do
       resources :tasks, only: %i(index show) do
         resource :output, only: :show
       end
+      resources :deploys, only: %i(create)
     end
   end
 end

--- a/db/migrate/20150317172421_index_users_by_login.rb
+++ b/db/migrate/20150317172421_index_users_by_login.rb
@@ -1,0 +1,5 @@
+class IndexUsersByLogin < ActiveRecord::Migration
+  def change
+    add_index :users, :login
+  end
+end

--- a/db/migrate/20150317173155_add_name_to_api_clients.rb
+++ b/db/migrate/20150317173155_add_name_to_api_clients.rb
@@ -1,0 +1,5 @@
+class AddNameToApiClients < ActiveRecord::Migration
+  def change
+    add_column :api_clients, :name, :string, default: ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,13 +11,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150212155406) do
+ActiveRecord::Schema.define(version: 20150317173155) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text     "permissions", limit: 65535
     t.integer  "creator_id",  limit: 4
-    t.datetime "created_at",                null: false
-    t.datetime "updated_at",                null: false
+    t.datetime "created_at",                             null: false
+    t.datetime "updated_at",                             null: false
+    t.string   "name",        limit: 255,   default: ""
   end
 
   add_index "api_clients", ["creator_id"], name: "index_api_clients_on_creator_id", using: :btree
@@ -114,6 +115,8 @@ ActiveRecord::Schema.define(version: 20150212155406) do
     t.datetime "updated_at"
     t.string   "avatar_url", limit: 255
   end
+
+  add_index "users", ["login"], name: "index_users_on_login", using: :btree
 
   create_table "webhooks", force: :cascade do |t|
     t.integer  "stack_id",   limit: 4,   null: false

--- a/test/controllers/api/deploys_controller_test.rb
+++ b/test/controllers/api/deploys_controller_test.rb
@@ -1,0 +1,37 @@
+require 'test_helper'
+
+class Api::DeploysControllerTest < ActionController::TestCase
+  setup do
+    authenticate!
+    @user = users(:walrus)
+    @stack = stacks(:shipit)
+    @commit = commits(:fifth)
+  end
+
+  test "#create triggers a new deploy for the stack" do
+    assert_difference -> { @stack.deploys.count }, +1 do
+      post :create, stack_id: @stack.to_param, sha: @commit.sha
+    end
+    assert_response :accepted
+    assert_json 'status', 'pending'
+  end
+
+  test "#create use the claimed user as author" do
+    request.headers['X-Shipit-User'] = @user.login
+    post :create, stack_id: @stack.to_param, sha: @commit.sha
+    deploy = Deploy.last
+    deploy.user == @user
+  end
+
+  test "#create renders a 422 if the sha isn't found" do
+    post :create, stack_id: @stack.to_param, sha: '123443543545'
+    assert_response :unprocessable_entity
+    assert_json 'errors', 'sha' => ['Unknown revision']
+  end
+
+  test "#create renders a 422 if the sha format is invalid" do
+    post :create, stack_id: @stack.to_param, sha: '1'
+    assert_response :unprocessable_entity
+    assert_json 'errors', 'sha' => ['is too short (minimum is 6 characters)']
+  end
+end

--- a/test/controllers/api/stacks_controller_test.rb
+++ b/test/controllers/api/stacks_controller_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 class Api::StacksControllerTest < ActionController::TestCase
   setup do
     authenticate!
+    @stack = stacks(:shipit)
   end
 
   test "#index returns a list of stacks" do


### PR DESCRIPTION
This add a `POST /api/:stack_id/deploys` endpoint that allows to programmatically trigger deploys.

The API trust the API client to provide the author thought the `X-Shipit-User` header.
