### PR TITLE
Fix: Non Github Enterprise omniauth issue

### DIFF
--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -118,7 +118,7 @@ module Shipit
   end
 
   def github_oauth_options
-    return unless github_enterprise?
+    return {} unless github_enterprise?
     {
       site: github_api_endpoint,
       authorize_url: github_url('/login/oauth/authorize'),

--- a/test/unit/shipit_test.rb
+++ b/test/unit/shipit_test.rb
@@ -38,4 +38,9 @@ class ShipitTest < ActiveSupport::TestCase
     Rails.application.secrets.stubs(:github_domain).returns('github.example.com')
     assert_equal 'https://github.example.com/api/v3/', Shipit.github_api_endpoint
   end
+
+  test ".github_oauth_options returns an empty hash if not enterprise" do
+    refute Shipit.github_enterprise?
+    assert_equal({}, Shipit.github_oauth_options)
+  end
 end


### PR DESCRIPTION
If using a non-Github Enterprise, omniauth was expecting a hash to be set
in its `client_options`, instead it got nil.

This fixes that.

Otherwise it would throw an error, in the `deep_symbolize` inside omniauth.