### PR TITLE
Put all operations on the git cache behind a lock

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -33,7 +33,7 @@ Metrics/LineLength:
   Max: 120
 
 Metrics/MethodLength:
-  Max: 25
+  Max: 26
 
 Metrics/ClassLength:
   Max: 400

--- a/app/jobs/clear_git_cache_job.rb
+++ b/app/jobs/clear_git_cache_job.rb
@@ -2,6 +2,6 @@ class ClearGitCacheJob < BackgroundJob
   queue_as :default
 
   def perform(stack)
-    Command.new('rm', '-rf', stack.git_path, chdir: stack.base_path).run!
+    stack.clear_git_cache!
   end
 end

--- a/app/jobs/git_mirror_update_job.rb
+++ b/app/jobs/git_mirror_update_job.rb
@@ -3,6 +3,8 @@ class GitMirrorUpdateJob < BackgroundJob
 
   def perform(stack)
     commands = StackCommands.new(stack)
-    commands.fetch.run
+    stack.acquire_git_cache_lock do
+      commands.fetch.run
+    end
   end
 end

--- a/app/jobs/perform_task_job.rb
+++ b/app/jobs/perform_task_job.rb
@@ -10,8 +10,10 @@ class PerformTaskJob < BackgroundJob
 
     @task.run!
     commands = Commands.for(@task)
-    capture commands.fetch
-    capture commands.clone
+    @task.acquire_git_cache_lock do
+      capture commands.fetch
+      capture commands.clone
+    end
     capture commands.checkout(@task.until_commit)
 
     record_deploy_spec!

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -40,6 +40,8 @@ class Task < ActiveRecord::Base
     state :error
   end
 
+  delegate :acquire_git_cache_lock, to: :stack
+
   def spec
     @spec ||= DeploySpec::FileSystem.new(working_directory, stack.environment)
   end


### PR DESCRIPTION
This is to make sure a `ClearGitCache` job won't delete the git repository while a deploy task is trying to clone it.

@gmalette for review please.
