### PR TITLE
Create `deployable_status` webhook when deployable state changes

### DIFF
--- a/app/models/hook.rb
+++ b/app/models/hook.rb
@@ -12,6 +12,7 @@ class Hook < ActiveRecord::Base
     rollback
     lock
     commit_status
+    deployable_status
   ).freeze
 
   belongs_to :stack, required: false

--- a/test/fixtures/hooks.yml
+++ b/test/fixtures/hooks.yml
@@ -20,3 +20,9 @@ shipit_commit_status:
   events: 'commit_status'
   url: https://example.com/events/commit_status
   content_type: json
+
+cyclimse_deploy_status:
+  stack: cyclimse
+  events: 'deploy_status'
+  url: https://example.com/events/deploy_status
+  content_type: json


### PR DESCRIPTION
This webhook fires whenever a commit changes to either green or red. Pending states are ignored.

Also fixed up the `commit_status` event payload so that it matches the way all the others work.

@byroot 