### PR TITLE
Fix nil significant-status

### DIFF
--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -161,7 +161,7 @@ class Commit < ActiveRecord::Base
 
   def significant_status
     statuses = meaningful_statuses
-    return nil if statuses.empty?
+    return UnknownStatus.new(self) if statuses.empty?
     return statuses.first if statuses.all?(&:success?)
     non_success_statuses = statuses.reject(&:success?)
     non_success_statuses.reject(&:pending?).first || non_success_statuses.first || UnknownStatus.new(self)

--- a/app/models/unknown_status.rb
+++ b/app/models/unknown_status.rb
@@ -1,10 +1,4 @@
-class UnknownStatus
-  attr_reader :commit
-
-  def initialize(commit)
-    @commit = commit
-  end
-
+UnknownStatus = Struct.new(:commit) do
   def state
     'unknown'
   end

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -293,6 +293,26 @@ class StacksTest < ActiveSupport::TestCase
     end
   end
 
+  test "#filter_visible_statuses removes statuses from hidden contexts" do
+    stack = stacks(:cyclimse)
+    stack.stubs(hidden_statuses: ['ci/hidden'])
+    commit1 = Status.new(state: 'pending', context: 'ci/valid')
+    commit2 = Status.new(state: 'pending', context: 'ci/valid')
+    hidden = Status.new(state: 'pending', context: 'ci/hidden')
+
+    assert_equal [commit1, commit2], stack.filter_visible_statuses([hidden, commit1, commit2])
+  end
+
+  test "#filter_meaningful_statuses removes statuses from soft-failing contexts" do
+    stack = stacks(:cyclimse)
+    stack.stubs(soft_failing_statuses: ['ci/soft-fail'])
+    commit1 = Status.new(state: 'pending', context: 'ci/valid')
+    commit2 = Status.new(state: 'pending', context: 'ci/valid')
+    soft_fail = Status.new(state: 'pending', context: 'ci/soft-fail')
+
+    assert_equal [commit1, commit2], stack.filter_meaningful_statuses([soft_fail, commit1, commit2])
+  end
+
   private
 
   def expect_hook(event, stack, payload)


### PR DESCRIPTION
This fixes the bug we had today where the commit had status but none significant, that caused Shipit to go down.

@davidcornu @camilo 