### PR TITLE
Implement an "Abort and Rollback" button on deploy log

### DIFF
--- a/app/assets/images/aborted.svg
+++ b/app/assets/images/aborted.svg
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg width="16px" height="16px" viewBox="0 0 16 16" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
+    <defs></defs>
+    <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
+        <g transform="translate(1.000000, 1.000000)" stroke-width="2" stroke="#EDAA4E">
+            <path d="M0,0 L14,14"></path>
+            <path d="M14,0 L0,14"></path>
+        </g>
+    </g>
+</svg>

--- a/app/assets/images/aborting.svg
+++ b/app/assets/images/aborting.svg
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 17.0.2, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<!DOCTYPE svg PUBLIC "-//W3C//DTD SVG 1.1//EN" "http://www.w3.org/Graphics/SVG/1.1/DTD/svg11.dtd">
+<svg version="1.1" id="Layer_1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px"
+	 width="21.164px" height="16.962px" viewBox="0 0 21.164 16.962" enable-background="new 0 0 21.164 16.962" xml:space="preserve">
+<g>
+	<path fill="#EDAA4E" d="M10.558,2c2.486,0,4.644,1.481,5.737,3.481h-2.629l3.749,3.492l3.749-3.492h-2.679
+		C17.261,2.481,14.18,0,10.558,0C6.921,0,3.827,2.269,2.613,5.481h2.184C5.884,3.404,8.056,2,10.558,2z"/>
+	<path fill="#EDAA4E" d="M10.558,14.962c-2.486,0-4.645-1.481-5.738-3.481h2.677L3.749,7.989L0,11.481h2.631
+		c1.224,3,4.305,5.481,7.927,5.481c3.637,0,6.731-2.269,7.945-5.481h-2.184C15.232,13.558,13.06,14.962,10.558,14.962z"/>
+</g>
+</svg>

--- a/app/assets/javascripts/shipit/deploy.js.coffee
+++ b/app/assets/javascripts/shipit/deploy.js.coffee
@@ -1,7 +1,37 @@
-$(document).on 'click', '.deploy-abort .deploy-action', (event) ->
-  event.preventDefault()
-  $target = $(event.currentTarget)
-  return if $target.hasClass('pending')
-  $target.addClass('pending')
-  enable = -> $target.removeClass('pending')
-  $.post($target.attr('href')).done(-> setTimeout(enable, 3000))
+class AbortButton
+  SELECTOR = '[data-action="abort"]'
+
+  @listen: ->
+    $(document).on('click', SELECTOR, @handle)
+
+  @handle: (event) =>
+    event.preventDefault()
+    button = new this($(event.currentTarget))
+    button.trigger()
+
+  constructor: (@$button) ->
+    @url = @$button.find('a[href]').attr('href')
+    @shouldRollback = @$button.data('rollback')
+
+  trigger: ->
+    return false if @isDisabled()
+
+    @disable()
+    @waitForCompletion()
+    $.post(@url).success(@waitForCompletion).error(@reenable)
+
+  waitForCompletion: =>
+    setTimeout(@reenable, 3000)
+
+  reenable: =>
+    @$button.removeClass('pending')
+    @$button.siblings(SELECTOR).removeClass('disabled')
+
+  disable: ->
+    @$button.addClass('pending')
+    @$button.siblings(SELECTOR).addClass('disabled')
+
+  isDisabled: ->
+    @$button.hasClass('pending') || @$button.hasClass('disabled')
+
+AbortButton.listen()

--- a/app/assets/javascripts/task.js.coffee
+++ b/app/assets/javascripts/task.js.coffee
@@ -4,8 +4,11 @@
 @OutputStream = new Stream
 
 jQuery ->
-  OutputStream.addEventListener 'status', (status) ->
+  OutputStream.addEventListener 'status', (status, response) ->
     $('[data-status]').attr('data-status', status)
