### PR TITLE
Prevent running concurrent tasks unless they are explictly allowed to

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,6 +255,18 @@ tasks:
       - ssh deploy@myserver.example.com 'touch myapp/restart.txt'
 ```
 
+By default custom tasks are not allowed to be triggered while a deploy is running. But if it's safe for that specific task you can change that behavior with the `allow_concurrency` attribute:
+
+```yml
+tasks:
+  flush_cache:
+    action: "Flush Cache"
+    steps:
+      - ssh deploy@myserver.example.com 'myapp/flush_cache.sh'
+    allow_concurrency: true
+```
+
+
 <h3 id="review-process">Review process</h3>
 
 You can display review elements, such as monitoring data or a pre-deployment checklist, on the deployment page in Shipit:

--- a/app/controllers/shipit/deploys_controller.rb
+++ b/app/controllers/shipit/deploys_controller.rb
@@ -16,7 +16,7 @@ module Shipit
     end
 
     def create
-      return redirect_to new_stack_deploy_path(@stack, sha: @until_commit.sha) if !params[:force] && @stack.deploying?
+      return redirect_to new_stack_deploy_path(@stack, sha: @until_commit.sha) if !params[:force] && @stack.active_task?
 
       @deploy = @stack.trigger_deploy(@until_commit, current_user, env: deploy_params[:env])
       respond_with(@deploy.stack, @deploy)

--- a/app/controllers/shipit/rollbacks_controller.rb
+++ b/app/controllers/shipit/rollbacks_controller.rb
@@ -4,7 +4,7 @@ module Shipit
     before_action :load_deploy
 
     def create
-      return redirect_to rollback_stack_deploy_path(@stack, @deploy) if !params[:force] && @stack.deploying?
+      return redirect_to rollback_stack_deploy_path(@stack, @deploy) if !params[:force] && @stack.active_task?
       @rollback = @deploy.trigger_rollback(current_user, env: rollback_params[:env])
       redirect_to stack_deploy_path(@stack, @rollback)
     end

--- a/app/controllers/shipit/tasks_controller.rb
+++ b/app/controllers/shipit/tasks_controller.rb
@@ -24,7 +24,7 @@ module Shipit
     def create
       @definition = stack.find_task_definition(params[:definition_id])
 
-      if @definition.allow_concurrency? || params[:force] || !@stack.deploying?
+      if @definition.allow_concurrency? || params[:force] || !@stack.active_task?
         @task = stack.trigger_task(params[:definition_id], current_user)
         redirect_to [stack, @task]
       else

--- a/app/controllers/shipit/tasks_controller.rb
+++ b/app/controllers/shipit/tasks_controller.rb
@@ -22,8 +22,14 @@ module Shipit
     end
 
     def create
-      @task = stack.trigger_task(params[:definition_id], current_user)
-      redirect_to [stack, @task]
+      @definition = stack.find_task_definition(params[:definition_id])
+
+      if @definition.allow_concurrency? || params[:force] || !@stack.deploying?
+        @task = stack.trigger_task(params[:definition_id], current_user)
+        redirect_to [stack, @task]
+      else
+        redirect_to new_stack_tasks_path(stack, @definition)
+      end
     end
 
     def abort

--- a/app/helpers/shipit/stacks_helper.rb
+++ b/app/helpers/shipit/stacks_helper.rb
@@ -12,7 +12,7 @@ module Shipit
 
       caption = 'Redeploy'
       caption = 'Locked' if commit.stack.locked? && !ignore_lock?
-      caption = 'Deploy in progress...' if commit.stack.deploying?
+      caption = 'Deploy in progress...' if commit.stack.active_task?
 
       link_to(caption, url, class: classes)
     end
@@ -70,7 +70,7 @@ module Shipit
       state = commit.status.state
       state = 'locked' if commit.stack.locked? && !ignore_lock?
       if commit.deployable?
-        state = commit.stack.deploying? ? 'deploying' : 'enabled'
+        state = commit.stack.active_task? ? 'deploying' : 'enabled'
       end
       t("deploy_button.caption.#{state}")
     end

--- a/app/jobs/shipit/fetch_deployed_revision_job.rb
+++ b/app/jobs/shipit/fetch_deployed_revision_job.rb
@@ -3,7 +3,7 @@ module Shipit
     queue_as :default
 
     def perform(stack)
-      return if stack.deploying?
+      return if stack.active_task?
 
       commands = StackCommands.new(stack)
 

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -191,12 +191,12 @@ module Shipit
     end
 
     def deploying?
-      !!active_deploy
+      !!active_task
     end
 
-    def active_deploy
-      return @active_deploy if defined?(@active_deploy)
-      @active_deploy ||= deploys_and_rollbacks.active.last
+    def active_task
+      return @active_task if defined?(@active_task)
+      @active_task ||= tasks.active.exclusive.last
     end
 
     def locked?
@@ -283,7 +283,7 @@ module Shipit
     private
 
     def clear_cache
-      remove_instance_variable(:@active_deploy) if defined?(@active_deploy)
+      remove_instance_variable(:@active_task) if defined?(@active_task)
     end
 
     def sync_github

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -85,7 +85,7 @@ module Shipit
     end
 
     def update_deployed_revision(sha)
-      return if deploying?
+      return if active_task?
 
       last_deploy = deploys_and_rollbacks.last
       actual_deployed_commit = commits.reachable.by_sha!(sha)
@@ -108,7 +108,7 @@ module Shipit
     end
 
     def status
-      return :deploying if deploying?
+      return :deploying if active_task?
       :default
     end
 
@@ -133,7 +133,7 @@ module Shipit
     end
 
     def deployable?
-      !locked? && !deploying?
+      !locked? && !active_task?
     end
 
     def repo_name=(name)
@@ -190,7 +190,7 @@ module Shipit
       Shipit.github_api.commits(github_repo_name, sha: branch)
     end
 
-    def deploying?
+    def active_task?
       !!active_task
     end
 

--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -15,6 +15,7 @@ module Shipit
     scope :success, -> { where(status: 'success') }
     scope :completed, -> { where(status: %w(success error failed flapping aborted)) }
     scope :active, -> { where(status: %w(pending running aborting)) }
+    scope :exclusive, -> { where(allow_concurrency: false) }
 
     scope :due_for_rollup, -> { completed.where(rolled_up: false).where('created_at <= ?', 1.hour.ago) }
 

--- a/app/models/shipit/task_definition.rb
+++ b/app/models/shipit/task_definition.rb
@@ -16,6 +16,7 @@ module Shipit
     end
 
     attr_reader :id, :action, :description, :steps, :checklist
+    alias_method :to_param, :id
 
     def initialize(id, config)
       @id = id
@@ -23,6 +24,11 @@ module Shipit
       @description = config['description'] || ''
       @steps = config['steps'] || []
       @checklist = config['checklist'] || []
+      @allow_concurrency = config['allow_concurrency'] || false
+    end
+
+    def allow_concurrency?
+      @allow_concurrency
     end
 
     def as_json
@@ -32,6 +38,7 @@ module Shipit
         description: description,
         steps: steps,
         checklist: checklist,
+        allow_concurrency: allow_concurrency?,
       }
     end
   end

--- a/app/views/shipit/deploys/_concurrent_deploy_warning.html.erb
+++ b/app/views/shipit/deploys/_concurrent_deploy_warning.html.erb
@@ -1,5 +1,5 @@
 <section class="warning concurrent-deploy">
-  <h2><%= render_github_user(@stack.active_deploy.author) %> is already deploying!</h2>
+  <h2><%= render_github_user(@stack.active_task.author) %> is already deploying!</h2>
   <ul>
     <li>Are you sure you want to deploy concurrently?</li>
     <li>

--- a/app/views/shipit/deploys/_deploy.html.erb
+++ b/app/views/shipit/deploys/_deploy.html.erb
@@ -23,12 +23,12 @@
   <% unless read_only %>
     <div class="commit-actions">
       <% if deploy.rollbackable? %>
-        <% if deploy.stack.deploying? %>
+        <% if deploy.stack.active_task? %>
           <%= link_to 'Deploy in progress...', '#', class: 'btn disabled deploy-action' %>
         <% else %>
           <%= link_to 'Rollback to this deploy...', rollback_stack_deploy_path(@stack, deploy), class: 'btn btn--delete deploy-action rollback-action' %>
         <% end %>
-      <% elsif deploy.currently_deployed? && !deploy.stack.deploying? %>
+      <% elsif deploy.currently_deployed? && !deploy.stack.active_task? %>
         <%= redeploy_button(deploy.until_commit) %>
       <% end %>
     </div>

--- a/app/views/shipit/deploys/new.html.erb
+++ b/app/views/shipit/deploys/new.html.erb
@@ -44,7 +44,7 @@
       </section>
     <% end %>
 
-    <%= render 'concurrent_deploy_warning' if @stack.deploying? %>
+    <%= render 'concurrent_deploy_warning' if @stack.active_task? %>
 
     <section class="submit-section">
       <%= f.hidden_field :until_commit_id %>

--- a/app/views/shipit/deploys/rollback.html.erb
+++ b/app/views/shipit/deploys/rollback.html.erb
@@ -40,7 +40,7 @@
       </section>
     <% end %>
 
-    <%= render 'concurrent_deploy_warning' if @stack.deploying? %>
+    <%= render 'concurrent_deploy_warning' if @stack.active_task? %>
 
     <section class="submit-section">
       <%= f.hidden_field :parent_id %>

--- a/app/views/shipit/tasks/new.html.erb
+++ b/app/views/shipit/tasks/new.html.erb
@@ -15,6 +15,10 @@
 
   <section class="submit-section">
     <%= form_for @task, url: stack_tasks_path(@stack, definition_id: @task.definition.id) do |f| %>
+      <% if !@task.definition.allow_concurrency? && @stack.deploying? %>
+        <%= render 'shipit/deploys/concurrent_deploy_warning' %>
+      <% end %>
+
       <%= f.submit @task.definition.action, :class => ['btn', 'primary', 'trigger-deploy'] %>
     <% end %>
   </section>

--- a/app/views/shipit/tasks/new.html.erb
+++ b/app/views/shipit/tasks/new.html.erb
@@ -15,7 +15,7 @@
 
   <section class="submit-section">
     <%= form_for @task, url: stack_tasks_path(@stack, definition_id: @task.definition.id) do |f| %>
-      <% if !@task.definition.allow_concurrency? && @stack.deploying? %>
+      <% if !@task.definition.allow_concurrency? && @stack.active_task? %>
         <%= render 'shipit/deploys/concurrent_deploy_warning' %>
       <% end %>
 

--- a/db/migrate/20160210183823_add_allow_concurrency_to_tasks.rb
+++ b/db/migrate/20160210183823_add_allow_concurrency_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddAllowParallelismToTasks < ActiveRecord::Migration
+  def change
+    add_column :tasks, :allow_concurrency, :boolean, null: false, default: false
+  end
+end

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -16,7 +16,7 @@ module Shipit
     end
 
     test "tasks defined in the shipit.yml can't be triggered if the stack is being deployed" do
-      assert @stack.deploying?
+      assert @stack.active_task?
       assert_no_difference -> { @stack.tasks.count } do
         post :create, stack_id: @stack, definition_id: @definition.id
       end
@@ -24,7 +24,7 @@ module Shipit
     end
 
     test "tasks defined in the shipit.yml can be triggered anyway if force apram is present" do
-      assert @stack.deploying?
+      assert @stack.active_task?
       assert_difference -> { @stack.tasks.count } do
         post :create, stack_id: @stack, definition_id: @definition.id, force: 'true'
       end

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -15,8 +15,25 @@ module Shipit
       assert_response :ok
     end
 
-    test "tasks defined in the shipit.yml can be triggered" do
-      assert_difference '@stack.tasks.count', 1 do
+    test "tasks defined in the shipit.yml can't be triggered if the stack is being deployed" do
+      assert @stack.deploying?
+      assert_no_difference -> { @stack.tasks.count } do
+        post :create, stack_id: @stack, definition_id: @definition.id
+      end
+      assert_redirected_to new_stack_tasks_path(@stack, @definition)
+    end
+
+    test "tasks defined in the shipit.yml can be triggered anyway if force apram is present" do
+      assert @stack.deploying?
+      assert_difference -> { @stack.tasks.count } do
+        post :create, stack_id: @stack, definition_id: @definition.id, force: 'true'
+      end
+      assert_redirected_to stack_task_path(@stack, Task.last)
+    end
+
+    test "tasks defined in the shipit.yml can be triggered while the stack is being deployed if specified as such" do
+      @definition = @stack.find_task_definition('flush_cache')
+      assert_difference -> { @stack.tasks.count } do
         post :create, stack_id: @stack, definition_id: @definition.id
       end
       assert_redirected_to stack_task_path(@stack, Task.last)

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160210201828) do
+ActiveRecord::Schema.define(version: 20160210185944) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text     "permissions", limit: 65535
@@ -156,6 +156,7 @@ ActiveRecord::Schema.define(version: 20160210201828) do
     t.boolean  "rollback_once_aborted",               default: false,     null: false
     t.text     "env"
     t.integer  "confirmations",                       default: 0,         null: false
+    t.boolean  "allow_concurrency",                   default: false,     null: false
   end
 
   add_index "tasks", ["rolled_up", "created_at", "status"], name: "index_tasks_on_rolled_up_and_created_at_and_status"

--- a/test/fixtures/shipit/stacks.yml
+++ b/test/fixtures/shipit/stacks.yml
@@ -26,6 +26,14 @@ shipit:
           "steps": [
             "cap $ENVIRONMENT deploy:restart"
           ]
+        },
+        "flush_cache": {
+          "action": "Flush cache",
+          "description": "Flush the application cache",
+          "steps": [
+            "cap $ENVIRONMENT cache:flush"
+          ],
+          "allow_concurrency": true
         }
       },
       "ci": {

--- a/test/jobs/fetch_deployed_revision_job_test.rb
+++ b/test/jobs/fetch_deployed_revision_job_test.rb
@@ -9,21 +9,21 @@ module Shipit
     end
 
     test 'the job abort if the stack is deploying' do
-      @stack.expects(:deploying?).returns(true)
+      @stack.expects(:active_task?).returns(true)
       assert_no_difference 'Deploy.count' do
         @job.perform(@stack)
       end
     end
 
     test 'the job abort if #fetch_deployed_revision returns nil' do
-      @stack.expects(:deploying?).returns(false)
+      @stack.expects(:active_task?).returns(false)
       StackCommands.any_instance.expects(:fetch_deployed_revision).returns(nil)
       @stack.expects(:update_deployed_revision).never
       @job.perform(@stack)
     end
 
     test 'the job call update_deployed_revision if #fetch_deployed_revision returns something' do
-      @stack.expects(:deploying?).returns(false)
+      @stack.expects(:active_task?).returns(false)
       StackCommands.any_instance.expects(:fetch_deployed_revision).returns(@commit.sha)
       @stack.expects(:update_deployed_revision).with(@commit.sha)
       @job.perform(@stack)

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -205,39 +205,39 @@ module Shipit
       shipit_stacks(:shipit).destroy
     end
 
-    test "#deploying? is false if stack has no deploy in either pending or running state" do
+    test "#active_task? is false if stack has no deploy in either pending or running state" do
       @stack.deploys.active.destroy_all
-      refute @stack.deploying?
+      refute @stack.active_task?
     end
 
-    test "#deploying? is false if stack has no deploy at all" do
+    test "#active_task? is false if stack has no deploy at all" do
       @stack.deploys.destroy_all
-      refute @stack.deploying?
+      refute @stack.active_task?
     end
 
-    test "#deploying? is true if stack has a deploy in either pending or running state" do
+    test "#active_task? is true if stack has a deploy in either pending or running state" do
       @stack.trigger_deploy(shipit_commits(:third), AnonymousUser.new)
-      assert @stack.deploying?
+      assert @stack.active_task?
     end
 
-    test "#deploying? is true if a rollback is ongoing" do
+    test "#active_task? is true if a rollback is ongoing" do
       shipit_deploys(:shipit_complete).trigger_rollback(AnonymousUser.new)
-      assert @stack.deploying?
+      assert @stack.active_task?
     end
 
-    test "#deploying? is memoized" do
+    test "#active_task? is memoized" do
       assert_queries(1) do
-        10.times { @stack.deploying? }
+        10.times { @stack.active_task? }
       end
     end
 
-    test "#deploying? cache is cleared if a deploy change state" do
+    test "#active_task? cache is cleared if a deploy change state" do
       assert_queries(1) do
-        10.times { @stack.deploying? }
+        10.times { @stack.active_task? }
       end
       @stack.tasks.where(status: 'running').first.error!
       assert_queries(1) do
-        10.times { @stack.deploying? }
+        10.times { @stack.active_task? }
       end
     end
 

--- a/test/models/task_definitions_test.rb
+++ b/test/models/task_definitions_test.rb
@@ -8,6 +8,7 @@ module Shipit
         'action' => 'Restart application',
         'description' => 'Restart app and job servers',
         'steps' => ['touch tmp/restart'],
+        'allow_concurrency' => true,
       )
     end
 
@@ -27,6 +28,7 @@ module Shipit
         description: 'Restart app and job servers',
         steps: ['touch tmp/restart'],
         checklist: [],
+        allow_concurrency: true,
       }
       assert_equal as_json, TaskDefinition.load(TaskDefinition.dump(@definition)).as_json
     end


### PR DESCRIPTION
By design tasks were allowed to be triggered even though a deploy or another task was already running.

But in practice it's not always true, especially for `restart` which is the one we advertise in the README.

So this PR prevent concurrent tasks, just like concurrent deploys are prevented, and it can be bypassed by clicking a checkbox like for deploy.

You can also give your task the `allow_concurrency: true` attribute to both allow to trigger the task during a deploy, and to trigger a deploy while this task is running.

@rafaelfranca @etiennebarrie for review please.

cc @eapache since IIRC you complained about this behavior a couple times.