### PR TITLE
Add ci.allow_failures to shipit.yml

### DIFF
--- a/app/helpers/stacks_helper.rb
+++ b/app/helpers/stacks_helper.rb
@@ -59,7 +59,7 @@ module StacksHelper
     if statuses.size == 1
       render statuses.first
     else
-      render StatusGroup.new(commit.significant_status, statuses)
+      render StatusGroup.new(commit)
     end
   end
 end

--- a/app/helpers/stacks_helper.rb
+++ b/app/helpers/stacks_helper.rb
@@ -55,11 +55,11 @@ module StacksHelper
   end
 
   def render_status(commit)
-    statuses = commit.last_statuses
+    statuses = commit.visible_statuses
     if statuses.size == 1
       render statuses.first
     else
-      render StatusGroup.new(statuses)
+      render StatusGroup.new(commit.significant_status, statuses)
     end
   end
 end

--- a/app/models/deploy_spec.rb
+++ b/app/models/deploy_spec.rb
@@ -97,6 +97,10 @@ class DeploySpec
     Array.wrap(config('ci', 'hide'))
   end
 
+  def soft_failing_statuses
+    Array.wrap(config('ci', 'allow_failures'))
+  end
+
   def review_checks
     config('review', 'checks') || []
   end

--- a/app/models/deploy_spec/file_system.rb
+++ b/app/models/deploy_spec/file_system.rb
@@ -18,7 +18,7 @@ class DeploySpec
 
     def cacheable_config
       (config || {}).deep_merge(
-        'ci' => {'hide' => hidden_statuses},
+        'ci' => {'hide' => hidden_statuses, 'allow_failures' => soft_failing_statuses},
         'machine' => {'environment' => machine_env, 'directory' => directory},
         'review' => {
           'checklist' => review_checklist,

--- a/app/models/stack.rb
+++ b/app/models/stack.rb
@@ -100,9 +100,12 @@ class Stack < ActiveRecord::Base
     end
   end
 
-  def filter_statuses(statuses)
-    hidden_statuses = cached_deploy_spec.hidden_statuses
+  def filter_visible_statuses(statuses)
     statuses.reject { |s| hidden_statuses.include?(s.context) }
+  end
+
+  def filter_meaningful_statuses(statuses)
+    filter_visible_statuses(statuses).reject { |s| soft_failing_statuses.include?(s.context) }
   end
 
   def deployable?
@@ -189,7 +192,7 @@ class Stack < ActiveRecord::Base
     ).first!
   end
 
-  delegate :task_definitions, to: :cached_deploy_spec
+  delegate :task_definitions, :hidden_statuses, :soft_failing_statuses, to: :cached_deploy_spec
 
   def monitoring?
     monitoring.present?

--- a/app/models/status_group.rb
+++ b/app/models/status_group.rb
@@ -3,15 +3,15 @@ class StatusGroup
 
   attr_reader :statuses, :significant_status
 
-  def initialize(significant_status, statuses)
-    @significant_status = significant_status
-    @statuses = statuses
+  def initialize(commit)
+    @significant_status = commit.significant_status
+    @statuses = commit.visible_statuses
   end
 
   delegate :state, to: :significant_status
 
   def description
-    "#{success_count} / #{sstatuses.count} checks OK"
+    "#{success_count} / #{statuses.count} checks OK"
   end
 
   def target_url

--- a/app/models/status_group.rb
+++ b/app/models/status_group.rb
@@ -1,23 +1,20 @@
 class StatusGroup
   STATES_PRIORITY = %w(failure error pending success).freeze
 
-  attr_reader :statuses
+  attr_reader :statuses, :significant_status
 
-  def initialize(statuses)
+  def initialize(significant_status, statuses)
+    @significant_status = significant_status
     @statuses = statuses
   end
 
-  delegate :state, to: :main_status
+  delegate :state, to: :significant_status
 
   def description
-    "#{success_count} / #{@statuses.count} checks OK"
+    "#{success_count} / #{sstatuses.count} checks OK"
   end
 
   def target_url
-  end
-
-  def main_status
-    @main_status ||= find_main_status
   end
 
   def to_partial_path
@@ -29,14 +26,6 @@ class StatusGroup
   end
 
   private
-
-  def find_main_status
-    STATES_PRIORITY.each do |state|
-      status = @statuses.find { |s| s.state == state }
-      return status if status
-    end
-    fail "No status found, this is not supposed to happen"
-  end
 
   def success_count
     @statuses.count { |s| s.state == 'success'.freeze }

--- a/test/models/status_group_test.rb
+++ b/test/models/status_group_test.rb
@@ -1,0 +1,24 @@
+require 'test_helper'
+
+class StatusGroupTest < ActiveSupport::TestCase
+  setup do
+    @commit = commits(:second)
+    @group = StatusGroup.new(@commit)
+  end
+
+  test "#description is a summary of the statuses" do
+    assert_equal '1 / 2 checks OK', @group.description
+  end
+
+  test "#group? returns true" do
+    assert_equal true, @group.group?
+  end
+
+  test "#target_url returns nil" do
+    assert_nil @group.target_url
+  end
+
+  test "#state is significant's status state" do
+    assert_equal @commit.significant_status.state, @group.state
+  end
+end

--- a/test/unit/deploy_spec_test.rb
+++ b/test/unit/deploy_spec_test.rb
@@ -202,7 +202,7 @@ class DeploySpecTest < ActiveSupport::TestCase
     assert_instance_of DeploySpec::FileSystem, @spec
     assert_instance_of DeploySpec, @spec.cacheable
     config = {
-      'ci' => {'hide' => []},
+      'ci' => {'hide' => [], 'allow_failures' => []},
       'machine' => {'environment' => {}, 'directory' => nil},
       'review' => {'checklist' => [], 'monitoring' => [], 'checks' => []},
       'dependencies' => {'override' => []},


### PR DESCRIPTION
It's a bit like `ci.hide` as it won't prevent deploy, but unlike `ci.hide` it will be visible in the UI.

It's useful if you want visibility on one of you CI but know it's likely to fail.

@gmalette @davidcornu @rafaelfranca for review

cc @arthurnn 