+
+    if status == 'aborted' && response.rollback_url
+      window.location = response.rollback_url
 
   tty = new TTY($('body'))
   OutputStream.addEventListener('chunk', tty.appendChunk)

--- a/app/assets/javascripts/task/stream.js.coffee
+++ b/app/assets/javascripts/task/stream.js.coffee
@@ -35,20 +35,20 @@ class @Stream
 
   success: (response) =>
     @retries = 0
-    @broadcastOutput(response.output)
-    @broadcastStatus(response.status)
+    @broadcastOutput(response.output, response)
+    @broadcastStatus(response.status, response)
     @start(response.url || false)
 
-  broadcastStatus: (status) ->
+  broadcastStatus: (status, args...) ->
     if status != @status
       @status = status
       for handler in @listeners('status')
-        handler(status)
+        handler(status, args...)
 
-  broadcastOutput: (raw) ->
+  broadcastOutput: (raw, args...) ->
     chunk = new Chunk(raw)
     for handler in @listeners('chunk')
-      handler(chunk)
+      handler(chunk, args...)
 
   error: (response) =>
     @start() if 600 > response.status >= 500 && (@retries += 1) < MAX_RETRIES

--- a/app/assets/stylesheets/_base/_banner.scss
+++ b/app/assets/stylesheets/_base/_banner.scss
@@ -58,13 +58,13 @@
 // -----------------------------------------------------------------------------
 
 .banner--orange {
-  background: #EDAA4E;
+  background: $orange;
 }
 
-.banner--grey {
-  background: #96A9BA;
+.banner--blue {
+  background: $banner-blue;
 }
 
 .banner--red {
-  background: #EE6A6A;
+  background: $banner-red;
 }

--- a/app/assets/stylesheets/_base/_base.scss
+++ b/app/assets/stylesheets/_base/_base.scss
@@ -2,15 +2,6 @@
 // BASE
 // =============================================================================
 
-$blue: #248af2;
-$green: #25C351;
-$red: #f39494;
-$bright-red: #F73B3B;
-$light-red: lighten($bright-red, 10%);
-$yellow: #FFC66C;
-$dark_yellow: #cea61b;
-$slate: #2e343a;
-$terminal-black: #272c30;
 $border-radius: 4px;
 
 @mixin clearfix {

--- a/app/assets/stylesheets/_base/_colors.scss
+++ b/app/assets/stylesheets/_base/_colors.scss
@@ -1,0 +1,16 @@
+// =============================================================================
+// COLORS
+// =============================================================================
+
+$orange: #EDAA4E;
+$banner-blue: #96A9BA;
+$banner-red: #EE6A6A;
+$blue: #248AF2;
+$green: #25C351;
+$red: #F39494;
+$bright-red: #F73B3B;
+$light-red: lighten($bright-red, 10%);
+$yellow: #FFC66C;
+$dark_yellow: #CEA61B;
+$slate: #2E343A;
+$terminal-black: #272C30;

--- a/app/assets/stylesheets/_pages/_commits.scss
+++ b/app/assets/stylesheets/_pages/_commits.scss
@@ -180,6 +180,26 @@
   }
 }
 
