### PR TITLE
Use FakeWeb when seeding db

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,11 +12,11 @@ end
 
 group :development, :test do
   gem 'faker'
+  gem 'fakeweb'
   gem 'rubocop'
 end
 
 group :test do
-  gem 'fakeweb'
   gem 'test_after_commit', '0.4.0'
   gem 'mocha'
   gem 'simplecov', require: false

--- a/test/dummy/db/seeds.rb
+++ b/test/dummy/db/seeds.rb
@@ -1,4 +1,8 @@
 require 'faker'
+require 'fakeweb'
+
+# Sometimes on Travis the background job runs immediately so provide a response to fake hooks
+FakeWeb.register_uri(:post, %r{https://example\.com/}, status: %w(200 OK))
 
 # Cheap hack to allow rake db:seed to work
 Stack.send(:define_method, :setup_hooks) {}


### PR DESCRIPTION
When seeding on CI, sometimes the hook delivery background job runs immediately (inside the call to `perform_later`).
So we use `FakeWeb` with a regex for any `example.com` url during the seeding process. We don't care what happens to
those webhooks durign seeding.

@byroot - I've run this 3 times on Travis and it succeeded on every db each time.