### PR TITLE
Allow overriding --frozen for bundle install

### DIFF
--- a/app/models/deploy_spec/bundler_discovery.rb
+++ b/app/models/deploy_spec/bundler_discovery.rb
@@ -26,7 +26,9 @@ class DeploySpec
     end
 
     def frozen_flag
-      '--frozen' if gemfile_lock_exists?
+      return unless gemfile_lock_exists?
+      return if config('dependencies', 'bundler', 'frozen') == false
+      '--frozen'
     end
 
     def bundler_without

--- a/test/unit/deploy_spec_test.rb
+++ b/test/unit/deploy_spec_test.rb
@@ -90,6 +90,12 @@ class DeploySpecTest < ActiveSupport::TestCase
     refute @spec.bundle_install.last.include?('--frozen')
   end
 
+  test '#bundle_install does not have --frozen if overridden in shipit.yml' do
+    @spec.stubs(:load_config).returns('dependencies' => {'bundler' => {'frozen' => false}})
+    @spec.stubs(:gemfile_lock_exists?).returns(true)
+    refute @spec.bundle_install.last.include?('--frozen')
+  end
+
   test '#deploy_steps returns `deploy.override` if present' do
     @spec.stubs(:load_config).returns('deploy' => {'override' => %w(foo bar baz)})
     assert_equal %w(foo bar baz), @spec.deploy_steps


### PR DESCRIPTION
In the case of Rubygems, they use a git submodule to include gems. In some cases, the `Gemfile.lock` and the submodule don't align perfectly, but they still want to be able to deploy to staging. 

@byroot @dwradcliffe 