### PR TITLE
fix for updating first deploy

### DIFF
--- a/app/models/stack.rb
+++ b/app/models/stack.rb
@@ -75,9 +75,9 @@ class Stack < ActiveRecord::Base
     last_deploy = deploys_and_rollbacks.last
     actual_deployed_commit = commits.reachable.by_sha!(sha)
 
-    if actual_deployed_commit == last_deploy.until_commit
+    if last_deploy && actual_deployed_commit == last_deploy.until_commit
       last_deploy.accept!
-    elsif actual_deployed_commit == last_deploy.since_commit
+    elsif last_deploy && actual_deployed_commit == last_deploy.since_commit
       last_deploy.reject!
     else
       deploys.create!(

--- a/test/controllers/api/stacks_controller_test.rb
+++ b/test/controllers/api/stacks_controller_test.rb
@@ -13,7 +13,7 @@ class Api::StacksControllerTest < ActionController::TestCase
     assert_response :ok
     assert_json '0.id', stack.id
     assert_json do |stacks|
-      assert_equal 2, stacks.size
+      assert_equal 3, stacks.size
     end
   end
 

--- a/test/fixtures/commits.yml
+++ b/test/fixtures/commits.yml
@@ -75,3 +75,16 @@ cyclimse_first:
   additions: 1
   deletions: 24
   updated_at: <%= 8.days.ago.to_s(:db) %>
+
+undeployed_stack_first:
+  id: 7
+  sha: 44b3833d39def7ec65b57b42f496eb27ab4980b6
+  message: "Cake!"
+  stack: undeployed_stack
+  author: bob
+  committer: bob
+  authored_at: <%= 2.days.ago.to_s(:db) %>
+  committed_at: <%= 1.days.ago.to_s(:db) %>
+  additions: 1
+  deletions: 24
+  updated_at: <%= 8.days.ago.to_s(:db) %>

--- a/test/fixtures/stacks.yml
+++ b/test/fixtures/stacks.yml
@@ -67,3 +67,40 @@ cyclimse:
       }
     }
   updated_at: <%= 8.days.ago.to_s(:db) %>
+
+undeployed_stack:
+  repo_owner: "shopify"
+  repo_name: "foo-bar"
+  environment: "production"
+  branch: master
+  ignore_ci: true
+  tasks_count: 0
+  undeployed_commits_count: 1
+  cached_deploy_spec: >
+    {
+      "machine": {"environment": {}},
+      "review": {
+        "checklist": ["foo", "bar", "baz"],
+        "monitoring": [
+          {"image": "https://example.com/monitor.png", "width": 200, "height": 300}
+        ]
+      },
+      "dependencies": {"override": []},
+      "deploy": {"override": null},
+      "rollback": {"override": ["echo 'Rollback!'"]},
+      "fetch": ["echo '42'"],
+      "tasks": {
+        "restart": {
+          "action": "Restart application",
+          "description": "Restart app and job servers",
+          "steps": [
+            "cap $ENVIRONMENT deploy:restart"
+          ]
+        }
+      },
+      "ci": {
+        "hide": ["ci/hidden"],
+        "allow_failures": ["ci/ok_to_fail"]
+      }
+    }
+  updated_at: <%= 8.days.ago.to_s(:db) %>

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -135,6 +135,18 @@ class StacksTest < ActiveSupport::TestCase
     assert_equal commits(:fifth), @stack.last_deployed_commit
   end
 
+  test "#update_deployed_revision creates a new completed deploy without previous deploys" do
+    stack = stacks(:undeployed_stack)
+    assert_empty stack.deploys_and_rollbacks
+    assert_difference 'Deploy.count', 1 do
+      deploy = stack.update_deployed_revision(commits(:undeployed_stack_first).sha)
+      assert_not_nil deploy
+      assert_equal commits(:undeployed_stack_first), deploy.since_commit
+      assert_equal commits(:undeployed_stack_first), deploy.until_commit
+    end
+    assert_equal commits(:undeployed_stack_first), stack.last_deployed_commit
+  end
+
   test "#update_deployed_revision works with short shas" do
     Deploy.active.update_all(status: 'error')
 


### PR DESCRIPTION
When adding a new stack to shipit that has already been deployed through other means and fetch has been added to `shipit.yml`, it causes the background job to throw nil exceptions.