+
+.status--aborting,
+[data-deploy-status='aborting'] {
+  border-color: $orange;
+
+  .status__icon {
+    background-image: asset-data-url("aborting.svg");
+    animation: rotate 2s linear infinite;
+  }
+}
+
+.status--aborted,
+[data-deploy-status='aborted'] {
+  border-color: $orange;
+
+  .status__icon {
+    background-image: asset-data-url("aborted.svg");
+  }
+}
+
 .status--success,
 [data-deploy-status='success'] {
   border-color: $green;

--- a/app/assets/stylesheets/_pages/_deploy.scss
+++ b/app/assets/stylesheets/_pages/_deploy.scss
@@ -24,21 +24,40 @@
 }
 
 .deploy-abort {
-  margin-left: 100px;
+  margin-left: 1rem;
+  &.first {
+    margin-left: 4rem;
+  }
+
   display: none;
-  &[data-status="running"] { display: inline-block; }
+  &[data-status="running"], &[data-status="aborting"] { display: inline-block; }
 
   text-align: center;
+
   .deploy-action {
     text-align: center;
     display: block;
-    &.pending {
-      .ready { display: none; }
-      .disabled { display: inline; }
-    }
-    .ready { display: inline; }
-    .disabled { display: none; }
   }
+
+  .caption--pending {
+    display: none;
+  }
+
+  &.disabled .deploy-action {
+    background-color: $light-red;
+  }
+
+  &.pending {
+    .deploy-action {
+      cursor: default;
+    }
+    .caption--ready {
+      display: none;
+    }
+    .caption--pending {
+      display: inline;
+    }
+  } 
 }
 
 .deploy-banner {
@@ -53,7 +72,8 @@
       width: 100%;
     }
 
