### PR TITLE
Concurrent deploys now need to be acknowledged with a checkbox

### DIFF
--- a/app/assets/javascripts/shipit/checklist.js.coffee
+++ b/app/assets/javascripts/shipit/checklist.js.coffee
@@ -1,9 +1,9 @@
 $document = $(document)
 
 toggleDeployButton = ->
-  $('.trigger-deploy').toggleClass('disabled btn--disabled', !!$(':checkbox[name=checklist]:not(:checked)').length)
+  $('.trigger-deploy').toggleClass('disabled btn--disabled', !!$(':checkbox.required:not(:checked)').length)
 
-$document.on('change', ':checkbox[name=checklist]', toggleDeployButton)
+$document.on('change', ':checkbox.required', toggleDeployButton)
 
 jQuery ($) ->
   toggleDeployButton()

--- a/app/views/shipit/deploys/_checklist.html.erb
+++ b/app/views/shipit/deploys/_checklist.html.erb
@@ -6,7 +6,7 @@
   <ul class="deploy-checklist">
     <%- checklist.each_with_index do |check, index| -%>
       <li class="deploy-checklist__item">
-        <%= check_box_tag :checklist, nil, false, class: 'deploy-checklist__item__checkbox', id: "checkbox_#{index}" %>
+        <%= check_box_tag :checklist, nil, false, class: 'deploy-checklist__item__checkbox required', id: "checkbox_#{index}" %>
         <label class="deploy-checklist__item__label" for="checkbox_<%= index %>">
           <%= sanitize(check, tags: %w(a strong), attributes: %w(href target)) %>
         </label>

--- a/app/views/shipit/deploys/_concurrent_deploy_warning.html.erb
+++ b/app/views/shipit/deploys/_concurrent_deploy_warning.html.erb
@@ -2,5 +2,9 @@
   <h2><%= render_github_user(@stack.active_deploy.author) %> is already deploying!</h2>
   <ul>
     <li>Are you sure you want to deploy concurrently?</li>
+    <li>
+      <%= check_box_tag :force, true, false, class: 'required' %>
+      Yes I know what I'm doing.
+    </li>
   </ul>
 </section>

--- a/app/views/shipit/deploys/new.html.erb
+++ b/app/views/shipit/deploys/new.html.erb
@@ -1,8 +1,6 @@
 <%= render partial: 'shipit/stacks/header', locals: { stack: @stack } %>
 
 <div class="wrapper">
-  <%= render 'concurrent_deploy_warning' if @stack.deploying? %>
-
   <section>
     <header class="section-header">
       <h2>Commits included in this deploy (<%= link_to_github_deploy(@deploy) %>)</h2>
@@ -45,10 +43,10 @@
         <% end %>
       </section>
     <% end %>
+
+    <%= render 'concurrent_deploy_warning' if @stack.deploying? %>
+
     <section class="submit-section">
-      <% if @stack.deploying? %>
-        <%= hidden_field_tag :force, value: true %>
-      <% end %>
       <%= f.hidden_field :until_commit_id %>
       <%= f.submit class: 'btn btn--primary btn--large trigger-deploy' %>
     </section>

--- a/app/views/shipit/deploys/rollback.html.erb
+++ b/app/views/shipit/deploys/rollback.html.erb
@@ -9,8 +9,6 @@
     </ul>
   </section>
 
-  <%= render 'concurrent_deploy_warning' if @stack.deploying? %>
-
   <section>
     <header class="section-header">
       <h2>Commits included in this rollback</h2>
@@ -41,10 +39,10 @@
         <% end %>
       </section>
     <% end %>
+
+    <%= render 'concurrent_deploy_warning' if @stack.deploying? %>
+
     <section class="submit-section">
-      <% if @stack.deploying? %>
-        <%= hidden_field_tag :force, value: true %>
-      <% end %>
       <%= f.hidden_field :parent_id %>
       <%= f.submit 'Rollback', :class => ['btn', 'rollback', 'trigger-rollback'], data: {confirm: "Are you really sure it's safe?"} %>
     </section>


### PR DESCRIPTION
### Context

If you attempt to deploy while another deploy is already ongoing (either because of a race condition, or because you bypassed the UI), you are warned by a banner:

<img width="1173" alt="capture d ecran 2016-02-05 a 15 55 57" src="https://cloud.githubusercontent.com/assets/44640/12858960/1ae5bb74-cc21-11e5-86f8-0f5226df2eec.png">

### Problem

If the review step become a bit too lengthly, e.g multiple checklist items plus review graphs and a long list of commits, the banner can easily be outside of the screen because of the scrolling.

### Solution

The banner is repeated at the bottom, and the second one require you to acknowledges the risks of a concurrent deploy before proceeding. Not sure if the top banner should be removed or not.

<img width="1183" alt="capture d ecran 2016-02-05 a 16 00 47" src="https://cloud.githubusercontent.com/assets/44640/12859046/a87c92e6-cc21-11e5-840f-0eaa6d67df96.png">


cc @aaslamin 

@davidcornu @etiennebarrie @tjoyal for review please.