### PR TITLE
Mark stacks as inaccessible if GitHub returns 404

### DIFF
--- a/app/models/stack.rb
+++ b/app/models/stack.rb
@@ -244,6 +244,14 @@ class Stack < ActiveRecord::Base
     Rails.cache.write(ci_enabled_cache_key, true)
   end
 
+  def mark_as_inaccessible!
+    update!(inaccessible_since: Time.now) unless inaccessible?
+  end
+
+  def inaccessible?
+    inaccessible_since?
+  end
+
   private
 
   def clear_cache

--- a/app/views/stacks/show.html.erb
+++ b/app/views/stacks/show.html.erb
@@ -17,6 +17,21 @@
   </div>
 <% end %>
 
+<% if @stack.inaccessible? %>
+  <div class="banner banner--red">
+    <div class="banner__inner wrapper">
+      <div class="banner__content">
+        <h2 class="banner__title">This repository seems to be missing!</h2>
+        <p class="banner__text">
+          Since <%= time_ago_in_words(@stack.inaccessible_since) %>
+          <%= link_to @stack.github_repo_name, github_repo_url(@stack.repo_owner, @stack.repo_name) %> is inaccessible.
+          This could be a permission issue, or the repository have been deleted on GitHub.
+        </p>
+      </div>
+    </div>
+  </div>
+<% end %>
+
 <% if @stack.locked? %>
   <div class="banner banner--orange">
     <div class="banner__inner wrapper">

--- a/db/migrate/20150630154640_add_inaccessible_since_to_stacks.rb
+++ b/db/migrate/20150630154640_add_inaccessible_since_to_stacks.rb
@@ -1,0 +1,5 @@
+class AddInaccessibleSinceToStacks < ActiveRecord::Migration
+  def change
+    add_column :stacks, :inaccessible_since, :datetime, default: nil
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150518214944) do
+ActiveRecord::Schema.define(version: 20150630171127) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text     "permissions", limit: 65535
@@ -121,6 +121,7 @@ ActiveRecord::Schema.define(version: 20150518214944) do
     t.text     "cached_deploy_spec",       limit: 65535
     t.integer  "lock_author_id",           limit: 4
     t.boolean  "ignore_ci"
+    t.datetime "inaccessible_since"
   end
 
   add_index "stacks", ["repo_owner", "repo_name", "environment"], name: "stack_unicity", unique: true, using: :btree

--- a/test/jobs/github_sync_job_test.rb
+++ b/test/jobs/github_sync_job_test.rb
@@ -48,4 +48,11 @@ class GithubSyncJobTest < ActiveSupport::TestCase
     assert_equal first, parent
     assert_equal [last], commits
   end
+
+  test "if GitHub returns a 404, the stacks is marked as inaccessible" do
+    @job.expects(:fetch_missing_commits).raises(Octokit::NotFound)
+    @job.perform(stack_id: @stack.id)
+
+    assert_equal true, @stack.reload.inaccessible_since?
+  end
 end


### PR DESCRIPTION
Fix: #318 

This isn't really the final solution, but it's more like a first step. There might be other places to handle 404, and we could leverage this column to bail out from some calls. I'll keep and eyes on exceptions and followups as needed.

@gmalette @davidcornu for review please.