### PR TITLE
Add submit button to stack settings edit

### DIFF
--- a/app/views/stacks/settings.html.erb
+++ b/app/views/stacks/settings.html.erb
@@ -10,6 +10,7 @@
         <p>Deploy URL (Where is this stack deployed to?)</p>
         <p><%= f.text_field :deploy_url, placeholder: 'https://' %></p>
         <p>Continuous Deployment? <%= f.check_box :continuous_deployment %></p>
+        <p><%= f.submit class: "btn", value: "Save" %></p>
       <%- end -%>
     </div>
     <div class="setting-section">


### PR DESCRIPTION
@byroot @garethson 

The form for settings in a stack's edit screen is missing a submit button.

![screen shot 2015-05-12 at 11 06 30 am](https://cloud.githubusercontent.com/assets/84159/7590523/fa808674-f896-11e4-9b1c-105205543ce8.png)
