### PR TITLE
Cleanup a bit the FirstParentCommitsIterator limit handling

### DIFF
--- a/app/jobs/github_sync_job.rb
+++ b/app/jobs/github_sync_job.rb
@@ -1,4 +1,5 @@
 class GithubSyncJob < BackgroundJob
+  MAX_FETCHED_COMMITS = 10
   @queue = :default
 
   self.timeout = 60
@@ -28,7 +29,9 @@ class GithubSyncJob < BackgroundJob
   def fetch_missing_commits(&block)
     commits = []
     iterator = FirstParentCommitsIterator.new(&block)
-    iterator.each do |commit|
+    iterator.each_with_index do |commit, index|
+      break if index >= MAX_FETCHED_COMMITS
+
       if shared_parent = lookup_commit(commit.sha)
         return commits, shared_parent
       end

--- a/lib/first_parent_commits_iterator.rb
+++ b/lib/first_parent_commits_iterator.rb
@@ -1,10 +1,4 @@
 class FirstParentCommitsIterator < OctokitIterator
-  MAX_PAGE = 2
-
-  def initialize(relation = nil, max_pages: MAX_PAGE, &block)
-    super
-  end
-
   def each
     last_ancestor = nil
     super do |commit|

--- a/lib/octokit_iterator.rb
+++ b/lib/octokit_iterator.rb
@@ -1,14 +1,13 @@
 class OctokitIterator
   include Enumerable
 
-  def initialize(relation = nil, max_pages: nil)
+  def initialize(relation = nil)
     if relation
       @response = relation.get(per_page: 100)
     else
       yield Shipit.github_api
       @response = Shipit.github_api.last_response
     end
-    @max_pages = max_pages
   end
 
   def each(&block)
@@ -16,13 +15,7 @@ class OctokitIterator
 
     loop do
       response.data.each(&block)
-
       return unless response.rels[:next]
-      if @max_pages
-        @max_pages -= 1
-        return if @max_pages <= 0
-      end
-
       response = response.rels[:next].get
     end
   end


### PR DESCRIPTION
The reason for this limit, is that when we setup a new stack, we don't wan't to fetch thousands of commits, the last few ones are just fine.

So this paging / limiting concern doesn't really make sense at the level of abstraction.

@davidcornu for review please.
