### PR TITLE
Don't wrap label and checkbox in a .form-group

### DIFF
--- a/app/views/stacks/new.html.erb
+++ b/app/views/stacks/new.html.erb
@@ -26,10 +26,8 @@
           <span class="form-hint">Where is this stack deployed to?</span>
         </p>
         <p>
-          <div class="form-group">
-            <%= f.label :ignore_ci, "Allow deploys regardless of CI status" %>
-            <%= f.check_box :ignore_ci %>
-          </div>
+          <%= f.label :ignore_ci, "Allow deploys regardless of CI status" %>
+          <%= f.check_box :ignore_ci %>
         </p>
         <p><%= f.submit class: 'btn' %></p>
       <% end %>


### PR DESCRIPTION
![screenshot 2015-05-21 11 13 40](https://cloud.githubusercontent.com/assets/2158003/7751902/77548a00-ffaa-11e4-9764-aeaacb21d9f8.png)

That label was black instead of grey because it was wrapped in a `.form-group` div

/cc @funionnn @byroot @gmalette 
