### PR TITLE
Store the milliseconds on the database column

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,8 +10,6 @@ env:
 rvm:
   - 2.1
 matrix:
-  allow_failures:
-    - env: "DATABASE=sqlite3"
   fast_finish: true
 notifications:
   email: false

--- a/app/models/status.rb
+++ b/app/models/status.rb
@@ -18,7 +18,7 @@ class Status < ActiveRecord::Base
       description: github_status.description,
       target_url: github_status.rels.try(:[], :target).try(:href),
       context: github_status.context,
-      created_at: github_status.created_at.to_s(:db),
+      created_at: github_status.created_at,
     )
   end
 

--- a/test/models/status_test.rb
+++ b/test/models/status_test.rb
@@ -34,7 +34,7 @@ class StatusTest < ActiveSupport::TestCase
   private
 
   def github_status
-    OpenStruct.new(
+    @github_status ||= OpenStruct.new(
       state: 'success',
       description: 'This is a description',
       context: 'default',


### PR DESCRIPTION
This will correct the comparison for databases that have millisecond precision and work like before for databases that don't have.

Also memoize the github_status object on the tests so the milliseconds are the same for the created_at property.

Closes #403