### PR TITLE
Hosting Shipit on Heroku

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ Shipit provides you with a Rails template. To bootstrap your Shipit installation
 1. If you don't have Rails installed, run this command: `gem install rails`
 2. Run this command:  `rails new shipit -m https://raw.githubusercontent.com/Shopify/shipit-engine/master/template.rb`
 3. Enter your **Client ID**, **Client Secret**, and **GitHub API access token** when prompted. These can be found on your application's GitHub page.
-4. To install the Shipit migrations, run this command: `rake shipit_engine:install:migrations`
-5. To setup the database, run this command: `rake db:setup`
+4. To setup the database, run this command: `rake db:setup`
 
 <h3 id="configuring-ymls">Configuring <code>shipit.yml</code> and <code>secrets.yml</code></h3>
 

--- a/template.rb
+++ b/template.rb
@@ -44,6 +44,29 @@ web: bundle exec rails s -p $PORT
 worker: bundle exec sidekiq -C config/sidekiq.yml
 CODE
 
+remove_file 'config/database.yml'
+create_file 'config/database.yml', <<-CODE
+default: &default
+  adapter: sqlite3
+  pool: 5
+  timeout: 5000
+
+development:
+  <<: *default
+  database: db/development.sqlite3
+
+# Warning: The database defined as "test" will be erased and
+# re-generated from your development database when you run "rake".
+# Do not set this db to the same as development or production.
+test:
+  <<: *default
+  database: db/test.sqlite3
+
+production:
+  url:  <%= ENV['DATABASE_URL'] %>
+  pool: <%= ENV['DB_POOL'] || 5 %>
+CODE
+
 create_file 'config/sidekiq.yml', <<-CODE
 :concurrency: 1
 :queues:
@@ -112,30 +135,6 @@ if yes?("Are you hosting Shipit on Heroku? (y/n)")
   gem_group :development, :test do
     gem 'sqlite3'
   end
-
-  remove_file 'config/database.yml'
-  create_file 'config/database.yml', <<-EOF
-default: &default
-  adapter: sqlite3
-  pool: 5
-  timeout: 5000
-
-development:
-  <<: *default
-  database: db/development.sqlite3
-
-# Warning: The database defined as "test" will be erased and
-# re-generated from your development database when you run "rake".
-# Do not set this db to the same as development or production.
-test:
-  <<: *default
-  database: db/test.sqlite3
-
-production:
-  url:  <%= ENV['DATABASE_URL'] %>
-  pool: <%= ENV['DB_POOL'] || 5 %>
-
-EOF
 end
 
 after_bundle do

--- a/template.rb
+++ b/template.rb
@@ -1,5 +1,8 @@
 # Template for rails new app
 # Run this like `rails new shipit -m template.rb`
+if Gem::Version.new(RUBY_VERSION) < Gem::Version.new("2.1.0")
+  raise Thor::Error, "You need at least Ruby 2.1.0 to install shipit"
+end
 if Gem::Version.new(Rails::VERSION::STRING) < Gem::Version.new("4.2.0")
   raise Thor::Error, "You need at least Rails 4.2.0 to install shipit"
 end
@@ -98,7 +101,7 @@ CODE
 
 if yes?("Are you hosting Shipit on Heroku? (y/n)")
   inject_into_file "Procfile", " -p $PORT", after: "web: bundle exec rails s"
-  inject_into_file "Gemfile", "ruby '2.2.3'", after: "source 'https://rubygems.org'\n"
+  inject_into_file "Gemfile", "ruby '#{RUBY_VERSION}'", after: "source 'https://rubygems.org'\n"
 
   gsub_file 'Gemfile', "# Use sqlite3 as the database for Active Record", ''
   gsub_file 'Gemfile', "gem 'sqlite3'", ''

--- a/template.rb
+++ b/template.rb
@@ -36,10 +36,11 @@ create_file '.env', <<-CODE
 GITHUB_OAUTH_ID=#{github_id}
 GITHUB_OAUTH_SECRET=#{github_secret}
 GITHUB_API_TOKEN=#{github_token}
+PORT=3000
 CODE
 
 create_file 'Procfile', <<-CODE
-web: bundle exec rails s
+web: bundle exec rails s -p $PORT
 worker: bundle exec sidekiq -C config/sidekiq.yml
 CODE
 
@@ -100,7 +101,6 @@ end
 CODE
 
 if yes?("Are you hosting Shipit on Heroku? (y/n)")
-  inject_into_file "Procfile", " -p $PORT", after: "web: bundle exec rails s"
   inject_into_file "Gemfile", "ruby '#{RUBY_VERSION}'", after: "source 'https://rubygems.org'\n"
 
   gsub_file 'Gemfile', "# Use sqlite3 as the database for Active Record", ''


### PR DESCRIPTION
I saw the issue to have first class Heroku support, so I thought Id try deploying Shipit to Heroku. I was able to do so and have everything run in the free tier.

Things I had to change:
* Procfile required `$PORT` to be set on the web container
* sidekiq was needed all the queues listed
* Gemfile changes
  * set the ruby version
  * use postgres instead of sqlite
  * require rails_12factor gem
* set production database url through an environment variable

Here is a [wiki article](https://github.com/perobertson/shipit-engine/wiki/Hosting-on-Heroku) about what needs set on Heroku in order to get it  deployed there.