### PR TITLE
Multiple GH teams

### DIFF
--- a/README.md
+++ b/README.md
@@ -316,7 +316,7 @@ development:
 
 The value for `id` is your application's  *Client ID*, and the value for `secret` is your application's *Client Secret* &mdash; both of these should appear on your application's GitHub page.
 
-The `team` is optional, and required only if you want to specify a team that has access to the stack in Shipit.
+The `teams` key is optional, and required only if you want to specify some teams which have access to the stack in Shipit.
 
 For example:
 
@@ -325,7 +325,9 @@ development:
   github_oauth:
     id: (your application's Client ID)
     secret: (your application's Client Secret)
-    team: Shipit/team
+    teams:
+      - Shipit/team
+      - Shipit/another_team
 ```
 <br>
 

--- a/app/controllers/shipit/shipit_controller.rb
+++ b/app/controllers/shipit/shipit_controller.rb
@@ -33,7 +33,7 @@ module Shipit
     def force_github_authentication
       if current_user.logged_in?
         teams = Shipit.github_teams
-        if teams && teams.none? { |team| team.in?(current_user.teams) }
+        unless teams.empty? || current_user.teams.where(id: teams).exists?
           team_list = teams.map(&:handle).to_sentence(two_words_connector: ' or ', last_word_connector: ', or ')
           render text: "You must be a member of #{team_list} to access this application.", status: :forbidden
         end

--- a/app/controllers/shipit/shipit_controller.rb
+++ b/app/controllers/shipit/shipit_controller.rb
@@ -32,9 +32,10 @@ module Shipit
 
     def force_github_authentication
       if current_user.logged_in?
-        team = Shipit.github_team
-        if team && !current_user.in?(team.members)
-          render text: "You must be a member of #{team.handle} to access this application.", status: :forbidden
+        teams = Shipit.github_teams
+        if teams && teams.none? { |team| team.in?(current_user.teams) }
+          team_list = teams.map(&:handle).to_sentence(two_words_connector: ' or ', last_word_connector: ', or ')
+          render text: "You must be a member of #{team_list} to access this application.", status: :forbidden
         end
       else
         redirect_to Shipit::Engine.routes.url_helpers.github_authentication_path(origin: request.original_url)

--- a/app/models/shipit/user.rb
+++ b/app/models/shipit/user.rb
@@ -2,6 +2,8 @@ module Shipit
   class User < ActiveRecord::Base
     DEFAULT_AVATAR = URI.parse('https://avatars.githubusercontent.com/u/583231?')
 
+    has_many :teams, through: :memberships
+    has_many :memberships
     has_many :authored_commits, class_name: :Commit, foreign_key: :author_id, inverse_of: :author
     has_many :commits, foreign_key: :committer_id, inverse_of: :committer
     has_many :tasks

--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -103,8 +103,9 @@ module Shipit
     secrets.host.presence
   end
 
-  def github_team
-    @github_team ||= github_oauth_credentials['team'] && Team.find_or_create_by_handle(github_oauth_credentials['team'])
+  def github_teams
+    teams = (Array(github_oauth_credentials['team']) + Array(github_oauth_credentials['teams'])).sort.uniq
+    @github_teams ||= teams.any? && teams.map { |t| Team.find_or_create_by_handle(t) }
   end
 
   def github_oauth_id

--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -105,7 +105,7 @@ module Shipit
 
   def github_teams
     teams = (Array(github_oauth_credentials['team']) + Array(github_oauth_credentials['teams'])).sort.uniq
-    @github_teams ||= teams.any? && teams.map { |t| Team.find_or_create_by_handle(t) }
+    @github_teams ||= teams.map { |t| Team.find_or_create_by_handle(t) }
   end
 
   def github_oauth_id

--- a/test/controllers/api/hooks_controller_test.rb
+++ b/test/controllers/api/hooks_controller_test.rb
@@ -9,7 +9,7 @@ module Shipit
       end
 
       test "the route has priority over stacks one" do
-        assert_recognizes({controller: 'shipit/api/hooks', action: 'show', id: '42' }, '/api/hooks/42')
+        assert_recognizes({controller: 'shipit/api/hooks', action: 'show', id: '42'}, '/api/hooks/42')
       end
 
       test "#index without a stack_id returns the list of global hooks" do
@@ -57,7 +57,9 @@ module Shipit
       end
 
       test "#create do not allow to set protected attributes" do
-        post :create, delivery_url: 'https://example.com/hook', events: %w(deploy rollback), created_at: 2.months.ago.to_s(:db)
+        post :create, delivery_url: 'https://example.com/hook',
+                      events: %w(deploy rollback),
+                      created_at: 2.months.ago.to_s(:db)
         Hook.last.created_at > 2.seconds.ago
       end
 

--- a/test/controllers/stacks_controller_test.rb
+++ b/test/controllers/stacks_controller_test.rb
@@ -54,11 +54,12 @@ module Shipit
       assert_redirected_to '/github/auth/github?origin=http%3A%2F%2Ftest.host%2F'
     end
 
-    test "current_user must be a member of Shipit.github_team" do
-      Shipit.stubs(:github_team).returns(shipit_teams(:cyclimse_cooks))
+    test "current_user must be a member of at least a Shipit.github_teams" do
+      session[:user_id] = shipit_users(:bob).id
+      Shipit.stubs(:github_teams).returns([shipit_teams(:cyclimse_cooks), shipit_teams(:shopify_developers)])
       get :index
       assert_response :forbidden
-      assert_equal 'You must be a member of cyclimse/cooks to access this application.', response.body
+      assert_equal 'You must be a member of cyclimse/cooks or shopify/developers to access this application.', response.body
     end
 
     test "#show is success" do

--- a/test/controllers/stacks_controller_test.rb
+++ b/test/controllers/stacks_controller_test.rb
@@ -59,7 +59,10 @@ module Shipit
       Shipit.stubs(:github_teams).returns([shipit_teams(:cyclimse_cooks), shipit_teams(:shopify_developers)])
       get :index
       assert_response :forbidden
-      assert_equal 'You must be a member of cyclimse/cooks or shopify/developers to access this application.', response.body
+      assert_equal(
+        'You must be a member of cyclimse/cooks or shopify/developers to access this application.',
+        response.body,
+      )
     end
 
     test "#show is success" do

--- a/test/dummy/config/secrets.example.yml
+++ b/test/dummy/config/secrets.example.yml
@@ -3,7 +3,9 @@ development:
   github_oauth:
     # id:
     # secret:
-    # team:
+    # teams:
+    #   -
+    #   -
   github_api:
     # access_token:
     # login:
@@ -23,5 +25,7 @@ test:
   github_oauth:
     id: 1d
     secret: s3cr37
-    # team:
+    # teams:
+    #   -
+    #   -
   redis_url: "redis://127.0.0.1:6379/7"

--- a/test/unit/shipit_test.rb
+++ b/test/unit/shipit_test.rb
@@ -44,5 +44,21 @@ module Shipit
       refute Shipit.github_enterprise?
       assert_equal({}, Shipit.github_oauth_options)
     end
+
+    test ".github_teams returns false if there's no team" do
+      assert_equal(false, Shipit.github_teams)
+    end
+
+    test ".github_teams returns the team key as an array" do
+      Rails.application.secrets.stubs(:github_oauth).returns('team' => 'shopify/developers')
+      assert_equal(['shopify/developers'], Shipit.github_teams.map(&:handle))
+    end
+
+    test ".github_teams merges the teams and team keys in a single array" do
+      Rails.application.secrets.stubs(:github_oauth).returns(
+        'team' => 'shopify/developers',
+        'teams' => ['shopify/developers', 'cyclimse/cooks'])
+      assert_equal(['cyclimse/cooks', 'shopify/developers'], Shipit.github_teams.map(&:handle))
+    end
   end
 end

--- a/test/unit/shipit_test.rb
+++ b/test/unit/shipit_test.rb
@@ -45,8 +45,8 @@ module Shipit
       assert_equal({}, Shipit.github_oauth_options)
     end
 
-    test ".github_teams returns false if there's no team" do
-      assert_equal(false, Shipit.github_teams)
+    test ".github_teams returns an empty array if there's no team" do
+      assert_equal([], Shipit.github_teams)
     end
 
     test ".github_teams returns the team key as an array" do


### PR DESCRIPTION
Rationale: sometimes a single team is not enough.

I tried to be as backward compatible as possible and thus a simple `team` with a single value still works. While I was there, I made Rubocop happy again.