### PR TITLE
Simple replacement for resque-lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -31,6 +31,7 @@ gem 'active_model_serializers'
 gem 'explicit-parameters'
 gem 'rack-cors', require: 'rack/cors'
 gem 'react-rails'
+gem 'redis-objects'
 
 group :development do
   gem 'quiet_assets'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -249,6 +249,8 @@ GEM
       redis-store (~> 1.1.0)
     redis-namespace (1.5.2)
       redis (~> 3.0, >= 3.0.4)
+    redis-objects (1.1.0)
+      redis (>= 3.0.2)
     redis-rack (1.5.0)
       rack (~> 1.5)
       redis-store (~> 1.1.0)
@@ -377,6 +379,7 @@ DEPENDENCIES
   rails (~> 4.2.1)
   rails-timeago (~> 2.0)
   react-rails
+  redis-objects
   redis-rails
   responders
   resque (= 1.26.pre.0)

--- a/app/jobs/background_job/unique.rb
+++ b/app/jobs/background_job/unique.rb
@@ -1,0 +1,39 @@
+class BackgroundJob
+  module Unique
+    extend ActiveSupport::Concern
+
+    DEFAULT_TIMEOUT = 10
+
+    included do
+      around_perform { |job, block| job.acquire_lock(&block) }
+    end
+
+    module ClassMethods
+      def redis_namespace
+        @redis_namespace ||= Redis::Namespace.new("#{Resque.redis.namespace}:#{name}", redis: Shipit.redis)
+      end
+    end
+
+    delegate :redis_namespace, to: :class
+
+    def acquire_lock(&block)
+      mutex = Redis::Lock.new(
+        lock_key(*arguments),
+        expiration: self.class.timeout || DEFAULT_TIMEOUT,
+        timeout: 0,
+      )
+      mutex.lock(&block)
+    end
+
+    def lock_key(*args)
+      args.map { |arg| hash_argument(arg) }.join('-')
+    end
+
+    private
+
+    def hash_argument(argument)
+      return argument.to_global_id.to_s if argument.respond_to?(:to_global_id)
+      argument.to_s
+    end
+  end
+end

--- a/app/jobs/chunk_rollup_job.rb
+++ b/app/jobs/chunk_rollup_job.rb
@@ -1,4 +1,6 @@
 class ChunkRollupJob < BackgroundJob
+  include BackgroundJob::Unique
+
   queue_as :default
 
   def perform(task)

--- a/app/jobs/github_sync_job.rb
+++ b/app/jobs/github_sync_job.rb
@@ -1,4 +1,6 @@
 class GithubSyncJob < BackgroundJob
+  include BackgroundJob::Unique
+
   MAX_FETCHED_COMMITS = 10
   queue_as :default
 

--- a/app/jobs/setup_github_hook_job.rb
+++ b/app/jobs/setup_github_hook_job.rb
@@ -1,4 +1,6 @@
 class SetupGithubHookJob < BackgroundJob
+  include BackgroundJob::Unique
+
   queue_as :default
 
   def perform(hook)

--- a/config/initializers/resque.rb
+++ b/config/initializers/resque.rb
@@ -1,0 +1,1 @@
+Resque.redis = Shipit.redis

--- a/lib/shipit/config.rb
+++ b/lib/shipit/config.rb
@@ -9,6 +9,10 @@ module Shipit::Config
     end
   end
 
+  def redis
+    @redis ||= Redis.new(url: Rails.application.secrets.redis_url, logger: Rails.logger)
+  end
+
   def github_api
     @github_api ||= begin
       credentials = Rails.application.secrets.github_credentials || {}


### PR DESCRIPTION
@gmalette and @davidcornu for review.

I removed `resque-lock` on master since it's simply not working anyway.

I took the occasion to rethink our need of it. As a reminder, `resque-lock` is supposed to drop the job on the floor is there is a similar one in the queue:
- `PerformTaskJob`: aka deploy job, in this case dropping the job is not the proper solution. If we want to prevent concurrent deploys we should do it in the model, and display an error message to the user.
- `FetchDeployedRevisionJob`, it's to prevent the deployed version to flak between 2 revisions when a stack is being deployed. The job already bail out if the stack is deploying, so it's good enough without a lock.
- `ClearGitCacheJob` That one could cause issue if triggered while another job tries to clone the local cache. It should use a lock, but again, it should not lock the entire job. All the code that use the local cache should acquire a lock first. 
- `GitMirrorUpdateJob` same deal.
- `GithubSyncJob`. This one make sense for a resque-lock thingy
- `ChunkRollupJob` This one too since 2 jobs could mix each other up.
