### PR TITLE
add --recursive option to git clone

### DIFF
--- a/lib/stack_commands.rb
+++ b/lib/stack_commands.rb
@@ -43,7 +43,7 @@ class StackCommands < Commands
   end
 
   def git_clone(url, path, branch: 'master', **kwargs)
-    git('clone', *modern_git_args, '--branch', branch, url, path, **kwargs)
+    git('clone', *modern_git_args, '--recursive', '--branch', branch, url, path, **kwargs)
   end
 
   def modern_git_args

--- a/test/unit/deploy_commands_test.rb
+++ b/test/unit/deploy_commands_test.rb
@@ -32,14 +32,16 @@ class DeployCommandsTest < ActiveSupport::TestCase
   test "#fetch calls git clone if repository cache do not exist" do
     Dir.expects(:exist?).with(@stack.git_path).returns(false)
     command = @commands.fetch
-    assert_equal %W(git clone --single-branch --branch master #{@stack.repo_git_url} #{@stack.git_path}), command.args
+    expected = %W(git clone --single-branch --recursive --branch master #{@stack.repo_git_url} #{@stack.git_path})
+    assert_equal expected, command.args
   end
 
   test "#fetch does not use --single-branch if git is outdated" do
     Dir.expects(:exist?).with(@stack.git_path).returns(false)
     StackCommands.stubs(git_version: Gem::Version.new('1.7.2.30'))
     command = @commands.fetch
-    assert_equal ['git', 'clone', '--branch', 'master', @stack.repo_git_url, @stack.git_path], command.args
+    expected = %W(git clone --recursive --branch master #{@stack.repo_git_url} #{@stack.git_path})
+    assert_equal expected, command.args
   end
 
   test "#fetch calls git fetch in base_path directory if repository cache do not exist" do


### PR DESCRIPTION
Any repos that have submodules probably need them to build properly.

This option fetches all submodules after the clone.

From the git docs:
> After the clone is created, initialize all submodules within, using their default settings. This is equivalent to running git submodule update --init --recursive immediately after the clone is finished.

@byroot @gmalette