### PR TITLE
Update the cached deploy spec on every pushes

### DIFF
--- a/app/jobs/cache_deploy_spec_job.rb
+++ b/app/jobs/cache_deploy_spec_job.rb
@@ -1,0 +1,10 @@
+class CacheDeploySpecJob < BackgroundJob
+  include BackgroundJob::Unique
+
+  def perform(stack)
+    commands = Commands.for(stack)
+    commands.with_temporary_working_directory(commit: stack.commits.last) do |path|
+      stack.update!(cached_deploy_spec: DeploySpec::FileSystem.new(path, stack.environment))
+    end
+  end
+end

--- a/app/jobs/github_sync_job.rb
+++ b/app/jobs/github_sync_job.rb
@@ -20,6 +20,7 @@ class GithubSyncJob < BackgroundJob
         end
       end
     end
+    CacheDeploySpecJob.perform_later(@stack)
   end
 
   def fetch_missing_commits(&block)

--- a/app/jobs/perform_task_job.rb
+++ b/app/jobs/perform_task_job.rb
@@ -16,8 +16,6 @@ class PerformTaskJob < BackgroundJob
     end
     capture commands.checkout(@task.until_commit)
 
-    record_deploy_spec!
-
     Bundler.with_clean_env do
       capture_all commands.install_dependencies
       capture_all commands.perform
@@ -45,9 +43,5 @@ class PerformTaskJob < BackgroundJob
       @task.write(line)
     end
     @task.write("\n")
-  end
-
-  def record_deploy_spec!
-    @task.stack.update(cached_deploy_spec: @task.spec)
   end
 end

--- a/test/jobs/cache_deploy_spec_job_test.rb
+++ b/test/jobs/cache_deploy_spec_job_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+require 'tmpdir'
+
+class CacheDeploySpecJobTest < ActiveSupport::TestCase
+  setup do
+    @stack = stacks(:shipit)
+    @last_commit = commits(:fifth)
+    @job = CacheDeploySpecJob.new
+  end
+
+  test "#perform checkout the repository to the last recorded commit and cache the deploy spec" do
+    @stack.update!(cached_deploy_spec: DeploySpec.new('review' => {'checklist' => %w(foo bar)}))
+
+    dir = Pathname(Dir.tmpdir)
+    StackCommands.any_instance.expects(:with_temporary_working_directory).with(commit: @last_commit).yields(dir)
+
+    assert_equal %w(foo bar), @stack.checklist
+    @job.perform(@stack)
+    assert_equal [], @stack.reload.checklist
+  end
+end

--- a/test/jobs/github_sync_job_test.rb
+++ b/test/jobs/github_sync_job_test.rb
@@ -13,6 +13,15 @@ class GithubSyncJobTest < ActiveSupport::TestCase
     @job.perform(stack_id: @stack.id)
   end
 
+  test "#perform finally enqueue a CacheDeploySpecJob" do
+    Stack.any_instance.stubs(:github_commits).returns(@github_commits)
+    @job.stubs(:fetch_missing_commits).yields.returns([[], nil])
+
+    assert_enqueued_with(job: CacheDeploySpecJob, args: [@stack]) do
+      @job.perform(stack_id: @stack.id)
+    end
+  end
+
   test "#perform mark all childs of the common parent as detached" do
     Stack.any_instance.expects(:github_commits).returns(@github_commits)
     @job.expects(:fetch_missing_commits).yields.returns([[], commits(:third)])


### PR DESCRIPTION
As discussed offline, the current situation where you need to deploy to update the cached deploy spec (the one that defines custom tasks, rollback ability, review elements, hidden ci status, etc), is just a relic of previous technical limitations. It has no reasons to still exist.

This PR update the cache everytime a new commit is received.

@gmalette @davidcornu for review please.