### PR TITLE
Fix migrations for postgres

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,8 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'mysql2'
+gem 'pg'
+gem 'sqlite3'
 
 group :development, :test do
   gem 'faker'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,6 +160,7 @@ GEM
       omniauth (~> 1.2)
     parser (2.2.2.3)
       ast (>= 1.1, < 3.0)
+    pg (0.18.2)
     powerpack (0.1.1)
     pry (0.10.1)
       coderay (~> 1.1.0)
@@ -244,6 +245,7 @@ GEM
       actionpack (>= 3.0)
       activesupport (>= 3.0)
       sprockets (>= 2.8, < 4.0)
+    sqlite3 (1.3.10)
     state_machines (0.2.2)
     state_machines-activemodel (0.1.2)
       activemodel (~> 4.1)
@@ -276,8 +278,10 @@ DEPENDENCIES
   fakeweb
   mocha
   mysql2
+  pg
   pry
   rubocop
   shipit-engine!
   simplecov
+  sqlite3
   test_after_commit (= 0.4.0)

--- a/circle.yml
+++ b/circle.yml
@@ -8,7 +8,8 @@ machine:
 
 database:
   override:
-    - script/bootstrap
+    - script/bootstrap:
+        parallel: true
 dependencies:
   bundler:
     without:
@@ -18,6 +19,6 @@ dependencies:
       - debug
 
 test:
-  post:
-    - bundle exec rubocop
-    - bundle exec rake db:seed # Make sure db:seed still works
+  override:
+    - script/circleci:
+        parallel: true

--- a/db/migrate/20140226233935_create_baseline.rb
+++ b/db/migrate/20140226233935_create_baseline.rb
@@ -19,7 +19,7 @@ class CreateBaseline < ActiveRecord::Migration
       t.text     "message",      limit: 65535,                 null: false
       t.datetime "created_at"
       t.datetime "updated_at"
-      t.boolean  "detached",     limit: 1,     default: false, null: false
+      t.boolean  "detached",                   default: false, null: false
       t.datetime "authored_at",                                null: false
       t.datetime "committed_at",                               null: false
       t.integer  "additions",    limit: 4
@@ -67,7 +67,7 @@ class CreateBaseline < ActiveRecord::Migration
       t.string   "content_type", limit: 4,    default: "json", null: false
       t.string   "secret",       limit: 255
       t.string   "events",       limit: 255,  default: "",     null: false
-      t.boolean  "insecure_ssl", limit: 1,    default: false,  null: false
+      t.boolean  "insecure_ssl",              default: false,  null: false
       t.datetime "created_at",                                 null: false
       t.datetime "updated_at",                                 null: false
     end
@@ -103,7 +103,7 @@ class CreateBaseline < ActiveRecord::Migration
       t.string   "deploy_url",               limit: 255
       t.string   "lock_reason",              limit: 255
       t.integer  "tasks_count",              limit: 4,     default: 0,            null: false
-      t.boolean  "continuous_deployment",    limit: 1,     default: false,        null: false
+      t.boolean  "continuous_deployment",                  default: false,        null: false
       t.integer  "undeployed_commits_count", limit: 4,     default: 0,            null: false
       t.text     "cached_deploy_spec",       limit: 65535
       t.integer  "lock_author_id",           limit: 4
@@ -131,7 +131,7 @@ class CreateBaseline < ActiveRecord::Migration
       t.datetime "created_at"
       t.datetime "updated_at"
       t.integer  "user_id",         limit: 4
-      t.boolean  "rolled_up",       limit: 1,     default: false,     null: false
+      t.boolean  "rolled_up",                     default: false,     null: false
       t.string   "type",            limit: 255
       t.integer  "parent_id",       limit: 4
       t.integer  "additions",       limit: 4,     default: 0

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -32,7 +32,7 @@ ActiveRecord::Schema.define(version: 20150424175630) do
     t.text     "message",      limit: 65535,                 null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "detached",     limit: 1,     default: false, null: false
+    t.boolean  "detached",                   default: false, null: false
     t.datetime "authored_at",                                null: false
     t.datetime "committed_at",                               null: false
     t.integer  "additions",    limit: 4,     default: 0
@@ -80,7 +80,7 @@ ActiveRecord::Schema.define(version: 20150424175630) do
     t.string   "content_type", limit: 4,    default: "json", null: false
     t.string   "secret",       limit: 255
     t.string   "events",       limit: 255,  default: "",     null: false
-    t.boolean  "insecure_ssl", limit: 1,    default: false,  null: false
+    t.boolean  "insecure_ssl",              default: false,  null: false
     t.datetime "created_at",                                 null: false
     t.datetime "updated_at",                                 null: false
   end
@@ -116,7 +116,7 @@ ActiveRecord::Schema.define(version: 20150424175630) do
     t.string   "deploy_url",               limit: 255
     t.string   "lock_reason",              limit: 255
     t.integer  "tasks_count",              limit: 4,     default: 0,            null: false
