### PR TITLE
Disable search and contributor filtering up to 10 stacks

### DIFF
--- a/app/assets/javascripts/shipit/search.js.coffee
+++ b/app/assets/javascripts/shipit/search.js.coffee
@@ -12,9 +12,9 @@ class StackSearch
   constructor: (root) ->
     @$root = $(root)
     @$root.on('keyup', '.stack-search', @onKeyUp)
-    @$root.on('click', '#show-all-stacks', (e) =>
+    @$root.on('click', '.show-all-stacks', (event) =>
       @$root.find('.not-matching').removeClass('not-matching')
-      e.preventDefault()
+      event.preventDefault()
     )
 
   onKeyUp: (event) =>

--- a/app/assets/stylesheets/_pages/_stacks.scss
+++ b/app/assets/stylesheets/_pages/_stacks.scss
@@ -109,8 +109,25 @@
   border: 1px #a0a0a0 solid;
 }
 
-.search-item.not-matching {
+.stack-search-header {
   display: none;
+}
+
+.show-all-stacks {
+  display: none;
+}
+
+.filtering-enabled {
+  .show-all-stacks {
+    display: inline-block;
+  }
+
+  .stack-search-header {
+    display: block;
+  }
+  .search-item.not-matching {
+    display: none;
+  }
 }
 
 .message {

--- a/app/controllers/stacks_controller.rb
+++ b/app/controllers/stacks_controller.rb
@@ -8,7 +8,7 @@ class StacksController < ShipitController
   def index
     @user_stacks = current_user.stacks_contributed_to
 
-    @stacks = Stack.order('(undeployed_commits_count > 0) desc', tasks_count: :desc)
+    @stacks = Stack.order('(undeployed_commits_count > 0) desc', tasks_count: :desc).to_a
   end
 
   def show

--- a/app/views/stacks/index.html.erb
+++ b/app/views/stacks/index.html.erb
@@ -5,9 +5,9 @@
   <%= link_to 'Add a stack', new_stack_path, class: 'btn secondary' %>
 <% end %>
 
-<div class="wrapper">
+<div class="wrapper <%= 'filtering-enabled' if @stacks.size > 10 %>">
   <section>
-    <header class="section-header">
+    <header class="section-header stack-search-header">
       <input class="stack-search" placeholder="Search <%= @stacks.size %> stacks" />
     </header>
     <ul class="stack-table-header">
@@ -27,7 +27,7 @@
       <% end %>
     </ul>
 
-    <%= link_to 'show all stacks', '#', class: 'btn secondary', id: 'show-all-stacks' %></p>
+    <%= link_to 'show all stacks', '#', class: 'btn secondary show-all-stacks' %></p>
   </section>
 
 </div>


### PR DESCRIPTION
Those two features while indispensable for organisations like Shopify with hundreds of stacks, is quite useless and even confusing for small organizations like rubygems that only have an handful of stacks.

@gmalette and @arthurnn for technical review please.

@funionnn and @vernalkick for CSS review please.

Before: 
![capture d ecran 2015-05-22 a 14 03 31](https://cloud.githubusercontent.com/assets/44640/7776742/68a97420-008b-11e5-8bc6-985e8690ae18.png)

After:
![capture d ecran 2015-05-22 a 14 03 50](https://cloud.githubusercontent.com/assets/44640/7776743/6e0461be-008b-11e5-9068-895876f1a5a1.png)
