### PR TITLE
Fix git branch regex

### DIFF
--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -118,7 +118,7 @@ class Commit < ActiveRecord::Base
   end
 
   def parsed
-    @parsed ||= message.match(/\AMerge pull request #(?<pr_id>\d+) from [\w\-\_\/]+\n\n(?<pr_title>.*)/)
+    @parsed ||= message.match(/\AMerge pull request #(?<pr_id>\d+) from [\w\-.\/]+\n\n(?<pr_title>.*)/)
   end
 
   def schedule_continuous_delivery

--- a/test/models/commits_test.rb
+++ b/test/models/commits_test.rb
@@ -13,6 +13,12 @@ class CommitsTest < ActiveSupport::TestCase
     refute @commit.pull_request?
   end
 
+  test "#pull_request? detects pull requests with unusual branch names" do
+    @pr.message = "Merge pull request #7 from Shopify/bump-to-v1.0.1\n\nBump to v1.0.1"
+    assert @pr.pull_request?
+    assert_equal "Bump to v1.0.1", @pr.pull_request_title
+  end
+
   test "#pull_request_id extract the pull request id from the message" do
     assert_equal 31, @pr.pull_request_id
     assert_nil @commit.pull_request_id


### PR DESCRIPTION
Git branches can contain periods, this is used for branches containing version numbers.
The `\w` character class also already covers the underscore.

@byroot 