### PR TITLE
Fix status change during transaction detection

### DIFF
--- a/app/models/deploy.rb
+++ b/app/models/deploy.rb
@@ -94,16 +94,20 @@ class Deploy < Task
 
   def reject!
     return if failed?
-    flap! unless flapping?
-    update!(confirmations: [confirmations - 1, -1].min)
-    failure! if confirmed?
+    transaction do
+      flap! unless flapping?
+      update!(confirmations: [confirmations - 1, -1].min)
+      failure! if confirmed?
+    end
   end
 
   def accept!
     return if success?
-    flap! unless flapping?
-    update!(confirmations: [confirmations + 1, 1].max)
-    complete! if confirmed?
+    transaction do
+      flap! unless flapping?
+      update!(confirmations: [confirmations + 1, 1].max)
+      complete! if confirmed?
+    end
   end
 
   def confirmed?

--- a/test/models/deploys_test.rb
+++ b/test/models/deploys_test.rb
@@ -369,6 +369,13 @@ class DeploysTest < ActiveSupport::TestCase
     assert_predicate @deploy, :failed?
   end
 
+  test "entering flapping state triggers webhooks" do
+    assert_enqueued_with job: EmitEventJob do
+      @deploy.reject!
+    end
+    assert_predicate @deploy, :flapping?
+  end
+
   private
 
   def expect_event(deploy)


### PR DESCRIPTION
Since multiple saves were performed in the same transaction, the after_commit callback couldn't see all of it.

It's what https://github.com/dylanahsmith/ar_transaction_changes solves but I didn't felt like including such gem.

@rafaelfranca @sgrif for review please (because Rails hack :/)