### PR TITLE
Define optional environment variables in shipit.yml

### DIFF
--- a/app/assets/stylesheets/_pages/_deploy.scss
+++ b/app/assets/stylesheets/_pages/_deploy.scss
@@ -9,6 +9,18 @@
   display: flex;
 }
 
+.environment-variables {
+  margin: 1rem 0;
+}
+
+.environment-variable {
+  input {
+    display: inline-block;
+    width: inherit;
+    margin-right: 1rem;
+  }
+}
+
 .deploy-checklist__item__label {
 
 }

--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -17,7 +17,7 @@ class DeploysController < ShipitController
   def create
     return redirect_to new_stack_deploy_path(@stack, sha: @until_commit.sha) if !params[:force] && @stack.deploying?
 
-    @deploy = @stack.trigger_deploy(@until_commit, current_user, deploy_params[:env])
+    @deploy = @stack.trigger_deploy(@until_commit, current_user, env: deploy_params[:env])
     respond_with(@deploy.stack, @deploy)
   end
 

--- a/app/controllers/deploys_controller.rb
+++ b/app/controllers/deploys_controller.rb
@@ -16,7 +16,8 @@ class DeploysController < ShipitController
 
   def create
     return redirect_to new_stack_deploy_path(@stack, sha: @until_commit.sha) if !params[:force] && @stack.deploying?
-    @deploy = @stack.trigger_deploy(@until_commit, current_user)
+
+    @deploy = @stack.trigger_deploy(@until_commit, current_user, deploy_params[:env])
     respond_with(@deploy.stack, @deploy)
   end
 
@@ -39,6 +40,6 @@ class DeploysController < ShipitController
   end
 
   def deploy_params
-    @deploy_params ||= params.require(:deploy).permit(:until_commit_id)
+    @deploy_params ||= params.require(:deploy).permit(:until_commit_id, env: @stack.deploy_variables.map(&:name))
   end
 end

--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -85,6 +85,10 @@ class Deploy < Task
     super || default_since_commit_id
   end
 
+  def variables
+    stack.deploy_variables
+  end
+
   private
 
   def trigger_revert_if_required

--- a/app/models/deploy_spec.rb
+++ b/app/models/deploy_spec.rb
@@ -61,6 +61,10 @@ class DeploySpec
     deploy_steps || cant_detect!(:deploy)
   end
 
+  def deploy_variables
+    Array.wrap(config('deploy', 'variables')).map(&VariableDefinition.method(:new))
+  end
+
   def rollback_steps
     config('rollback', 'override') || discover_rollback_steps
   end

--- a/app/models/deploy_spec/file_system.rb
+++ b/app/models/deploy_spec/file_system.rb
@@ -26,7 +26,7 @@ class DeploySpec
           'checks' => review_checks,
         },
         'dependencies' => {'override' => dependencies_steps},
-        'deploy' => {'override' => deploy_steps},
+        'deploy' => {'override' => deploy_steps, 'variables' => deploy_variables.map(&:to_h)},
         'rollback' => {'override' => rollback_steps},
         'fetch' => fetch_deployed_revision_steps,
         'tasks' => cacheable_tasks,

--- a/app/models/stack.rb
+++ b/app/models/stack.rb
@@ -48,13 +48,14 @@ class Stack < ActiveRecord::Base
     task
   end
 
-  def trigger_deploy(until_commit, user)
+  def trigger_deploy(until_commit, user, env = nil)
     since_commit = last_deployed_commit
 
     deploy = deploys.create(
       user_id: user.id,
       until_commit: until_commit,
       since_commit: since_commit,
+      env: env || {},
     )
     deploy.enqueue
     deploy
@@ -192,7 +193,7 @@ class Stack < ActiveRecord::Base
     ).first!
   end
 
-  delegate :task_definitions, :hidden_statuses, :soft_failing_statuses, to: :cached_deploy_spec
+  delegate :task_definitions, :hidden_statuses, :soft_failing_statuses, :deploy_variables, to: :cached_deploy_spec
 
   def monitoring?
     monitoring.present?

--- a/app/models/stack.rb
+++ b/app/models/stack.rb
@@ -48,7 +48,7 @@ class Stack < ActiveRecord::Base
     task
   end
 
