### PR TITLE
Quote USER env variable value

### DIFF
--- a/lib/task_commands.rb
+++ b/lib/task_commands.rb
@@ -30,7 +30,7 @@ class TaskCommands < Commands
     normalized_name = ActiveSupport::Inflector.transliterate(@task.author.name)
     super.merge(
       'ENVIRONMENT' => @stack.environment,
-      'USER' => "#{@task.author.login} (#{normalized_name}) via Shipit",
+      'USER' => "'#{@task.author.login} (#{normalized_name}) via Shipit'",
       'EMAIL' => @task.author.email,
       'BUNDLE_PATH' => Rails.root.join('data', 'bundler').to_s,
       'SHIPIT_LINK' => permalink,


### PR DESCRIPTION
Fixes the issue which happens while using ```USER``` variable in bash command.

For eg:

```bash: -c: line 0: `cd <path> && ( RAILS_ENV=staging RBENV_ROOT=/data/rbenv RBENV_VERSION=2.0.0-p247 /data/rbenv/bin/rbenv exec bundle exec rake honeybadger:deploy TO=staging REPO=git@github.com:<repo> USER=ershad (Ershad K) via Shipit )'```

The text ```ershad (Ershad K) via Shipit``` should be quotes.
