### PR TITLE
Do not prevent use to deploy concurrently but make sure they see a warning

### DIFF
--- a/app/assets/javascripts/application/flash.js.coffee
+++ b/app/assets/javascripts/application/flash.js.coffee
@@ -1,2 +1,2 @@
 jQuery ($) ->
-  setTimeout((-> $('.flash').remove()), 3000)
+  setTimeout((-> $('.flash-success').remove()), 3000)

--- a/app/assets/stylesheets/_base/_base.scss
+++ b/app/assets/stylesheets/_base/_base.scss
@@ -352,8 +352,13 @@ a.disabled {
   border-radius: 4px;
   min-width: 30%;
   text-align: center;
+  z-index: 1;
 }
 
 .flash-success {
   background-color: #E2F1FF;
+}
+
+.flash-warning {
+  background-color: orange;
 }

--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -14,6 +14,7 @@ class DeploysController < ApplicationController
   end
 
   def create
+    return redirect_to new_stack_deploy_path(@stack, sha: @until_commit.sha) if !params[:force] && @stack.deploying?
     @deploy = @stack.trigger_deploy(@until_commit, current_user)
     respond_with(@deploy.stack, @deploy)
   end

--- a/app/controllers/rollbacks_controller.rb
+++ b/app/controllers/rollbacks_controller.rb
@@ -1,20 +1,14 @@
 class RollbacksController < ApplicationController
   before_action :load_stack
   before_action :load_deploy
-  before_action :ensure_stack_is_not_being_deployed
 
   def create
+    return redirect_to rollback_stack_deploy_path(@stack, @deploy) if !params[:force] && @stack.deploying?
     @rollback = @deploy.trigger_rollback(current_user)
     redirect_to stack_deploy_path(@stack, @rollback)
   end
 
   private
-
-  def ensure_stack_is_not_being_deployed
-    return unless @stack.deploying?
-
-    redirect_to rollback_stack_deploy_path(@stack, @deploy), error: t('error.deploy_in_progress')
-  end
 
   def load_stack
     @stack ||= Stack.from_param!(params[:stack_id])

--- a/app/models/stack.rb
+++ b/app/models/stack.rb
@@ -153,8 +153,12 @@ class Stack < ActiveRecord::Base
   end
 
   def deploying?
-    return @deploying if defined?(@deploying)
-    @deploying = deploys.active.any?
+    !!active_deploy
+  end
+
+  def active_deploy
+    return @active_deploy if defined?(@active_deploy)
+    @active_deploy ||= deploys.active.last
   end
 
   def locked?
@@ -218,7 +222,7 @@ class Stack < ActiveRecord::Base
   private
 
   def clear_cache
-    remove_instance_variable(:@deploying) if defined?(@deploying)
+    remove_instance_variable(:@active_deploy) if defined?(@active_deploy)
   end
 
   def sync_github

--- a/app/views/deploys/_concurrent_deploy_warning.html.erb
+++ b/app/views/deploys/_concurrent_deploy_warning.html.erb
@@ -1,0 +1,6 @@
+<section class="warning concurrent-deploy">
+  <h2><%= render_github_user(@stack.active_deploy.author) %> is already deploying!</h2>
+  <ul>
+    <li>Are you sure you want to deploy concurrently?</li>
+  </ul>
+</section>

--- a/app/views/deploys/new.html.erb
+++ b/app/views/deploys/new.html.erb
@@ -1,6 +1,8 @@
 <%= render partial: "stacks/header", locals: { stack: @stack } %>
 
 <div class="wrapper">
+  <%= render 'concurrent_deploy_warning' if @stack.deploying? %>
+
   <section>
     <header class="section-header">
       <h2>Commits included in this deploy</h2>
@@ -29,6 +31,9 @@
 
   <section class="submit-section">
     <%= form_for [@stack, @deploy] do |f| %>
+      <% if @stack.deploying? %>
+        <%= hidden_field_tag :force, value: true %>
+      <% end %>
       <%= f.hidden_field :until_commit_id %>
       <%= f.submit :class => ['btn', 'primary', 'trigger-deploy'] %>
     <% end %>

