### PR TITLE
Add ignore ci action to stacks controller

### DIFF
--- a/app/controllers/stacks_controller.rb
+++ b/app/controllers/stacks_controller.rb
@@ -1,5 +1,5 @@
 class StacksController < ShipitController
-  before_action :load_stack, only: %i(update destroy settings sync_webhooks clear_git_cache refresh)
+  before_action :load_stack, only: %i(update destroy settings sync_webhooks clear_git_cache refresh ignore_ci)
 
   def new
     @stack = Stack.new
@@ -58,6 +58,13 @@ class StacksController < ShipitController
     redirect_to stack_settings_path(@stack)
   end
 
+  def ignore_ci
+    @stack.ignore_ci = true
+    @stack.save
+    flash[:success] = "This stack is now ignoring CI statuses. Deploy anything you want!"
+    redirect_to stack_path(@stack)
+  end
+
   private
 
   def load_stack
@@ -69,7 +76,7 @@ class StacksController < ShipitController
   end
 
   def update_params
-    params.require(:stack).permit(:deploy_url, :lock_reason, :continuous_deployment).tap do |params|
+    params.require(:stack).permit(:deploy_url, :lock_reason, :continuous_deployment, :ignore_ci).tap do |params|
       params[:lock_author_id] = params[:lock_reason].present? ? current_user.id : nil
     end
   end

--- a/app/controllers/stacks_controller.rb
+++ b/app/controllers/stacks_controller.rb
@@ -1,5 +1,5 @@
 class StacksController < ShipitController
-  before_action :load_stack, only: %i(update destroy settings sync_webhooks clear_git_cache refresh ignore_ci)
+  before_action :load_stack, only: %i(update destroy settings sync_webhooks clear_git_cache refresh)
 
   def new
     @stack = Stack.new

--- a/app/controllers/stacks_controller.rb
+++ b/app/controllers/stacks_controller.rb
@@ -45,7 +45,7 @@ class StacksController < ShipitController
 
   def update
     @stack.update(update_params)
-    redirect_to stack_settings_path(@stack)
+    redirect_to params[:return_to].presence || stack_settings_path(@stack)
   end
 
   def sync_webhooks
@@ -56,12 +56,6 @@ class StacksController < ShipitController
   def clear_git_cache
     ClearGitCacheJob.perform_later(@stack)
     redirect_to stack_settings_path(@stack)
-  end
-
-  def ignore_ci
-    @stack.update!(ignore_ci: true)
-    flash[:success] = "This stack is now ignoring CI statuses. Deploy anything you want!"
-    redirect_to stack_path(@stack)
   end
 
   private

--- a/app/controllers/stacks_controller.rb
+++ b/app/controllers/stacks_controller.rb
@@ -59,8 +59,7 @@ class StacksController < ShipitController
   end
 
   def ignore_ci
-    @stack.ignore_ci = true
-    @stack.save
+    @stack.update!(ignore_ci: true)
     flash[:success] = "This stack is now ignoring CI statuses. Deploy anything you want!"
     redirect_to stack_path(@stack)
   end

--- a/app/views/stacks/settings.html.erb
+++ b/app/views/stacks/settings.html.erb
@@ -10,6 +10,7 @@
         <p>Deploy URL (Where is this stack deployed to?)</p>
         <p><%= f.text_field :deploy_url, placeholder: 'https://' %></p>
         <p>Continuous Deployment? <%= f.check_box :continuous_deployment %></p>
+        <p>Don't require CI to deploy: <%= f.check_box :ignore_ci %></p>
         <p><%= f.submit class: "btn", value: "Save" %></p>
       <%- end -%>
     </div>

--- a/app/views/stacks/show.html.erb
+++ b/app/views/stacks/show.html.erb
@@ -20,7 +20,8 @@
       <p>
         <strong>Heads Up!</strong>
         This stack is not configured for CI, but it currently requires a passing build to be able to deploy a commit.
-        You can either configure CI yourself, or <a href="#">ignore CI statuses and deploy any commits you want.</a>
+        You can either configure CI yourself, or
+        <%= link_to "ignore CI and deploy any commits you want.", stack_ignore_ci_path(@stack), method: :put %>
       </p>
       <a class="dismiss-ignore-ci-warning"><small><em>Dismiss this message.</em></small></a>
     </div>

--- a/app/views/stacks/show.html.erb
+++ b/app/views/stacks/show.html.erb
@@ -21,7 +21,7 @@
         <strong>Heads Up!</strong>
         This stack is not configured for CI, but it currently requires a passing build to be able to deploy a commit.
         You can either configure CI yourself, or
-        <%= link_to "ignore CI and deploy any commits you want.", stack_ignore_ci_path(@stack), method: :put %>
+        <%= button_to "ignore CI and deploy any commits you want.", stack_path(@stack, stack: {ignore_ci: true}, return_to: stack_path(@stack)), method: :patch %>
       </p>
       <a class="dismiss-ignore-ci-warning"><small><em>Dismiss this message.</em></small></a>
     </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,7 +38,6 @@ Shipit::Engine.routes.draw do
     get :refresh, controller: :stacks # For easier design, sorry :/
     post :sync_webhooks, controller: :stacks
     post :clear_git_cache, controller: :stacks
-    put :ignore_ci, controller: :stacks
   end
 
   scope '/*stack_id', stack_id: stack_id_format, as: :stack do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Shipit::Engine.routes.draw do
     get :refresh, controller: :stacks # For easier design, sorry :/
     post :sync_webhooks, controller: :stacks
     post :clear_git_cache, controller: :stacks
+    put :ignore_ci, controller: :stacks
   end
 
   scope '/*stack_id', stack_id: stack_id_format, as: :stack do

--- a/test/controllers/stacks_controller_test.rb
+++ b/test/controllers/stacks_controller_test.rb
@@ -144,4 +144,11 @@ class StacksControllerTest < ActionController::TestCase
     end
     assert_redirected_to stack_settings_path(@stack)
   end
+
+  test "#ignore_ci updates stack" do
+    cyclimse = stacks(:cyclimse)
+    put :ignore_ci, id: cyclimse.to_param
+    assert_redirected_to stack_path(cyclimse)
+    assert(cyclimse.ignore_ci?)
+  end
 end

--- a/test/controllers/stacks_controller_test.rb
+++ b/test/controllers/stacks_controller_test.rb
@@ -145,10 +145,8 @@ class StacksControllerTest < ActionController::TestCase
     assert_redirected_to stack_settings_path(@stack)
   end
 
-  test "#ignore_ci updates stack" do
-    cyclimse = stacks(:cyclimse)
-    put :ignore_ci, id: cyclimse.to_param
-    assert_redirected_to stack_path(cyclimse)
-    assert(cyclimse.ignore_ci?)
+  test "#update redirects to return_to parameter" do
+    patch :update, id: @stack.to_param, stack: {ignore_ci: false}, return_to: stack_path(@stack)
+    assert_redirected_to stack_path(@stack)
   end
 end


### PR DESCRIPTION
Closes #372 

This does a few things, it hooks up the link to ignore CI from #372 to a new action on the stack controller. Then it adds a settings field for toggling the ignore_ci option on and off.

/cc @byroot @gmalette @funionnn 