### PR TITLE
Allow to restrict API clients to a single stack

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -32,5 +32,13 @@ module Api
       user_login = request.headers['X-Shipit-User'].presence
       User.find_by(login: user_login) if user_login
     end
+
+    def stacks
+      @stacks ||= current_api_client.stack_id? ? Stack.where(id: current_api_client.stack_id) : Stack.all
+    end
+
+    def stack
+      @stack ||= stacks.from_param!(params[:stack_id])
+    end
   end
 end

--- a/app/controllers/api/deploys_controller.rb
+++ b/app/controllers/api/deploys_controller.rb
@@ -9,11 +9,5 @@ module Api
       param_error!(:force, "Can't deploy a locked stack") if !params.force && stack.locked?
       render_resource stack.trigger_deploy(commit, current_user), status: :accepted
     end
-
-    private
-
-    def stack
-      @stack ||= Stack.from_param!(params[:stack_id])
-    end
   end
 end

--- a/app/controllers/api/hooks_controller.rb
+++ b/app/controllers/api/hooks_controller.rb
@@ -44,9 +44,5 @@ module Api
     def stack_id
       stack.id if params[:stack_id].present?
     end
-
-    def stack
-      @stack ||= Stack.from_param!(params[:stack_id])
-    end
   end
 end

--- a/app/controllers/api/locks_controller.rb
+++ b/app/controllers/api/locks_controller.rb
@@ -1,16 +1,14 @@
 module Api
   class LocksController < BaseController
-    before_action :load_stack
-
     params do
       requires :reason, String, presence: true
     end
     def create
-      if @stack.locked?
+      if stack.locked?
         render json: {message: 'Already locked'}, status: :conflict
       else
-        @stack.update(lock_reason: params.reason)
-        render_resource @stack
+        stack.update(lock_reason: params.reason)
+        render_resource stack
       end
     end
 
@@ -18,19 +16,13 @@ module Api
       requires :reason, String, presence: true
     end
     def update
-      @stack.update(lock_reason: params.reason)
-      render_resource @stack
+      stack.update(lock_reason: params.reason)
+      render_resource stack
     end
 
     def destroy
-      @stack.update(lock_reason: nil)
-      render_resource @stack
-    end
-
-    private
-
-    def load_stack
-      @stack = Stack.from_param!(params[:stack_id])
+      stack.update(lock_reason: nil)
+      render_resource stack
     end
   end
 end

--- a/app/controllers/api/outputs_controller.rb
+++ b/app/controllers/api/outputs_controller.rb
@@ -9,9 +9,5 @@ module Api
     def task
       @task ||= stack.tasks.find(params[:task_id])
     end
-
-    def stack
-      @stack ||= Stack.from_param!(params[:stack_id])
-    end
   end
 end

--- a/app/controllers/api/stacks_controller.rb
+++ b/app/controllers/api/stacks_controller.rb
@@ -1,17 +1,11 @@
 module Api
   class StacksController < BaseController
     def index
-      render_resources Stack.all
+      render_resources stacks
     end
 
     def show
       render_resource stack
-    end
-
-    private
-
-    def stack
-      @stack ||= Stack.from_param!(params[:id])
     end
   end
 end

--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -1,19 +1,11 @@
 module Api
   class TasksController < BaseController
-    before_action :load_stack
-
     def index
-      render_resources @stack.tasks
+      render_resources stack.tasks
     end
 
     def show
-      render_resource @stack.tasks.find(params[:id])
-    end
-
-    private
-
-    def load_stack
-      @stack = Stack.from_param!(params[:stack_id])
+      render_resource stack.tasks.find(params[:id])
     end
   end
 end

--- a/app/models/api_client.rb
+++ b/app/models/api_client.rb
@@ -1,5 +1,6 @@
 class ApiClient < ActiveRecord::Base
   belongs_to :creator, class_name: 'User'
+  belongs_to :stack
 
   validates :creator, :name, presence: true
 

--- a/app/models/stack.rb
+++ b/app/models/stack.rb
@@ -10,6 +10,7 @@ class Stack < ActiveRecord::Base
   has_many :rollbacks
   has_many :github_hooks, dependent: :destroy
   has_many :hooks, dependent: :destroy
+  has_many :api_clients, dependent: :destroy
   belongs_to :lock_author, class_name: :User
 
   before_validation :update_defaults

--- a/db/migrate/20150402143210_add_stack_id_to_api_clients.rb
+++ b/db/migrate/20150402143210_add_stack_id_to_api_clients.rb
@@ -1,0 +1,5 @@
+class AddStackIdToApiClients < ActiveRecord::Migration
+  def change
+    add_column :api_clients, :stack_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150330153704) do
+ActiveRecord::Schema.define(version: 20150402143210) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text     "permissions", limit: 65535
@@ -19,6 +19,7 @@ ActiveRecord::Schema.define(version: 20150330153704) do
     t.datetime "created_at",                             null: false
     t.datetime "updated_at",                             null: false
     t.string   "name",        limit: 255,   default: ""
+    t.integer  "stack_id",    limit: 4
   end
 
   add_index "api_clients", ["creator_id"], name: "index_api_clients_on_creator_id", using: :btree

--- a/test/controllers/api/stacks_controller_test.rb
+++ b/test/controllers/api/stacks_controller_test.rb
@@ -12,6 +12,9 @@ class Api::StacksControllerTest < ActionController::TestCase
     get :index
     assert_response :ok
     assert_json '0.id', stack.id
+    assert_json do |stacks|
+      assert_equal 2, stacks.size
+    end
   end
 
   test "#index is paginable" do
@@ -29,5 +32,13 @@ class Api::StacksControllerTest < ActionController::TestCase
   test "the `next` link is not provided when the last page is reached" do
     get :index, page_size: Stack.count
     assert_no_link 'next'
+  end
+
+  test "an api client scoped to a stack will only see that one stack" do
+    authenticate!(:here_come_the_walrus)
+    get :index
+    assert_json do |stacks|
+      assert_equal 1, stacks.size
+    end
   end
 end

--- a/test/fixtures/api_clients.yml
+++ b/test/fixtures/api_clients.yml
@@ -1,2 +1,8 @@
 spy:
+  name: Spy
   creator: walrus
+
+here_come_the_walrus:
+  name: Here Come The Walrus
+  creator: walrus
+  stack: shipit

--- a/test/helpers/api_helper.rb
+++ b/test/helpers/api_helper.rb
@@ -1,8 +1,9 @@
 module ApiHelper
   private
 
-  def authenticate!
-    @client ||= api_clients(:spy)
-    request.headers['Authorization'] = "Basic #{Base64.encode64(@client.authentication_token)}"
+  def authenticate!(client = @client || :spy)
+    client = api_clients(client) if client.is_a?(Symbol)
+    @client ||= client
+    request.headers['Authorization'] = "Basic #{Base64.encode64(client.authentication_token)}"
   end
 end


### PR DESCRIPTION
This will be helpful for half-public usage like HereComeTheWalrus. Next step is to implement API permissions so we can issue read only tokens.
