### PR TITLE
Fire a new `commit_status` webhook when commit statuses change

### DIFF
--- a/app/controllers/webhooks_controller.rb
+++ b/app/controllers/webhooks_controller.rb
@@ -18,7 +18,7 @@ class WebhooksController < ActionController::Base
     branches = params[:branches] || []
     if branches.find { |branch| branch[:name] == stack.branch }
       commit = stack.commits.find_by_sha!(params[:sha])
-      commit.statuses.create!(params.permit(:state, :description, :target_url, :context, :created_at))
+      commit.add_status(params.permit(:state, :description, :target_url, :context, :created_at))
     end
     head :ok
   end

--- a/app/models/commit.rb
+++ b/app/models/commit.rb
@@ -83,6 +83,15 @@ class Commit < ActiveRecord::Base
     end
   end
 
+  def add_status(status_attributes)
+    previous_status = significant_status
+    statuses.create!(status_attributes)
+    reload # to get the statuses into the right order (since sorted :desc)
+    new_status = significant_status
+    Hook.emit(:commit_status, stack, commit: self, stack: stack, status: new_status) if previous_status != new_status
+    new_status
+  end
+
   def checks
     @checks ||= CommitChecks.new(self)
   end

--- a/app/models/hook.rb
+++ b/app/models/hook.rb
@@ -11,6 +11,7 @@ class Hook < ActiveRecord::Base
     deploy
     rollback
     lock
+    commit_status
   ).freeze
 
   belongs_to :stack, required: false

--- a/test/fixtures/hooks.yml
+++ b/test/fixtures/hooks.yml
@@ -14,3 +14,9 @@ shipit_tasks:
   events: 'task'
   url: https://example.com/events/deploy
   content_type: json
+
+shipit_commit_status:
+  stack: shipit
+  events: 'commit_status'
+  url: https://example.com/events/commit_status
+  content_type: json

--- a/test/fixtures/stacks.yml
+++ b/test/fixtures/stacks.yml
@@ -27,6 +27,10 @@ shipit:
             "cap $ENVIRONMENT deploy:restart"
           ]
         }
+      },
+      "ci": {
+        "hide": ["ci/hidden"],
+        "allow_failures": ["ci/ok_to_fail"]
       }
     }
   updated_at: <%= 8.days.ago.to_s(:db) %>

--- a/test/models/hook_test.rb
+++ b/test/models/hook_test.rb
@@ -34,7 +34,7 @@ class HookTest < ActiveSupport::TestCase
     end
   end
 
-  test ".deliver schedule a delivery for each matching hook" do
+  test ".deliver schedules a delivery for each matching hook" do
     assert_difference -> { Delivery.count }, 2 do
       Hook.deliver(:deploy, @stack, 'foo' => 42)
     end
@@ -47,7 +47,7 @@ class HookTest < ActiveSupport::TestCase
     assert_equal 'scheduled', delivery.status
   end
 
-  test ".scoped? returns true if the hook have a stack_id" do
+  test ".scoped? returns true if the hook has a stack_id" do
     @hook.stack_id = nil
     refute @hook.scoped?
 


### PR DESCRIPTION
@byroot Very initial idea for status webhooks. Does this seem like it's on the right track to you? Thanks!