### PR TITLE
Include SHA of last successful deploy in ENV

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@
 
 **Shipit** is a deployment tool that makes shipping code better for everyone. It's especially great for large teams of developers and designers who work together to build and deploy GitHub repos. You can use it to:
 
-* add new applications to your deployment environment without having to change core configuration files repeatedly &mdash; `shipit.yml` is basically plug and play 
+* add new applications to your deployment environment without having to change core configuration files repeatedly &mdash; `shipit.yml` is basically plug and play
 * control the pace of development by pushing, locking, and rolling back deploys from within Shipit
 * enforce checklists and provide monitoring right at the point of deployment.
 
-Shipit's compatible with just about anything that you can deploy using a script. It natively detects stacks using [bundler](http://bundler.io/) and [Capistrano](http://capistranorb.com/), and it has tools that make it easy to deploy to [Heroku](https://www.heroku.com/) or [RubyGems](https://rubygems.org/). At Shopify, we've used Shipit to sychronize and deploy hundreds of projects across dozens of teams, using Python, Rails, RubyGems, Java, and Go. 
+Shipit's compatible with just about anything that you can deploy using a script. It natively detects stacks using [bundler](http://bundler.io/) and [Capistrano](http://capistranorb.com/), and it has tools that make it easy to deploy to [Heroku](https://www.heroku.com/) or [RubyGems](https://rubygems.org/). At Shopify, we've used Shipit to sychronize and deploy hundreds of projects across dozens of teams, using Python, Rails, RubyGems, Java, and Go.
 
 This guide aims to help you [set up](#installation-and-setup), [use](#using-shipit), and [understand](#reference) Shipit.
 
@@ -66,7 +66,7 @@ A **stack** is composed of a GitHub repository, a branch, and a deployment envir
 
 <h3 id="adding-stacks">Add a new stack</h3>
 
-1. From the main page in Shipit, click **Add a stack**. 
+1. From the main page in Shipit, click **Add a stack**.
 2. On the **Create a stack** page, enter the required information:
     * Repo
     * Branch
@@ -91,7 +91,7 @@ A **stack** is composed of a GitHub repository, a branch, and a deployment envir
 
 <h3 id="configuring-stacks">Edit stack settings</h3>
 
-To edit a stack's settings, open the stack in Shipit, then click the gear icon in the page header. 
+To edit a stack's settings, open the stack in Shipit, then click the gear icon in the page header.
 
 From a stack's **Settings** page, you can:
 
@@ -124,7 +124,7 @@ All the settings in `shipit.yml` are optional. Most applications can be deployed
 The **<code>dependencies</code>** step allows you to install all the packages your deploy script needs.
 
 <h4 id="bundler-support">Bundler</h3>
-  
+
 If your application uses Bundler, Shipit will detect it automatically and take care of the `bundle install` and prefix your commands with `bundle exec`.
 
 By default the following gem groups will be ignored:
@@ -207,12 +207,12 @@ key: val # things added as environment variables
 
 You can create custom tasks that users execute directly from a stack's overview page in Shipit. To create a new custom task, specify its parameters in the `tasks` section of the `shipit.yml` file. For example:
 
-**<code>tasks</code>** restarts the application. 
+**<code>tasks</code>** restarts the application.
 
 ```yml
 tasks:
   restart:
-    action: "Restart Application"     
+    action: "Restart Application"
     description: "Sometimes needed if you the application to restart but don't want to ship any new code."
     steps:
       - ssh deploy@myserver.example.com 'touch myapp/restart.txt'
@@ -222,14 +222,14 @@ tasks:
 
 You can display review elements, such as monitoring data or a pre-deployment checklist, on the deployment page in Shipit:
 
-**<code>review.checklist</code>** contains a pre-deploy checklist that appears on the deployment page in Shipit, with each item in the checklist as a separate string in the array. It can contain `strong` and `a` HTML tags. Users cannot deploy from Shipit until they have checked each item in the checklist. 
+**<code>review.checklist</code>** contains a pre-deploy checklist that appears on the deployment page in Shipit, with each item in the checklist as a separate string in the array. It can contain `strong` and `a` HTML tags. Users cannot deploy from Shipit until they have checked each item in the checklist.
 
 For example:
 
 ```yml
 review:
   checklist:
-    - >      
+    - >
     Do you know if it is safe to revert the code being shipped? What happens if we need to undo this deploy?
     - Has the Docs team been notified of any major changes to the app?
     - Is the app stable right now?
@@ -258,13 +258,13 @@ For example:
 
 ```yml
 development:
-  secret_key_base: s3cr3t # This needs to be a very long, fully random 
+  secret_key_base: s3cr3t # This needs to be a very long, fully random
 ```
 <br>
 
-**`github_oauth`** contains the settings required to authenticate users through GitHub. 
+**`github_oauth`** contains the settings required to authenticate users through GitHub.
 
-The value for `id` is your application's  *Client ID*, and the value for `secret` is your application's *Client Secret* &mdash; both of these should appear on your application's GitHub page. 
+The value for `id` is your application's  *Client ID*, and the value for `secret` is your application's *Client Secret* &mdash; both of these should appear on your application's GitHub page.
 
 The `team` is optional, and required only if you want to specify a team that has access to the stack in Shipit.
 
@@ -273,13 +273,13 @@ For example:
 ```yml
 development:
   github_oauth:
-    id: (your application's Client ID)                
-    secret: (your application's Client Secret)            
-    team: Shipit/team  
+    id: (your application's Client ID)
+    secret: (your application's Client Secret)
+    team: Shipit/team
 ```
 <br>
 
-**`github_api`** communicates with the GitHub API about the stacks and setup Hooks. It should reflect the guidelines at  https://github.com/octokit/octokit.rb. 
+**`github_api`** communicates with the GitHub API about the stacks and setup Hooks. It should reflect the guidelines at  https://github.com/octokit/octokit.rb.
 
 If you specify an `access_token`, you don't need a `login` and `password`. The opposite is also true:  if you specify a `login` and `password`, then you don't need an `access_token`.
 
@@ -289,27 +289,27 @@ For example:
 
 ```yml
 development:
-  github_api:             
+  github_api:
     access_token: 10da65c687f6degaf5475ce12a980d5vd8c44d2a
 ```
 <br>
 
-**`host`**  is the host that hosts Shipit. It's used to generate URLs, and it's the host that GitHub will try to talk to. 
+**`host`**  is the host that hosts Shipit. It's used to generate URLs, and it's the host that GitHub will try to talk to.
 
 For example:
 ```yml
 development:
-  host: 'http://localhost:3000' 
+  host: 'http://localhost:3000'
 ```
 <br>
 
-**`redis_url`** is the URL of the redis instance that Shipit uses. 
+**`redis_url`** is the URL of the redis instance that Shipit uses.
 
 For example:
 
 ```yml
 development:
-  redis_url: "redis://127.0.0.1:6379/7" 
+  redis_url: "redis://127.0.0.1:6379/7"
 ```
 
 <h2 id="script-parameters">Script parameters</h2>
@@ -321,6 +321,7 @@ Your deploy scripts have access to the following environment variables:
 * `USER`: Full name of the user that triggered the deploy/task
 * `EMAIL`: Email of the user that triggered the deploy/task (if available)
 * `ENVIRONMENT`: The stack environment (e.g production / staging)
+* `LAST_DEPLOYED_SHA`: The git SHA of the last deployed commit
 * All the content of the `secrets.yml` `env` key
 * All the content of the `shipit.yml` `machine.environment` key
 

--- a/lib/task_commands.rb
+++ b/lib/task_commands.rb
@@ -34,6 +34,7 @@ class TaskCommands < Commands
       'EMAIL' => @task.author.email,
       'BUNDLE_PATH' => Rails.root.join('data', 'bundler').to_s,
       'SHIPIT_LINK' => permalink,
+      'LAST_DEPLOYED_SHA' => @stack.last_deployed_commit.sha,
     ).merge(deploy_spec.machine_env)
   end
 

--- a/test/unit/deploy_commands_test.rb
+++ b/test/unit/deploy_commands_test.rb
@@ -122,6 +122,13 @@ class DeployCommandsTest < ActiveSupport::TestCase
     assert_equal "http://shipit.com/shopify/shipit2/production/deploys/#{@deploy.id}", command.env['SHIPIT_LINK']
   end
 
+  test "#perform calls cap $environment deploy with the LAST_DEPLOYED_SHA in the environment" do
+    commands = @commands.perform
+    assert_equal 1, commands.length
+    command = commands.first
+    assert_equal @deploy.stack.last_deployed_commit.sha, command.env['LAST_DEPLOYED_SHA']
+  end
+
   test "#perform transliterates the user name" do
     @deploy.user = User.new(login: 'Sirupsen', name: "Simon Hørup Eskildsen")
     commands = @commands.perform


### PR DESCRIPTION
Includes the SHA of the last deployed commit as the environment variable `LAST_DEPLOYED_SHA`.

[Diff without whitespace](https://github.com/Shopify/shipit-engine/pull/419/files?w=1)

@byroot @wvanbergen 