### PR TITLE
Fix rails version in gemspec

### DIFF
--- a/shipit-engine.gemspec
+++ b/shipit-engine.gemspec
@@ -16,7 +16,7 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.rdoc"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency 'rails', '~> 4.2.2'
+  s.add_dependency 'rails', '~> 4.2.0'
   s.add_dependency 'securecompare', '~> 1.0.0'
   s.add_dependency 'validate_url', '~> 1.0.0'
   s.add_dependency 'explicit-parameters', '~> 0.0.3'


### PR DESCRIPTION
Changes the rails version so 4.2.0 and 4.2.1 can be used