-    t.boolean  "continuous_deployment",    limit: 1,     default: false,        null: false
+    t.boolean  "continuous_deployment",                  default: false,        null: false
     t.integer  "undeployed_commits_count", limit: 4,     default: 0,            null: false
     t.text     "cached_deploy_spec",       limit: 65535
     t.integer  "lock_author_id",           limit: 4
@@ -144,7 +144,7 @@ ActiveRecord::Schema.define(version: 20150424175630) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "user_id",         limit: 4
-    t.boolean  "rolled_up",       limit: 1,     default: false,     null: false
+    t.boolean  "rolled_up",                     default: false,     null: false
     t.string   "type",            limit: 255
     t.integer  "parent_id",       limit: 4
     t.integer  "additions",       limit: 4,     default: 0

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -4,6 +4,18 @@
 set -e
 set -x
 
+#!/bin/bash
+
 cp -n test/dummy/config/secrets.example.yml test/dummy/config/secrets.yml || true
+
+case $CIRCLE_NODE_INDEX in
+  1)
+    cp test/config/database.postgres.yml test/dummy/config/database.yml
+    ;;
+  2)
+    cp test/config/database.sqlite.yml test/dummy/config/database.yml
+    ;;
+esac
+
 bundle install
 bundle exec rake db:create db:schema:load db:seed

--- a/script/circleci
+++ b/script/circleci
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+case $CIRCLE_NODE_INDEX in
+  0 )
+    bundle exec rake test
+    ;;
+  1)
+    bundle exec rake test
+    ;;
+  2)
+    bundle exec rake test
+    ;;
+  3)
+    bundle exec rubocop
+    bundle exec rake db:seed # Make sure db:seed still works
+    ;;
+esac

--- a/test/config/database.postgres.yml
+++ b/test/config/database.postgres.yml
@@ -1,0 +1,10 @@
+default: &default
+  adapter: postgresql
+
+development:
+  <<: *default
+  database: shipit_development
+
+test:
+  <<: *default
+  database: shipit_test

--- a/test/config/database.sqlite.yml
+++ b/test/config/database.sqlite.yml
@@ -1,0 +1,10 @@
+default: &default
+  adapter: sqlite3
+
+development:
+  <<: *default
+  database: db/development.sqlite3
+
+test:
+  <<: *default
+  database: db/test.sqlite3

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -32,7 +32,7 @@ ActiveRecord::Schema.define(version: 20150518214944) do
     t.text     "message",      limit: 65535,                 null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "detached",     limit: 1,     default: false, null: false
+    t.boolean  "detached", default: false, null: false
     t.datetime "authored_at",                                null: false
     t.datetime "committed_at",                               null: false
     t.integer  "additions",    limit: 4
@@ -80,7 +80,7 @@ ActiveRecord::Schema.define(version: 20150518214944) do
     t.string   "content_type", limit: 4,    default: "json", null: false
     t.string   "secret",       limit: 255
     t.string   "events",       limit: 255,  default: "",     null: false
-    t.boolean  "insecure_ssl", limit: 1,    default: false,  null: false
+    t.boolean  "insecure_ssl", default: false,  null: false
     t.datetime "created_at",                                 null: false
     t.datetime "updated_at",                                 null: false
   end
@@ -116,11 +116,11 @@ ActiveRecord::Schema.define(version: 20150518214944) do
     t.string   "deploy_url",               limit: 255
     t.string   "lock_reason",              limit: 255
     t.integer  "tasks_count",              limit: 4,     default: 0,            null: false
-    t.boolean  "continuous_deployment",    limit: 1,     default: false,        null: false
+    t.boolean  "continuous_deployment",    default: false,        null: false
     t.integer  "undeployed_commits_count", limit: 4,     default: 0,            null: false
     t.text     "cached_deploy_spec",       limit: 65535
     t.integer  "lock_author_id",           limit: 4
-    t.boolean  "ignore_ci",                limit: 1
+    t.boolean  "ignore_ci"
   end
 
   add_index "stacks", ["repo_owner", "repo_name", "environment"], name: "stack_unicity", unique: true, using: :btree
@@ -145,7 +145,7 @@ ActiveRecord::Schema.define(version: 20150518214944) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.integer  "user_id",         limit: 4
-    t.boolean  "rolled_up",       limit: 1,        default: false,     null: false
+    t.boolean  "rolled_up",       default: false,     null: false
     t.string   "type",            limit: 255
     t.integer  "parent_id",       limit: 4
     t.integer  "additions",       limit: 4,        default: 0


### PR DESCRIPTION
when trying to run shipit on postgres was getting the following error on migration run:
```
StandardError: An error has occurred, this and all later migrations canceled:

PG::SyntaxError: ERROR:  syntax error at or near "("
LINE 1: SELECT 'boolean(1)'::regtype::oid
```

Removing the limit on the boolean column should fix the problem.

review @byroot 