### PR TITLE
Use ActiveJob for BackgroundJob::Unique lock key serialization

### DIFF
--- a/app/jobs/background_job/unique.rb
+++ b/app/jobs/background_job/unique.rb
@@ -20,14 +20,7 @@ class BackgroundJob
     end
 
     def lock_key(*args)
-      ([self.class.name] + args).map { |arg| hash_argument(arg) }.join('-')
-    end
-
-    private
-
-    def hash_argument(argument)
-      return argument.to_global_id.to_s if argument.respond_to?(:to_global_id)
-      argument.to_s
+      ActiveJob::Arguments.serialize([self.class.name] + args).join('-')
     end
   end
 end

--- a/test/jobs/unique_job_test.rb
+++ b/test/jobs/unique_job_test.rb
@@ -14,4 +14,10 @@ class UniqueJobTest < ActiveSupport::TestCase
     end
     assert called
   end
+
+  test "the lock key is serialized" do
+    task = tasks(:shipit_restart)
+    job = ChunkRollupJob.new(task)
+    assert_equal %(ChunkRollupJob-{"_aj_globalid"=>"gid://shipit/Task/#{task.id}"}), job.lock_key(*job.arguments)
+  end
 end


### PR DESCRIPTION
[`ActiveJob::Arguments.serialize`](http://api.rubyonrails.org/v4.2.3/classes/ActiveJob/Arguments.html#method-i-serialize) can take care of serializing using `to_global_id` when possible for us.
~~No tests, sorry~~ Added a test

It changes slightly the lock key:
```patch
-"ChunkRollupJob-gid://shipit/Task/783434608"
+"ChunkRollupJob-{\"_aj_globalid\"=>\"gid://shipit/Task/783434608\"}"
```