### PR TITLE
Prevent fetch deployed revision during rollbacks

### DIFF
--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -186,6 +186,11 @@ class StacksTest < ActiveSupport::TestCase
     assert @stack.deploying?
   end
 
+  test "#deploying? is true if a rollback is ongoing" do
+    deploys(:shipit_complete).trigger_rollback(AnonymousUser.new)
+    assert @stack.deploying?
+  end
+
   test "#deploying? is memoized" do
     assert_queries(1) do
       10.times { @stack.deploying? }


### PR DESCRIPTION
cc @eapache since IIRC you reported this bug a while ago.

I finally figured it out. We have this STI hierarchy: `Task -> Deploy -> Rollback`.

But `has_many :deploys` was selecting only the `Deploy` instances.

@rafaelfranca you may know a better way to express this?

@gmalette @davidcornu for review please.