### PR TITLE
Show branch name in list of stacks

### DIFF
--- a/app/assets/stylesheets/_pages/_stacks.scss
+++ b/app/assets/stylesheets/_pages/_stacks.scss
@@ -19,7 +19,7 @@
   @include clearfix;
   margin: 0; padding: 1.25rem 0 1rem;
   .col {
-    width: 33.33%;
+    width: 25%;
     float: left;
   }
   li {
@@ -33,7 +33,7 @@
   list-style-type: none;
   margin: 0; padding: 0; margin-bottom: 1.5rem;
     .col {
-      width: 33.33%;
+      width: 25%;
       float: left;
       text-overflow: ellipsis;
       white-space: nowrap;

--- a/app/views/stacks/index.html.erb
+++ b/app/views/stacks/index.html.erb
@@ -13,6 +13,7 @@
     <ul class="stack-table-header">
       <li class="col">Name</li>
       <li class="col">Environment</li>
+      <li class="col">Branch</li>
       <li class="col">Deploy URL</li>
     </ul>
     <ul class="stack-lst">
@@ -21,6 +22,7 @@
           <%= link_to stack_path(stack), class: 'commits-path' do %>
             <span class="col"><%= stack.repo_name %></span>
             <small class="col"><%= stack.environment.capitalize %></small>
+            <small class="col"><%= stack.branch %></small>
             <small class="col"><%= stack.deploy_url %></small>
           <% end %>
         </li>


### PR DESCRIPTION
Sometimes it's helpful to know which branch is getting deployed. This PR adds 'branch' column to the home page.

![Alt text](https://monosnap.com/file/4EJfZYGAj0pmLFHTA2qGQKUk7W7Vf0.png)