### PR TITLE
Fix GitHub authentication redirection

### DIFF
--- a/app/controllers/shipit_controller.rb
+++ b/app/controllers/shipit_controller.rb
@@ -30,7 +30,7 @@ class ShipitController < ApplicationController
         render text: "You must be a member of #{team.handle} to access this application.", status: :forbidden
       end
     else
-      redirect_to github_authentication_path(origin: request.original_url)
+      redirect_to Shipit::Engine.routes.url_helpers.github_authentication_path(origin: request.original_url)
     end
   end
 

--- a/test/controllers/stacks_controller_test.rb
+++ b/test/controllers/stacks_controller_test.rb
@@ -49,7 +49,7 @@ class StacksControllerTest < ActionController::TestCase
   test "GitHub authentication is mandatory" do
     session[:user_id] = nil
     get :index
-    assert_redirected_to github_authentication_path(origin: root_url)
+    assert_redirected_to '/github/auth/github?origin=http%3A%2F%2Ftest.host%2F'
   end
 
   test "current_user must be a member of Shipit.github_team" do


### PR DESCRIPTION
Reported by @arich55

```ruby
(byebug) github_authentication_path(origin: request.original_url)
DEPRECATION WARNING: You are trying to generate the URL for a named route called "github_authentication" but no such route was found. In the future, this will result in an `ActionController::UrlGenerationError` exception. (called from force_github_authentication at (byebug):1)
"/assets?action=request&controller=github_authentication&origin=http%3A%2F%2Flocalhost%3A3000%2F"
```

Seems like what we were doing here: https://github.com/Shopify/shipit-engine/blob/ef726051c66b769f2eab05158d18f8a5be0aca25/app/controllers/shipit_controller.rb#L4-L5 doesn't work anymore in 4.2.5. TBH I felt bad when I added this, it was clearly sketchy.

I can say it worked in 4.2.2.

@rafaelfranca any idea how we should do this (this PR is just a workaround).
