### PR TITLE
Implement an API to trigger custom tasks

### DIFF
--- a/app/controllers/api/base_controller.rb
+++ b/app/controllers/api/base_controller.rb
@@ -6,6 +6,7 @@ module Api
     include Paginable
 
     rescue_from ApiClient::InsufficientPermission, with: :insufficient_permission
+    rescue_from TaskDefinition::NotFound, with: :not_found
 
     class << self
       def require_permission(operation, scope, options = {})
@@ -56,6 +57,10 @@ module Api
 
     def insufficient_permission(error)
       render status: :forbidden, json: {message: error.message}
+    end
+
+    def not_found(_error)
+      render status: :not_found, json: {status: '404', error: 'Not Found'}
     end
   end
 end

--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -1,6 +1,7 @@
 module Api
   class TasksController < BaseController
     require_permission :read, :stack
+    require_permission :deploy, :stack, only: :trigger
 
     def index
       render_resources stack.tasks
@@ -8,6 +9,10 @@ module Api
 
     def show
       render_resource stack.tasks.find(params[:id])
+    end
+
+    def trigger
+      render_resource stack.trigger_task(params[:task_name], current_user), status: :accepted
     end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,6 +84,7 @@ Shipit::Engine.routes.draw do
         resource :output, only: :show
       end
       resources :deploys, only: %i(create)
+      post '/task/:task_name' => 'tasks#trigger', as: :trigger_task
       resources :hooks, only: %i(index create show update destroy)
     end
 

--- a/test/controllers/api/tasks_controller_test.rb
+++ b/test/controllers/api/tasks_controller_test.rb
@@ -13,4 +13,24 @@ class Api::TasksControllerTest < ActionController::TestCase
     assert_response :ok
     assert_json '0.id', task.id
   end
+
+  test "#show returns a task" do
+    task = @stack.tasks.last
+
+    get :show, stack_id: @stack.to_param, id: task.id
+    assert_response :ok
+    assert_json 'id', task.id
+  end
+
+  test "#trigger triggers a custom task" do
+    post :trigger, stack_id: @stack.to_param, task_name: 'restart'
+    assert_response :accepted
+    assert_json 'type', 'task'
+    assert_json 'status', 'pending'
+  end
+
+  test "#trigger returns a 404 when the task doesn't exist" do
+    post :trigger, stack_id: @stack.to_param, task_name: 'doesnt_exist'
+    assert_response :not_found
+  end
 end


### PR DESCRIPTION
Part of: https://github.com/Shopify/shipit-engine/issues/363

Requested by @dwradcliffe 

Endpoint `POST /api/stacks/:organization/:repository/:environment/task/:task_name`

 e.g: `POST /api/shopify/shipit/production/task/restart`.

@gmalette @davidcornu @dwradcliffe for review please.