-    &[data-status="running"]:before {
+    &[data-status="running"]:before,
+    &[data-status="aborting"]:before {
       content: "";
       background-color: $blue;
       bottom: 0;

--- a/app/assets/stylesheets/shipit.scss
+++ b/app/assets/stylesheets/shipit.scss
@@ -1,6 +1,7 @@
 //= require 'ansi_stream'
 @import "_base/_media-queries";
 @import "_base/_utility";
+@import "_base/_colors";
 @import "_base/_base";
 @import "_base/_forms";
 @import "_base/_buttons";

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,5 +1,4 @@
 class TasksController < ShipitController
-  include ChunksHelper
   include Pagination
 
   before_action :stack
@@ -27,17 +26,12 @@ class TasksController < ShipitController
   end
 
   def abort
-    task.abort!
+    task.abort!(rollback_once_aborted: params[:rollback].present?)
     head :ok
   end
 
   def tail
-    output = task.chunks.tail(params[:last_id]).pluck(:text).join
-    render json: {
-      url: next_chunks_url(task),
-      status: task.status,
-      output: output,
-    }
+    render json: TailTaskSerializer.new(task, context: params)
   end
 
   private

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -4,6 +4,7 @@ class Deploy < Task
   state_machine :status do
     after_transition to: :success, do: :schedule_continuous_delivery
     after_transition to: :success, do: :update_undeployed_commits_count
+    after_transition to: :aborted, do: :trigger_revert_if_required
   end
 
   before_create :denormalize_commit_stats
@@ -21,7 +22,8 @@ class Deploy < Task
     )
   end
 
-  def trigger_rollback(user)
+  # Rolls the stack back to this deploy
+  def trigger_rollback(user = AnonymousUser.new)
     rollback = build_rollback(user)
     rollback.save!
     rollback.enqueue
@@ -33,6 +35,22 @@ class Deploy < Task
     rollback
   end
 
+  # Rolls the stack back to the **previous** deploy
+  def trigger_revert
+    rollback = Rollback.create!(
+      user_id: user_id,
+      stack_id: stack_id,
+      parent_id: id,
+      since_commit: until_commit,
+      until_commit: since_commit,
+    )
+    rollback.enqueue
+    lock_reason = "A rollback for #{until_commit.sha} has been triggered. " \
+      "Please make sure the reason for the rollback has been addressed before deploying again."
+    stack.update!(lock_reason: lock_reason, lock_author_id: user_id)
+    rollback
+  end
+
   def rollback?
     false
   end
@@ -41,8 +59,14 @@ class Deploy < Task
     [since_commit, until_commit]
   end
 
+  delegate :supports_rollback?, to: :stack
+
   def rollbackable?
-    stack.supports_rollback? && success? && until_commit_id != stack.last_deployed_commit.try!(:id)
+    success? && supports_rollback? && !currently_deployed?
+  end
+
+  def currently_deployed?
+    until_commit_id == stack.last_deployed_commit.try!(:id)
   end
 
   def commits
@@ -62,6 +86,12 @@ class Deploy < Task
   end
 
   private
+
+  def trigger_revert_if_required
+    return unless rollback_once_aborted?
+    return unless supports_rollback?
+    trigger_revert
+  end
 
   def default_since_commit_id
     return unless stack

--- a/app/models/rollback.rb
+++ b/app/models/rollback.rb
@@ -1,9 +1,15 @@
 class Rollback < Deploy
+  belongs_to :deploy, foreign_key: :parent_id
+
   def rollback?
     true
   end
 
   def rollbackable?
+    false
+  end
+
+  def supports_rollback?
     false
   end
 

--- a/app/models/stack.rb
+++ b/app/models/stack.rb
@@ -88,12 +88,8 @@ class Stack < ActiveRecord::Base
     :default
   end
 
-  def last_deploy
-    @last_deploy ||= deploys.last
-  end
-
   def last_successful_deploy
-    deploys.success.last
+    deploys_and_rollbacks.success.order(created_at: :desc).first
   end
 
   def last_deployed_commit

--- a/app/serializers/tail_task_serializer.rb
+++ b/app/serializers/tail_task_serializer.rb
@@ -1,0 +1,37 @@
+class TailTaskSerializer < ActiveModel::Serializer
+  include ChunksHelper
+  include ConditionalAttributes
+
+  attributes :url, :status, :output, :rollback_url
+
+  def url
+    return @url if defined? @url
+    @url = next_chunks_url(task)
+  end
+
+  def include_url?
+    !url.blank?
+  end
+
+  def output
+    task.chunks.tail(context[:last_id]).pluck(:text).join
+  end
+
+  def rollback_url
+    stack_deploy_path(stack, rollback)
+  end
+
+  def include_rollback_url?
+    !rollback.nil?
+  end
+
+  private
+
+  alias_method :task, :object
+  delegate :stack, to: :object
+
+  def rollback
+    return @rollback if defined? @rollback
+    @rollback = stack.rollbacks.where(parent_id: task.id).last
+  end
+end

--- a/app/views/layouts/shipit.html.erb
+++ b/app/views/layouts/shipit.html.erb
@@ -12,7 +12,7 @@
     <%= content_tag :div, msg, class: ["flash-#{name}", :flash] %>
   <% end %>
 
-  <div class="banner notification banner--grey hidden">
+  <div class="banner notification banner--blue hidden">
     <div class="banner__inner wrapper">
       <div class="banner__content">
         <h2 class="banner__title">Do you want to enable desktop notifications?</h2>

--- a/app/views/tasks/_task_output.html.erb
+++ b/app/views/tasks/_task_output.html.erb
@@ -14,12 +14,21 @@
         <%= content_for :task_title %>
       </span>
 
-      <span class="deploy-abort" data-status="<%= task.status %>">
+      <span class="deploy-abort first" data-action="abort" data-status="<%= task.status %>">
         <%= link_to abort_stack_task_path(@stack, task), class: 'btn btn--delete deploy-action' do %>
-        <span class="ready">Abort Deploy</span>
-        <span class="disabled">Aborting</span>
+          <span class="caption--ready">Abort Deploy</span>
+          <span class="caption--pending">Aborting...</span>
         <% end %>
       </span>
+
+      <% if task.supports_rollback? %>
+        <span class="deploy-abort" data-action="abort" data-rollback="true" data-status="<%= task.status %>">
+          <%= link_to abort_stack_task_path(@stack, task, rollback: true), class: 'btn btn--delete deploy-action' do %>
+            <span class="caption--ready">Abort Deploy and Rollback</span>
+            <span class="caption--pending">Aborting with Rollback...</span>
+          <% end %>
+        </span>
+      <% end %>
     </div>
   </div>
 

--- a/db/migrate/20150708143032_add_rollback_when_complete_on_task.rb
+++ b/db/migrate/20150708143032_add_rollback_when_complete_on_task.rb
@@ -1,0 +1,5 @@
+class AddRollbackWhenCompleteOnTask < ActiveRecord::Migration
+  def change
+    add_column :tasks, :rollback_once_aborted, :boolean, default: false, null: false
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150630171127) do
+ActiveRecord::Schema.define(version: 20150708143032) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text     "permissions", limit: 65535
@@ -139,20 +139,21 @@ ActiveRecord::Schema.define(version: 20150630171127) do
   add_index "statuses", ["commit_id"], name: "index_statuses_on_commit_id"
 
   create_table "tasks", force: :cascade do |t|