-  def trigger_deploy(until_commit, user, env = nil)
+  def trigger_deploy(until_commit, user, env: nil)
     since_commit = last_deployed_commit
 
     deploy = deploys.create(

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -7,6 +7,7 @@ class Task < ActiveRecord::Base
   has_many :chunks, -> { order(:id) }, class_name: 'OutputChunk', dependent: :destroy
 
   serialize :definition, TaskDefinition
+  serialize :env, Hash
 
   scope :success, -> { where(status: 'success') }
   scope :completed, -> { where(status: %w(success error failed)) }

--- a/app/models/variable_definition.rb
+++ b/app/models/variable_definition.rb
@@ -1,0 +1,19 @@
+class VariableDefinition
+  attr_reader :name, :title, :value, :default
+
+  def initialize(attributes)
+    @name = attributes.fetch('name')
+    @title = attributes['title']
+    @value = attributes['value']
+    @default = attributes['default']
+  end
+
+  def to_h
+    {
+      'name' => @name,
+      'title' => @title,
+      'value' => @value,
+      'default' => @default,
+    }
+  end
+end

--- a/app/views/deploys/new.html.erb
+++ b/app/views/deploys/new.html.erb
@@ -29,13 +29,28 @@
 
   <%= render_checklist @stack.checklist %>
 
-  <section class="submit-section">
-    <%= form_for [@stack, @deploy] do |f| %>
+  <%= form_for [@stack, @deploy] do |f| %>
+    <% unless @deploy.variables.empty? %>
+      <section>
+        <header class="section-header environment-variables">
+          <h2>Environment variables</h2>
+        </header>
+        <%= f.fields_for :env do |env_fields| %>
+          <% @deploy.variables.each do |variable| %>
+            <p class="environment-variable">
+              <%= env_fields.text_field variable.name, value: variable.default %>
+              <%= env_fields.label variable.name, variable.title || variable.name %>
+            </p>
+          <% end %>
+        <% end %>
+      </section>
+    <% end %>
+    <section class="submit-section">
       <% if @stack.deploying? %>
         <%= hidden_field_tag :force, value: true %>
       <% end %>
       <%= f.hidden_field :until_commit_id %>
       <%= f.submit class: 'btn btn--primary btn--large trigger-deploy' %>
-    <% end %>
-  </section>
+    </section>
+  <% end %>
 </div>

--- a/db/migrate/20150814182557_add_env_to_tasks.rb
+++ b/db/migrate/20150814182557_add_env_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddEnvToTasks < ActiveRecord::Migration
+  def change
+    add_column :tasks, :env, :text
+  end
+end

--- a/lib/task_commands.rb
+++ b/lib/task_commands.rb
@@ -35,7 +35,7 @@ class TaskCommands < Commands
       'BUNDLE_PATH' => Rails.root.join('data', 'bundler').to_s,
       'SHIPIT_LINK' => permalink,
       'LAST_DEPLOYED_SHA' => @stack.last_deployed_commit.sha,
-    ).merge(deploy_spec.machine_env)
+    ).merge(deploy_spec.machine_env).merge(@task.env)
   end
 
   def checkout(commit)

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -36,6 +36,19 @@ class DeploysControllerTest < ActionController::TestCase
     end
   end
 
+  test ":create can receive an :env hash" do
+    env = {'SAFETY_DISABLED' => '1'}
+    post :create, stack_id: @stack.to_param, deploy: {until_commit_id: @commit.id, env: env}
+    new_deploy = Deploy.last
+    assert_equal env, new_deploy.env
+  end
+
+  test ":create can receive an :env keys not declared in the deploy spec" do
+    post :create, stack_id: @stack.to_param, deploy: {until_commit_id: @commit.id, env: {'H4X0R' => '1'}}
+    new_deploy = Deploy.last
+    assert_equal({}, new_deploy.env)
+  end
+
   test ":create with `force` option ignore the active deploys" do
     deploys(:shipit_running).update_column(:status, 'running')
 

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150708143032) do
+ActiveRecord::Schema.define(version: 20150814204960) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text     "permissions", limit: 65535
@@ -154,6 +154,7 @@ ActiveRecord::Schema.define(version: 20150708143032) do
     t.text     "definition",            limit: 65535
     t.binary   "gzip_output"
     t.boolean  "rollback_once_aborted",               default: false,     null: false
