### PR TITLE
Allow to require specific commit statuses

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -239,7 +239,7 @@ GEM
       addressable (~> 2.3.5)
       faraday (~> 0.8, < 0.10)
     securecompare (1.0.0)
-    simplecov (0.10.0)
+    simplecov (0.11.1)
       docile (~> 1.1.0)
       json (~> 1.8)
       simplecov-html (~> 0.10.0)

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ The settings in the `shipit.yml` file relate to the different things you can do 
 * [Installing dependencies](#installing-dependencies) (`dependencies`)
 * [Deployment](#deployment) (`deploy`, `rollback`, `fetch`)
 * [Environment](#environment) (`machine.environment`)
-* [CI](#ci) (`ci.hide`, `ci.allow_failures`)
+* [CI](#ci) (`ci.require`, `ci.hide`, `ci.allow_failures`)
 * [Custom tasks](#custom-tasks) (`restart`, `unlock`)
 * [Review Process](#review-process) (`monitor`, `checklist`, `checks`)
 
@@ -213,6 +213,14 @@ machine:
 ```
 
 <h3 id="ci">CI</h3>
+**<code>ci.require</code>** contains an array of the [statuses context](https://developer.github.com/v3/repos/statuses/) you want Shipit to disallow deploys if any of them is missing.
+
+For example:
+```yml
+ci:
+  require:
+    - ci/circleci
+```
 
 **<code>ci.hide</code>** contains an array of the [statuses context](https://developer.github.com/v3/repos/statuses/) you want Shipit to ignore.
 

--- a/app/helpers/stacks_helper.rb
+++ b/app/helpers/stacks_helper.rb
@@ -66,20 +66,11 @@ module StacksHelper
   end
 
   def deploy_button_caption(commit)
-    state = commit.significant_status.state
+    state = commit.status.state
     state = 'locked' if commit.stack.locked? && !ignore_lock?
     if commit.deployable?
       state = commit.stack.deploying? ? 'deploying' : 'enabled'
     end
     t("deploy_button.caption.#{state}")
-  end
-
-  def render_status(commit)
-    statuses = commit.visible_statuses
-    if statuses.size == 1
-      render statuses.first
-    else
-      render StatusGroup.new(commit)
-    end
   end
 end

--- a/app/models/deploy_spec.rb
+++ b/app/models/deploy_spec.rb
@@ -101,6 +101,10 @@ class DeploySpec
     Array.wrap(config('ci', 'hide'))
   end
 
+  def required_statuses
+    Array.wrap(config('ci', 'require'))
+  end
+
   def soft_failing_statuses
     Array.wrap(config('ci', 'allow_failures'))
   end

--- a/app/models/deploy_spec/file_system.rb
+++ b/app/models/deploy_spec/file_system.rb
@@ -18,7 +18,11 @@ class DeploySpec
 
     def cacheable_config
       (config || {}).deep_merge(
-        'ci' => {'hide' => hidden_statuses, 'allow_failures' => soft_failing_statuses},
+        'ci' => {
+          'hide' => hidden_statuses,
+          'allow_failures' => soft_failing_statuses,
+          'require' => required_statuses,
+        },
         'machine' => {'environment' => machine_env, 'directory' => directory},
         'review' => {
           'checklist' => review_checklist,

--- a/app/models/missing_status.rb
+++ b/app/models/missing_status.rb
@@ -1,0 +1,18 @@
+class MissingStatus < SimpleDelegator
+  def initialize(instance, missing_statuses)
+    @missing_statuses = missing_statuses
+    super(instance)
+  end
+
+  def state
+    'missing'
+  end
+
+  def success?
+    false
+  end
+
+  def description
+    I18n.t('missing_status.description', missing_statuses: @missing_statuses.to_sentence, count: @missing_statuses.size)
+  end
+end

--- a/app/models/stack.rb
+++ b/app/models/stack.rb
@@ -212,7 +212,7 @@ class Stack < ActiveRecord::Base
     ).first!
   end
 
-  delegate :plugins, :task_definitions, :hidden_statuses, :soft_failing_statuses,
+  delegate :plugins, :task_definitions, :hidden_statuses, :required_statuses, :soft_failing_statuses,
            :deploy_variables, to: :cached_deploy_spec
 
   def monitoring?

--- a/app/models/status_group.rb
+++ b/app/models/status_group.rb
@@ -3,9 +3,9 @@ class StatusGroup
 
   attr_reader :statuses, :significant_status
 
-  def initialize(commit)
-    @significant_status = commit.significant_status
-    @statuses = commit.visible_statuses
+  def initialize(significant_status, visible_statuses)
+    @significant_status = significant_status
+    @statuses = visible_statuses
   end
 
   delegate :state, to: :significant_status

--- a/app/views/commits/_commit.html.erb
+++ b/app/views/commits/_commit.html.erb
@@ -1,6 +1,6 @@
 <li class="commit" id="commit-<%= commit.id %>">
   <%= render 'commits/commit_author', commit: commit %>
-  <%= render_status commit %>
+  <%= render commit.status %>
   <div class="commit-details">
     <span class="commit-title"><%= render_commit_message_with_link commit %></span>
     <p class="commit-meta">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,12 +29,17 @@ en:
       locked: Locked
       deploying: Deploy in progress...
       enabled: Deploy
+      missing: Missing CI
 
   deploy_spec:
     hint:
       deploy: Impossible to detect how to deploy this application. Please define `deploy.override` in your shipit.yml
       rollback: Impossible to detect how to rollback this application. Please define `rollback.override` in your shipit.yml
       fetch: Impossible to detect how to fetch the deployed revision for this application. Please define `fetch` in your shipit.yml
+  missing_status:
+    description:
+      one: "%{missing_statuses} is required for deploy but was not sent"
+      other: "%{missing_statuses} are required for deploy but were not sent"
   deploys:
     description: "deploy of %{sha}"
   rollbacks:

--- a/test/fixtures/stacks.yml
+++ b/test/fixtures/stacks.yml
@@ -3,7 +3,7 @@ shipit:
   repo_name: "shipit-engine"
   environment: "production"
   branch: master
-  ignore_ci: true
+  ignore_ci: false
   tasks_count: 3
   undeployed_commits_count: 1
   cached_deploy_spec: >

--- a/test/models/commits_test.rb
+++ b/test/models/commits_test.rb
@@ -262,11 +262,23 @@ class CommitsTest < ActiveSupport::TestCase
   end
 
   test "#deployable? is true if commit status is 'success'" do
-    assert commits(:cyclimse_first).deployable?
+    assert_predicate commits(:cyclimse_first), :deployable?
   end
 
   test "#deployable? is true if stack is set to 'ignore_ci'" do
-    assert commits(:first).deployable?
+    commit = commits(:first)
+    commit.stack.update!(ignore_ci: true)
+    assert_predicate commit, :deployable?
+  end
+
+  test "#deployable? is false if commit has no statuses" do
+    refute_predicate commits(:fifth), :deployable?
+  end
+
+  test "#deployable? is false if a required status is missing" do
+    commit = commits(:cyclimse_first)
+    commit.stack.stubs(:required_statuses).returns(%w(ci/very-important))
+    refute_predicate commit, :deployable?
   end
 
   expected_webhook_transitions = { # we expect deployable_status to fire on these transitions, and not on any others

--- a/test/models/missing_status_test.rb
+++ b/test/models/missing_status_test.rb
@@ -1,0 +1,21 @@
+require 'test_helper'
+
+class MissingStatusTest < ActiveSupport::TestCase
+  setup do
+    @real_status = statuses(:first_pending)
+    @status = MissingStatus.new(@real_status, %w(ci/very-important style/very-important-too))
+  end
+
+  test "#state is 'missing'" do
+    assert_equal 'missing', @status.state
+  end
+
+  test "#description explains the situation" do
+    message = 'ci/very-important and style/very-important-too are required for deploy but were not sent'
+    assert_equal message, @status.description
+  end
+
+  test "#success? is false" do
+    refute_predicate @status, :success?
+  end
+end

--- a/test/models/status_group_test.rb
+++ b/test/models/status_group_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 class StatusGroupTest < ActiveSupport::TestCase
   setup do
     @commit = commits(:second)
-    @group = StatusGroup.new(@commit)
+    @group = StatusGroup.new(@commit.significant_status, @commit.visible_statuses)
   end
 
   test "#description is a summary of the statuses" do

--- a/test/unit/deploy_spec_test.rb
+++ b/test/unit/deploy_spec_test.rb
@@ -202,7 +202,7 @@ class DeploySpecTest < ActiveSupport::TestCase
     assert_instance_of DeploySpec::FileSystem, @spec
     assert_instance_of DeploySpec, @spec.cacheable
     config = {
-      'ci' => {'hide' => [], 'allow_failures' => []},
+      'ci' => {'hide' => [], 'allow_failures' => [], 'require' => []},
       'machine' => {'environment' => {}, 'directory' => nil},
       'review' => {'checklist' => [], 'monitoring' => [], 'checks' => []},
       'dependencies' => {'override' => []},


### PR DESCRIPTION
When a stack have multiple commit statuses expected, if one of the reporting services is down and send no status at all, users can easily miss that a very important CI step is missing.

I was initially against this idea (proposed by @etiennebarrie) because I though it was unnecessary complexity, but in retrospect, it can prevent really bad problems.

@etiennebarrie @mcgain @es @rafaelfranca for review please.