### PR TITLE
Add `ci.hide` key to the shipit.yml to ignore CI statuses

### DIFF
--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -85,7 +85,7 @@ class Commit < ActiveRecord::Base
   end
 
   def last_statuses
-    statuses.to_a.uniq(&:context).sort_by(&:context).presence || [UnknownStatus.new(self)]
+    stack.filter_statuses(statuses.to_a.uniq(&:context).sort_by(&:context)).presence || [UnknownStatus.new(self)]
   end
 
   def children

--- a/app/models/deploy_spec.rb
+++ b/app/models/deploy_spec.rb
@@ -92,6 +92,10 @@ class DeploySpec
     config('review', 'monitoring') || []
   end
 
+  def hidden_statuses
+    Array.wrap(config('ci', 'hide'))
+  end
+
   private
 
   def coerce_task_definition(config)

--- a/app/models/deploy_spec/file_system.rb
+++ b/app/models/deploy_spec/file_system.rb
@@ -18,6 +18,7 @@ class DeploySpec
 
     def cacheable_config
       (config || {}).deep_merge(
+        'ci' => {'hide' => hidden_statuses},
         'machine' => {'environment' => machine_env, 'directory' => directory},
         'review' => {'checklist' => review_checklist},
         'dependencies' => {'override' => dependencies_steps},

--- a/app/models/stack.rb
+++ b/app/models/stack.rb
@@ -107,6 +107,13 @@ class Stack < ActiveRecord::Base
     end
   end
 
+  def filter_statuses(statuses)
+    hidden_statuses = cached_deploy_spec.try!(:hidden_statuses)
+    return statuses if hidden_statuses.blank?
+
+    statuses.reject { |s| hidden_statuses.include?(s.context) }
+  end
+
   def deployable?
     !locked? && !deploying?
   end

--- a/test/models/commits_test.rb
+++ b/test/models/commits_test.rb
@@ -205,7 +205,7 @@ class CommitsTest < ActiveSupport::TestCase
   end
 
   test "#state is `unknown` by default" do
-    assert_equal 'unknown', Commit.new.state
+    assert_equal 'unknown', @stack.commits.new.state
   end
 
   test "#state is `success` if all most recent the statuses are `success`" do
@@ -218,6 +218,18 @@ class CommitsTest < ActiveSupport::TestCase
 
   test "#state is `pending` one of the most recent the statuses is `pending` and none is `failure` or `error`" do
     assert_equal 'pending', commits(:fourth).state
+  end
+
+  test "#last_statuses returns the list of the most recent status of each context" do
+    assert_equal 4, commits(:second).statuses.count
+    assert_equal 2, commits(:second).last_statuses.count
+  end
+
+  test "#last_statuses rejects the statuses that are specified in the deploy spec's `ci.hide`" do
+    commit = commits(:second)
+    assert_equal 2, commit.last_statuses.count
+    commit.stack.update!(cached_deploy_spec: DeploySpec.new('ci' => {'hide' => 'metrics/coveralls'}))
+    assert_equal 1, commits(:second).last_statuses.count
   end
 
   test "#deployable? is true if commit status is 'success'" do

--- a/test/unit/deploy_spec_test.rb
+++ b/test/unit/deploy_spec_test.rb
@@ -202,6 +202,7 @@ class DeploySpecTest < ActiveSupport::TestCase
     assert_instance_of DeploySpec::FileSystem, @spec
     assert_instance_of DeploySpec, @spec.cacheable
     config = {
+      'ci' => {'hide' => []},
       'machine' => {'environment' => {}, 'directory' => nil},
       'review' => {'checklist' => []},
       'dependencies' => {'override' => []},
@@ -252,5 +253,19 @@ class DeploySpecTest < ActiveSupport::TestCase
 
   test "#review_monitoring returns an empty array if the section is missing" do
     assert_equal [], @spec.review_monitoring
+  end
+
+  test "#hidden_statuses is empty by default" do
+    assert_equal [], @spec.hidden_statuses
+  end
+
+  test "#hidden_statuses is an array even if the value is a string" do
+    @spec.expects(:load_config).returns('ci' => {'hide' => 'ci/circleci'})
+    assert_equal %w(ci/circleci), @spec.hidden_statuses
+  end
+
+  test "#hidden_statuses is an array even if the value is present" do
+    @spec.expects(:load_config).returns('ci' => {'hide' => %w(ci/circleci ci/jenkins)})
+    assert_equal %w(ci/circleci ci/jenkins), @spec.hidden_statuses
   end
 end


### PR DESCRIPTION
Sometimes you have a CI reporting statuses on commits, but you don't care about that specific CI for shipping. This PR allows you to hide it from the Shipit UI from the `shipit.yml`.

Example of `shipit.yml`

```yaml
ci:
  hide:
    - ci/circleci
```

The usual downside apply: This directive will only take effect once the commit containing the `shipit.yml` change will be shipped in production.

@rafaelfranca @gmalette @davidcornu for review please.

cc @xthexder 