-    t.integer  "stack_id",        limit: 4,                         null: false
-    t.integer  "since_commit_id", limit: 4,                         null: false
-    t.integer  "until_commit_id", limit: 4,                         null: false
-    t.string   "status",          limit: 255,   default: "pending", null: false
+    t.integer  "stack_id",              limit: 4,                         null: false
+    t.integer  "since_commit_id",       limit: 4,                         null: false
+    t.integer  "until_commit_id",       limit: 4,                         null: false
+    t.string   "status",                limit: 255,   default: "pending", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.integer  "user_id",         limit: 4
-    t.boolean  "rolled_up",                     default: false,     null: false
-    t.string   "type",            limit: 255
-    t.integer  "parent_id",       limit: 4
-    t.integer  "additions",       limit: 4,     default: 0
-    t.integer  "deletions",       limit: 4,     default: 0
-    t.text     "definition",      limit: 65535
+    t.integer  "user_id",               limit: 4
+    t.boolean  "rolled_up",                           default: false,     null: false
+    t.string   "type",                  limit: 255
+    t.integer  "parent_id",             limit: 4
+    t.integer  "additions",             limit: 4,     default: 0
+    t.integer  "deletions",             limit: 4,     default: 0
+    t.text     "definition",            limit: 65535
     t.binary   "gzip_output"
+    t.boolean  "rollback_once_aborted",               default: false,     null: false
   end
 
   add_index "tasks", ["rolled_up", "created_at", "status"], name: "index_tasks_on_rolled_up_and_created_at_and_status"

--- a/test/fixtures/output_chunks.yml
+++ b/test/fixtures/output_chunks.yml
@@ -1,5 +1,3 @@
-# Read about fixtures at http://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
-
 shipit:
   task: shipit
   text: "deploy deploy deploy, faiiil"
@@ -22,4 +20,28 @@ shipit5:
 
 shipit6:
   task: shipit
+  text: "sudo chmod -R 777 /"
+
+shipit_running:
+  task: shipit_running
+  text: "deploy deploy deploy, faiiil"
+
+shipit_running:
+  task: shipit_running
+  text: "Migrating some stuff"
+
+shipit_running3:
+  task: shipit_running
+  text: "Compiling all the sass"
+
+shipit_running4:
+  task: shipit_running
+  text: "Making ops cry"
+
+shipit_running5:
+  task: shipit_running
+  text: "sudo rm -rf /"
+
+shipit_running6:
+  task: shipit_running
   text: "sudo chmod -R 777 /"

--- a/test/fixtures/stacks.yml
+++ b/test/fixtures/stacks.yml
@@ -5,7 +5,7 @@ shipit:
   branch: master
   ignore_ci: true
   tasks_count: 3
-  undeployed_commits_count: 3
+  undeployed_commits_count: 1
   cached_deploy_spec: >
     {
       "machine": {"environment": {}},

--- a/test/fixtures/tasks.yml
+++ b/test/fixtures/tasks.yml
@@ -7,6 +7,7 @@ shipit:
   status: success
   additions: 1
   deletions: 1
+  created_at: <%= (60 - 1).minutes.ago.to_s(:db) %>
 
 shipit2:
   user: walrus
@@ -17,6 +18,7 @@ shipit2:
   status: failed
   additions: 12
   deletions: 64
+  created_at: <%= (60 - 2).minutes.ago.to_s(:db) %>
 
 shipit_restart:
   user: walrus
@@ -34,6 +36,7 @@ shipit_restart:
         "cap $ENVIRONMENT deploy:restart"
       ]
     }