+    t.text     "env"
   end
 
   add_index "tasks", ["rolled_up", "created_at", "status"], name: "index_tasks_on_rolled_up_and_created_at_and_status"

--- a/test/fixtures/stacks.yml
+++ b/test/fixtures/stacks.yml
@@ -16,7 +16,7 @@ shipit:
         ]
       },
       "dependencies": {"override": []},
-      "deploy": {"override": null},
+      "deploy": {"override": null, "variables": [{"name": "SAFETY_DISABLED", "title": "Set to 1 to do dangerous things", "default": 0}]},
       "rollback": {"override": ["echo 'Rollback!'"]},
       "fetch": ["echo '42'"],
       "tasks": {

--- a/test/unit/command_test.rb
+++ b/test/unit/command_test.rb
@@ -17,6 +17,12 @@ class CommandTest < ActiveSupport::TestCase
     assert_equal [%(cap '' deploy)], command.interpolated_arguments
   end
 
+  test '#interpolate_environment_variables escape the variable contents' do
+    malicious_string = '$(echo pwnd)'
+    command = Command.new('echo $FOO', env: {'FOO' => malicious_string}, chdir: '.')
+    assert_equal malicious_string, command.run.chomp
+  end
+
   test "#interpolate_environment_variables fallback to ENV" do
     command = Command.new('cap $LANG deploy', env: {'ENVIRONMENT' => 'production'}, chdir: '.')
     assert_equal [%(cap #{ENV['LANG']} deploy)], command.interpolated_arguments

--- a/test/unit/deploy_commands_test.rb
+++ b/test/unit/deploy_commands_test.rb
@@ -171,4 +171,10 @@ class DeployCommandsTest < ActiveSupport::TestCase
     command = @commands.install_dependencies.first
     assert_equal '1', command.env['GLOBAL']
   end
+
+  test "the deploy's `env` is merged in ENVIRONMENT" do
+    @deploy.env = {'FOO' => 'BAR'}
+    command = @commands.install_dependencies.first
+    assert_equal 'BAR', command.env['FOO']
+  end
 end

--- a/test/unit/deploy_spec_test.rb
+++ b/test/unit/deploy_spec_test.rb
@@ -206,12 +206,28 @@ class DeploySpecTest < ActiveSupport::TestCase
       'machine' => {'environment' => {}, 'directory' => nil},
       'review' => {'checklist' => [], 'monitoring' => [], 'checks' => []},
       'dependencies' => {'override' => []},
-      'deploy' => {'override' => nil},
+      'deploy' => {'override' => nil, 'variables' => []},
       'rollback' => {'override' => nil},
       'fetch' => nil,
       'tasks' => {},
     }
     assert_equal config, @spec.cacheable.config
+  end
+
+  test "#deploy_variables returns an empty array by default" do
+    assert_equal [], @spec.deploy_variables
+  end
+
+  test "#deploy_variables returns an array of VariableDefinition instances" do
+    @spec.stubs(:load_config).returns('deploy' => {'variables' => [{
+      'name' => 'SAFETY_DISABLED',
+      'title' => 'Set to 1 to do dangerous things',
+      'default' => 0,
+    }]})
+
+    assert_equal 1, @spec.deploy_variables.size
+    variable_definition = @spec.deploy_variables.first
+    assert_equal 'SAFETY_DISABLED', variable_definition.name
   end
 
   test "task definitions prepend bundle exec if necessary" do


### PR DESCRIPTION
The idea is to be able to toggle flags and / or adjust settings in the deploy script from the Shipit UI.

e.g.

``` yml
deploy:
  variables:
    - name: RAILS42_PERCENTAGE
      title:  Percentage of servers running Rails 4.2
      default: 0
```

Will produce on the deploy page:

![capture d ecran 2015-08-14 a 17 29 04](https://cloud.githubusercontent.com/assets/44640/9284459/fe946fb6-42a9-11e5-9727-9f2f1919c340.png)

@rafaelfranca @davidcornu @gmalette 

Possible followups:
- Do the same for tasks
- Allow to persist the value that was set for the following deploys
- Value validation / sanitization e.g. (`type: number`)
