### PR TITLE
Add an lock create api which responds with an error if already locked.

### DIFF
--- a/app/controllers/api/locks_controller.rb
+++ b/app/controllers/api/locks_controller.rb
@@ -5,6 +5,18 @@ module Api
     params do
       requires :reason, String, presence: true
     end
+    def create
+      if @stack.locked?
+        render json: {message: 'Already locked'}, status: :conflict
+      else
+        @stack.update(lock_reason: params.reason)
+        render_resource @stack
+      end
+    end
+
+    params do
+      requires :reason, String, presence: true
+    end
     def update
       @stack.update(lock_reason: params.reason)
       render_resource @stack

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,7 +69,7 @@ Shipit::Application.routes.draw do
     end
 
     scope '/stacks/*stack_id', stack_id: stack_id_format, as: :stack do
-      resource :lock, only: %i(update destroy)
+      resource :lock, only: %i(create update destroy)
       resources :tasks, only: %i(index show) do
         resource :output, only: :show
       end

--- a/test/controllers/api/locks_controller_test.rb
+++ b/test/controllers/api/locks_controller_test.rb
@@ -6,6 +6,19 @@ class Api::LocksControllerTest < ActionController::TestCase
     @stack = stacks(:shipit)
   end
 
+  test "#create sets a lock" do
+    post :create, stack_id: @stack.to_param, reason: 'Just for fun!'
+    assert_response :ok
+    assert_json 'is_locked', true
+    assert_json 'lock_reason', 'Just for fun!'
+  end
+
+  test "#create fails if already locked" do
+    @stack.update!(lock_reason: "Don't forget me")
+    post :create, stack_id: @stack.to_param, reason: 'Just for fun!'
+    assert_response :conflict
+  end
+
   test "#update sets a lock" do
     put :update, stack_id: @stack.to_param, reason: 'Just for fun!'
     assert_response :ok


### PR DESCRIPTION
@byroot for review
## Problem

We want to be able to take a lock (e.g. for genghis) without accidentally replacing another lock.
## Solution

Add a lock create api which responds with an error if the stack is already locked.