+  created_at: <%= (60 - 3).minutes.ago.to_s(:db) %>
 
 shipit_pending:
   since_commit_id: 2 # second
@@ -43,6 +46,7 @@ shipit_pending:
   status: pending
   additions: 432
   deletions: 406
+  created_at: <%= (60 - 4).minutes.ago.to_s(:db) %>
 
 shipit_running:
   user: walrus
@@ -53,6 +57,7 @@ shipit_running:
   status: running
   additions: 420
   deletions: 342
+  created_at: <%= (60 - 5).minutes.ago.to_s(:db) %>
 
 shipit_complete:
   user: bob
@@ -60,6 +65,31 @@ shipit_complete:
   until_commit_id: 4
   type: Deploy
   stack: shipit
-  status: complete
+  status: success
   additions: 420
   deletions: 342
+  created_at: <%= (60 - 6).minutes.ago.to_s(:db) %>
+
+shipit_aborted:
+  user: bob
+  since_commit_id: 3
+  until_commit_id: 4
+  type: Deploy
+  stack: shipit
+  status: aborted
+  additions: 420
+  deletions: 342
+  rollback_once_aborted: true
+  created_at: <%= (60 - 7).minutes.ago.to_s(:db) %>
+
+shipit_rollback:
+  user: bob
+  deploy: shipit_aborted
+  since_commit_id: 3
+  until_commit_id: 4
+  type: Rollback
+  stack: shipit
+  status: aborted
+  additions: 420
+  deletions: 342
+  created_at: <%= (60 - 8).minutes.ago.to_s(:db) %>

--- a/test/helpers/json_helper.rb
+++ b/test/helpers/json_helper.rb
@@ -10,6 +10,18 @@ module JSONHelper
     end
   end
 
+  def assert_json_keys(path, keys = nil)
+    keys, path = path, nil if keys.nil?
+
+    value = follow_path(path.to_s.split('.'))
+    case value
+    when Hash
+      assert_equal keys.sort, value.keys.sort
+    else
+      assert false, "Expected #{path} to be a Hash, was: #{value.inspect}"
+    end
+  end
+
   def assert_no_json(path)
     segments = path.to_s.split('.')
     last_segment = segments.pop

--- a/test/models/commits_test.rb
+++ b/test/models/commits_test.rb
@@ -164,7 +164,7 @@ class CommitsTest < ActiveSupport::TestCase
 
   test "#creating a commit update the undeployed_commits_count" do
     walrus = users(:walrus)
-    assert_equal 3, @stack.undeployed_commits_count
+    assert_equal 1, @stack.undeployed_commits_count
     @stack.commits.create(author: walrus,
                           committer: walrus,
                           sha: "ab12",
@@ -173,7 +173,7 @@ class CommitsTest < ActiveSupport::TestCase
                           message: "more fish!")
 
     @stack.reload
-    assert_equal 4, @stack.undeployed_commits_count
+    assert_equal 2, @stack.undeployed_commits_count
   end
 
   test "fetch_stats! pulls additions and deletions from github" do

--- a/test/models/rollbacks_test.rb
+++ b/test/models/rollbacks_test.rb
@@ -8,4 +8,12 @@ class RollbackTest < ActiveSupport::TestCase
   test "#rollback? returns true" do
     assert @rollback.rollback?
   end
