### PR TITLE
Fix width of sticky version of banner

### DIFF
--- a/app/assets/stylesheets/_pages/_deploy.scss
+++ b/app/assets/stylesheets/_pages/_deploy.scss
@@ -60,7 +60,8 @@
   &.sticky {
     position: fixed;
     top: 0;
-    width: 100%;
+    left: 0;
+    right: 0;
   }
 
   &[data-status="running"]:before,
@@ -101,6 +102,11 @@
 
 .sidebar.enabled + .deploy-main {
   margin-left: 300px;
+
+  .deploy-banner.sticky {
+    box-sizing: border-box;
+    margin-left: 300px;
+  }
 }
 
 .sidebar {


### PR DESCRIPTION
@byroot I missed testing the change I made yesterday with the sidebar enabled and the output long enough to make the heading sticky. This fixes it.

### Before
![](http://take.ms/CRRbM)

### After
![](http://take.ms/Csyae)