### PR TITLE
Add test for auto-linking in lock descriptions and handling for nil lock authors

### DIFF
--- a/app/views/stacks/show.html.erb
+++ b/app/views/stacks/show.html.erb
@@ -39,7 +39,7 @@
       <div class="banner__content">
         <h2 class="banner__title">
           <i class="icon icon--lock"></i>
-          Deploys are locked by <%= @stack.lock_author.name || AnonymousUser.new.name %>
+          Deploys are locked by <%= (@stack.lock_author || AnonymousUser.new).name %>
         </h2>
         <p class="banner__text">
           <%= auto_link @stack.lock_reason %>

--- a/test/controllers/stacks_controller_test.rb
+++ b/test/controllers/stacks_controller_test.rb
@@ -64,6 +64,18 @@ class StacksControllerTest < ActionController::TestCase
     assert_response :ok
   end
 
+  test "#show handles locked stacks without a lock_author" do
+    @stack.update!(lock_reason: "I am a lock with no author")
+    get :show, id: @stack.to_param
+  end
+
+  test "#show auto-links URLs in lock reason" do
+    @stack.update!(lock_reason: 'http://google.com')
+    get :show, id: @stack.to_param
+    assert_response :ok
+    assert_select 'a[href="http://google.com"]'
+  end
+
   test "#create creates a Stack, queues a job to setup webhooks and redirects to it" do
     params = {}
     params[:stack] = {


### PR DESCRIPTION
@byroot @gmalette 

I forgot to add a test for the auto-linking, so I added that - while I was adding it I also discovered that when `lock_author` is `nil` you'd get a 500 error, so I fixed that too.