### PR TITLE
Directly use Shipit.redis to store task pids, instead of expecting Rails.cache to be shared

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -151,11 +151,12 @@ class Task < ActiveRecord::Base
   end
 
   def pid
-    Rails.cache.read("task:#{id}:pid")
+    pid = Shipit.redis.get("task:#{id}:pid")
+    pid.presence && pid.to_i
   end
 
   def pid=(pid)
-    Rails.cache.write("task:#{id}:pid", pid, expires_in: 1.hour)
+    Shipit.redis.set("task:#{id}:pid", pid, ex: 1.hour.to_i)
   end
 
   def abort!(rollback_once_aborted: false)


### PR DESCRIPTION
Fixes: https://github.com/Shopify/shipit-engine/issues/506

Any of @gmalette @davidcornu @etiennebarrie @rafaelfranca for review please.

Before you ask the behavior is tested there: https://github.com/Shopify/shipit-engine/blob/eca332d7f14fc4e886568af0169cd48d0986c3a9/test/models/deploys_test.rb#L259-L262

cc @gmontard
