### PR TITLE
Add ability to update the reason for a deploy lock.

### DIFF
--- a/app/views/stacks/settings.html.erb
+++ b/app/views/stacks/settings.html.erb
@@ -15,16 +15,24 @@
     <div class="setting-section">
       <h5>Lock deploys</h5>
       <%= form_for @stack do |f| %>
-        <% if @stack.lock_reason.present? %>
-          <p><%= f.hidden_field :lock_reason, value: nil %></p>
-          <p>Deploys are currently locked: <%= @stack.lock_reason %></p>
-          <p><%= f.submit class: "btn", value: "Unlock" %></p>
-        <% else %>
-          <p>Please enter a reason to lock deploys for this stack</p>
-          <p><%= f.text_field :lock_reason %></p>
-          <p><%= f.submit class: "btn", value: "Lock" %></p>
-        <% end %>
+        <p>
+          <%= f.label :lock_reason, 'Reason for lock' %>
+          <%= f.text_field :lock_reason %>
+          <% if @stack.locked? %>
+            <%= f.submit class: "btn", value: "Update Reason" %>
+          <% else %>
+            </p>
+            <p>
+              <%= f.submit class: "btn", value: "Lock" %>
+          <% end %>
+        </p>
       <%- end -%>
+      <% if @stack.locked? %>
+        <%= form_for @stack do |f| %>
+          <%= f.hidden_field :lock_reason, value: nil %>
+          <p><%= f.submit class: "btn", value: "Unlock" %></p>
+        <%- end -%>
+      <% end %>
     </div>
     <div class="setting-section">
       <h5>Resynchronize this stack</h5>


### PR DESCRIPTION
@davidcornu & @byroot for review

Fixes #316

Add an "Update Reason" button to change the reason for a deploy lock without having to unlock deploys.

Here is how it looks without deploys locked.  I made the lock reason field a required field, so it will show a "Please fill out this field" tooltip when the "Lock" button is clicked without filling out the lock reason field.

![screen shot 2015-04-11 at 7 44 21 pm](https://cloud.githubusercontent.com/assets/954402/7103716/7dc30592-e083-11e4-964e-5718207159cf.png)

After deploys are locked, then there is a new "Lock Reason" button beside the lock reason text field.

![screen shot 2015-04-11 at 7 45 16 pm](https://cloud.githubusercontent.com/assets/954402/7103717/81fc1996-e083-11e4-8411-68b78c84a2a9.png)

The unlock button is in a separate form, so the lock reason isn't submitted with it.
