### PR TITLE
Restrict access to a specific github team

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -19,10 +19,15 @@ class ApplicationController < ActionController::Base
   def force_github_authentication
     return unless Shipit.github
     return unless Shipit.github_required?
-    return if current_user.logged_in?
 
-    redirect_to authentication_path(:github, origin: request.original_url)
-    false
+    if current_user.logged_in?
+      team = Shipit.github_team
+      if team && !current_user.in?(team.members)
+        render text: "You must me a member of #{team.handle} to access this application.", status: :forbidden
+      end
+    else
+      redirect_to authentication_path(:github, origin: request.original_url)
+    end
   end
 
   def current_user

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -31,6 +31,10 @@ class Team < ActiveRecord::Base
     end
   end
 
+  def handle
+    "#{organization}/#{slug}"
+  end
+
   def add_member(member)
     members.append(member) unless members.include?(member)
   end

--- a/lib/shipit/config.rb
+++ b/lib/shipit/config.rb
@@ -28,18 +28,26 @@ module Shipit::Config
     Rails.application.secrets.api_clients_secret || ''
   end
 
-  delegate :authentication, :github, :host, to: :secrets
+  delegate :authentication, :host, to: :secrets
 
   def github_required?
-    github && !github['optional']
+    !github['optional']
+  end
+
+  def github_team
+    @github_team ||= github['team'] && Team.find_or_create_by_handle(github['team'])
   end
 
   def github_key
-    github && github['key']
+    github['key']
   end
 
   def github_secret
-    github && github['secret']
+    github['secret']
+  end
+
+  def github
+    secrets.github || {}
   end
 
   def authentication_settings

--- a/test/controllers/stacks_controller_test.rb
+++ b/test/controllers/stacks_controller_test.rb
@@ -19,6 +19,13 @@ class StacksControllerTest < ActionController::TestCase
     assert_response :ok
   end
 
+  test "current_user must be a member of Shipit.github_team" do
+    Shipit.stubs(:github_team).returns(teams(:cyclimse_cooks))
+    get :index
+    assert_response :forbidden
+    assert_equal 'You must me a member of cyclimse/cooks to access this application.', response.body
+  end
+
   test "#show is success" do
     get :show, id: @stack.to_param
     assert_response :ok


### PR DESCRIPTION
Fixes https://github.com/Shopify/shipit2/issues/327

This is kind of the MVP feature, i.e restrict access of all shipit to members of a GitHub team.

In the future the we might require more granularity, but this should be good enough for Rubygems needs.

@gmalette @davidcornu @dwradcliffe for review please.