+
+  test "#rollbackable? returns false" do
+    refute @rollback.rollbackable?
+  end
+
+  test "#supports_rollback? returns false" do
+    refute @rollback.supports_rollback?
+  end
 end

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -78,7 +78,7 @@ class StacksTest < ActiveSupport::TestCase
     deploy = @stack.trigger_deploy(last_commit, AnonymousUser.new)
     assert deploy.persisted?
     assert_equal last_commit.id, deploy.until_commit_id
-    assert_equal deploys(:shipit).until_commit_id, deploy.since_commit_id
+    assert_equal deploys(:shipit_complete).until_commit_id, deploy.since_commit_id
   end
 
   test "#trigger_deploy deploy until the commit passed in argument" do
@@ -88,9 +88,9 @@ class StacksTest < ActiveSupport::TestCase
   end
 
   test "#trigger_deploy since_commit is the last completed deploy until_commit if there is a previous deploy" do
-    last_commit = commits(:third)
+    last_commit = commits(:fifth)
     deploy = @stack.trigger_deploy(last_commit, AnonymousUser.new)
-    assert_equal deploys(:shipit).until_commit_id, deploy.since_commit_id
+    assert_equal deploys(:shipit_complete).until_commit_id, deploy.since_commit_id
   end
 
   test "#trigger_deploy since_commit is the first stack commit if there is no previous deploy" do
@@ -125,11 +125,11 @@ class StacksTest < ActiveSupport::TestCase
   test "#update_deployed_revision create a new completed deploy" do
     Deploy.active.update_all(status: 'error')
 
-    assert_equal commits(:second), @stack.last_deployed_commit
+    assert_equal commits(:fourth), @stack.last_deployed_commit
     assert_difference 'Deploy.count', +1 do
       deploy = @stack.update_deployed_revision(commits(:fifth).sha)
       assert_not_nil deploy
-      assert_equal commits(:second), deploy.since_commit
+      assert_equal commits(:fourth), deploy.since_commit
       assert_equal commits(:fifth), deploy.until_commit
     end
     assert_equal commits(:fifth), @stack.last_deployed_commit
@@ -138,11 +138,11 @@ class StacksTest < ActiveSupport::TestCase
   test "#update_deployed_revision works with short shas" do
     Deploy.active.update_all(status: 'error')
 
-    assert_equal commits(:second), @stack.last_deployed_commit
+    assert_equal commits(:fourth), @stack.last_deployed_commit
     assert_difference 'Deploy.count', +1 do
       deploy = @stack.update_deployed_revision(commits(:fifth).sha[0..5])
       assert_not_nil deploy
-      assert_equal commits(:second), deploy.since_commit
+      assert_equal commits(:fourth), deploy.since_commit
       assert_equal commits(:fifth), deploy.until_commit
     end
     assert_equal commits(:fifth), @stack.last_deployed_commit

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -38,6 +38,7 @@ class ActiveSupport::TestCase
 
   setup do
     @routes = Shipit::Engine.routes
+    Process.stubs(:kill)
   end
 
   teardown do


### PR DESCRIPTION
Fix #449 

### Workflow

  - When a deploy is running and the stack supports rollbacks, the "Abort and Rollback Deploy" button is visible.
  - Clicking it trigger the abort just like the old button, but also flip a flag
  - Once the deploy successfuly aborted, a rollback is triggered
  - The output polling endpoint then include a link to the newly triggered rollback
  - The user is redirected to the rollback's output

### What it looks like: 

The button in the deploy header:
![capture d ecran 2015-07-08 a 13 56 10](https://cloud.githubusercontent.com/assets/44640/8577804/21d17d6e-2579-11e5-8770-26e1464e4b9c.png)


The 2 new states in the deploys list (the first one is `aborting`, the other is `aborted`):
![capture d ecran 2015-07-08 a 13 47 15](https://cloud.githubusercontent.com/assets/44640/8577786/0591ee04-2579-11e5-996e-0de8d035512b.png)

@gmalette @davidcornu @rafaelfranca for review please. As well as @KnVerey for the UX part.

I did my best in term of design, but it could be improved I guess...