### PR TITLE
Add support for OSX.

### DIFF
--- a/app/models/deploy_spec/bundler_discovery.rb
+++ b/app/models/deploy_spec/bundler_discovery.rb
@@ -22,7 +22,13 @@ class DeploySpec
     end
 
     def remove_ruby_version_from_gemfile
-      %q(sed -i '/^ruby\s/d' Gemfile) # Heroku apps often specify a ruby version.
+      # Heroku apps often specify a ruby version.
+      if /darwin/ =~ RUBY_PLATFORM
+        # OSX is nitpicky about the -i.
+        %q(sed -i '' '/^ruby\s/d' Gemfile)
+      else
+        %q(sed -i '/^ruby\s/d' Gemfile)
+      end
     end
 
     def frozen_flag


### PR DESCRIPTION
OSX is nitpicky when it comes to `sed`. It would throw an error when running the command.

[0] http://stackoverflow.com/questions/16745988/sed-command-works-fine-on-ubuntu-but-not-mac