--- a/app/views/deploys/rollback.html.erb
+++ b/app/views/deploys/rollback.html.erb
@@ -9,6 +9,8 @@
     </ul>
   </section>
 
+  <%= render 'concurrent_deploy_warning' if @stack.deploying? %>
+
   <section>
     <header class="section-header">
       <h2>Commits included in this rollback</h2>
@@ -25,6 +27,9 @@
 
   <section class="submit-section">
     <%= form_for [@stack, @rollback] do |f| %>
+      <% if @stack.deploying? %>
+        <%= hidden_field_tag :force, value: true %>
+      <% end %>
       <%= f.hidden_field :parent_id %>
       <%= f.submit 'Rollback', :class => ['btn', 'rollback', 'trigger-rollback'], data: {confirm: "Are you really sure it's safe?"} %>
     <% end %>

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -2,6 +2,7 @@ require 'test_helper'
 
 class DeploysControllerTest < ActionController::TestCase
   setup do
+    Deploy.where(status: %w(running pending)).update_all(status: 'success')
     @stack = stacks(:shipit)
     @deploy = deploys(:shipit)
     @commit = commits(:second)
@@ -18,10 +19,38 @@ class DeploysControllerTest < ActionController::TestCase
     assert_response :success
   end
 
+  test ":new shows a warning if a deploy is already running" do
+    deploys(:shipit_running).update_column(:status, 'running')
+
+    get :new, stack_id: @stack.to_param, sha: @commit.sha
+    assert_response :success
+    assert_select '.warning.concurrent-deploy h2' do |elements|
+      assert_equal 'Lando Walrussian is already deploying!', elements.first.text
+    end
+    assert_select '#new_deploy #force', 1
+  end
+
   test ":create persists a new deploy" do
     assert_difference '@stack.deploys.count', +1 do
       post :create, stack_id: @stack.to_param, deploy: {until_commit_id: @commit.id}
     end
+  end
+
+  test ":create with `force` option ignore the active deploys" do
+    deploys(:shipit_running).update_column(:status, 'running')
+
+    assert_difference '@stack.deploys.count', +1 do
+      post :create, stack_id: @stack.to_param, deploy: {until_commit_id: @commit.id}, force: true
+    end
+  end
+
+  test ":create redirect back to :new with a warning if there is an active deploy" do
+    deploys(:shipit_running).update_column(:status, 'running')
+
+    assert_no_difference '@stack.deploys.count' do
+      post :create, stack_id: @stack.to_param, deploy: {until_commit_id: @commit.id}
+    end
+    assert_redirected_to new_stack_deploy_path(@stack, sha: @commit.sha)
   end
 
   test ":create redirects to the new deploy" do
@@ -34,5 +63,21 @@ class DeploysControllerTest < ActionController::TestCase
     Deploy.any_instance.expects(:abort!)
     post :abort, stack_id: @stack.to_param, id: @deploy.id
     assert_response :success
+  end
+
+  test ":rollback is success" do
+    get :rollback, stack_id: @stack.to_param, id: @deploy.id
+    assert_response :success
+  end
+
+  test ":rollback shows a warning if a deploy is already running" do
+    deploys(:shipit_running).update_column(:status, 'running')
+
+    get :rollback, stack_id: @stack.to_param, id: @deploy.id
+    assert_response :success
+    assert_select '.warning.concurrent-deploy h2' do |elements|
+      assert_equal 'Lando Walrussian is already deploying!', elements.first.text
+    end
+    assert_select '#new_rollback #force', 1
   end
 end


### PR DESCRIPTION
![capture d ecran 2015-04-28 a 17 35 50](https://cloud.githubusercontent.com/assets/44640/7381495/d1aa2540-edd1-11e4-96da-471cc1556ca4.png)

The title pretty much says it all. This PR should handle concurrency correctly. By that I mean:
- Go to `deploys#new`
- No concurrent deploy so no warnings
- Another user is faster
- Hit the button
- Get redirected back with a warning
- Click again and the deploy happen

@gmalette for review please.
