### PR TITLE
GZip Rolled up Logs

### DIFF
--- a/app/jobs/chunk_rollup_job.rb
+++ b/app/jobs/chunk_rollup_job.rb
@@ -9,19 +9,11 @@ class ChunkRollupJob < BackgroundJob
       return
     end
 
-    chunk_count = task.chunks.count
-
-    unless chunk_count > 1
-      logger.error("Task ##{task.id} only has #{chunk_count} chunks. Aborting.")
+    if task.rolled_up?
+      logger.error("Task ##{task.id} has already been rolled up. Aborting.")
       return
     end
 
-    output = task.chunk_output
-
-    ActiveRecord::Base.transaction do
-      OutputChunk.where(id: task.chunks.ids).delete_all
-      task.write(output)
-      task.update_attribute(:rolled_up, true)
-    end
+    task.rollup_chunks
   end
 end

--- a/db/migrate/20150515190352_add_output_column_to_tasks.rb
+++ b/db/migrate/20150515190352_add_output_column_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddOutputColumnToTasks < ActiveRecord::Migration
+  def change
+    add_column :tasks, :gzip_output, :binary, limit: 16777215
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20140226233935) do
+ActiveRecord::Schema.define(version: 20150515195626) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text     "permissions", limit: 65535
@@ -137,19 +137,20 @@ ActiveRecord::Schema.define(version: 20140226233935) do
   add_index "statuses", ["commit_id"], name: "index_statuses_on_commit_id", using: :btree
 
   create_table "tasks", force: :cascade do |t|
-    t.integer  "stack_id",        limit: 4,                         null: false
-    t.integer  "since_commit_id", limit: 4,                         null: false
-    t.integer  "until_commit_id", limit: 4,                         null: false
-    t.string   "status",          limit: 255,   default: "pending", null: false
+    t.integer  "stack_id",        limit: 4,                            null: false
+    t.integer  "since_commit_id", limit: 4,                            null: false
+    t.integer  "until_commit_id", limit: 4,                            null: false
+    t.string   "status",          limit: 255,      default: "pending", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "user_id",         limit: 4
-    t.boolean  "rolled_up",       limit: 1,     default: false,     null: false
+    t.boolean  "rolled_up",       limit: 1,        default: false,     null: false
     t.string   "type",            limit: 255
     t.integer  "parent_id",       limit: 4
-    t.integer  "additions",       limit: 4,     default: 0
-    t.integer  "deletions",       limit: 4,     default: 0
+    t.integer  "additions",       limit: 4,        default: 0
+    t.integer  "deletions",       limit: 4,        default: 0
     t.text     "definition",      limit: 65535
+    t.binary   "gzip_output",     limit: 16777215
   end
 
   add_index "tasks", ["rolled_up", "created_at", "status"], name: "index_tasks_on_rolled_up_and_created_at_and_status", using: :btree

--- a/test/jobs/chunk_rollup_job_test.rb
+++ b/test/jobs/chunk_rollup_job_test.rb
@@ -6,13 +6,15 @@ class ChunkRollupJobTest < ActiveSupport::TestCase
     @job = ChunkRollupJob.new
   end
 
-  test "#perform combines all the chunks into a new one and sets rolled_up to true" do
+  test "#perform combines all the chunks into a output and sets rolled_up to true" do
     expected_output = @task.chunk_output
+    assert @task.output.blank?
 
     @job.perform(@task)
 
     @task.reload
-    assert_equal 1, @task.chunks.count
+    assert_equal 0, @task.chunks.count
+    assert @task.output.present?
     assert_equal expected_output, @task.chunk_output
     assert @task.rolled_up
   end
@@ -27,12 +29,12 @@ class ChunkRollupJobTest < ActiveSupport::TestCase
     @job.perform(@task)
   end
 
-  test "#perform ignores tasks with zero or one chunk" do
+  test "#perform ignores tasks already rolled up" do
     logger = mock
     logger.expects(:error).once
     @job.stubs(logger: logger)
 
-    @task.chunks.delete_all
+    @task.rolled_up = true
 
     @job.perform(@task)
   end

--- a/test/models/deploys_test.rb
+++ b/test/models/deploys_test.rb
@@ -258,6 +258,22 @@ class DeploysTest < ActiveSupport::TestCase
     end
   end
 
+  test "#chunk_output joins all chunk test if logs not rolled up" do
+    assert_equal @deploy.chunks.count, @deploy.chunks.count
+    assert_equal @deploy.chunks.pluck(:text).join, @deploy.chunk_output
+    refute @deploy.rolled_up
+  end
+
+  test "#chunk_output returns logs from records if rolled up" do
+    expected_output = @deploy.chunks.pluck(:text).join
+    @deploy.rollup_chunks
+
+    assert_no_queries do
+      assert_equal expected_output, @deploy.chunk_output
+      assert @deploy.rolled_up
+    end
+  end
+
   private
 
   def expect_event(deploy)


### PR DESCRIPTION
Fixes: https://github.com/Shopify/shipit2/issues/353

As discussed before, by GZipping the logs during rollup basically get rid of the size issue. Especially since logs tend to have a lot of repetition which gives us really nice compression rates.

paired with @byroot 

@gmalette @davidcornu for review please.
