### PR TITLE
add redis_url method that returns a URL

### DIFF
--- a/lib/shipster.rb
+++ b/lib/shipster.rb
@@ -52,6 +52,10 @@ module Shipster
     @app_name ||= secrets.app_name || Rails.application.class.name.split(':').first
   end
 
+  def redis_url
+    @redis_url ||= URI(secrets.redis_url.presence || fail("Missing `redis_url` setting in secrets.yml"))
+  end
+
   def redis
     @redis ||= Redis.new(url: Rails.application.secrets.redis_url, logger: Rails.logger)
   end


### PR DESCRIPTION
This allows us to use the parsed redis url in the application. For example, in `config/environments/production.rb`:

``` ruby
config.cache_store = :redis_store, {host: Shipster.redis_url.host, port: Shipster.redis_url.port, db: 1}
config.session_store :redis_store, {host: Shipster.redis_url.host, port: Shipster.redis_url.port, db: 5, key: '_shipit_session_id'}
```

r: @byroot 
