### PR TITLE
Add variables to the task definitions

### DIFF
--- a/app/models/shipit/task_definition.rb
+++ b/app/models/shipit/task_definition.rb
@@ -15,7 +15,7 @@ module Shipit
       end
     end
 
-    attr_reader :id, :action, :description, :steps, :checklist
+    attr_reader :id, :action, :description, :steps, :checklist, :variables
     alias_method :to_param, :id
 
     def initialize(id, config)
@@ -23,6 +23,7 @@ module Shipit
       @action = config['action']
       @description = config['description'] || ''
       @steps = config['steps'] || []
+      @variables = task_variables(config['variables'] || [])
       @checklist = config['checklist'] || []
       @allow_concurrency = config['allow_concurrency'] || false
     end
@@ -37,9 +38,16 @@ module Shipit
         action: action,
         description: description,
         steps: steps,
+        variables: variables.map(&:to_h),
         checklist: checklist,
         allow_concurrency: allow_concurrency?,
       }
+    end
+
+    private
+
+    def task_variables(config_variables)
+      config_variables.map(&VariableDefinition.method(:new))
     end
   end
 end

--- a/test/dummy/db/seeds.rb
+++ b/test/dummy/db/seeds.rb
@@ -51,6 +51,9 @@ module Shipit
               "steps": [
                 "bundle exec cap $ENVIRONMENT deploy:restart"
               ],
+              "variables": [
+                {"name": "SAFETY_DISABLED", "title": "Set to 1 to do stuff", "default": "0"}
+              ],
               "checklist": [
                 "Hold on your butts",
                 "Eat some chips"

--- a/test/models/task_definitions_test.rb
+++ b/test/models/task_definitions_test.rb
@@ -9,6 +9,8 @@ module Shipit
         'description' => 'Restart app and job servers',
         'steps' => ['touch tmp/restart'],
         'allow_concurrency' => true,
+        'variables' => [{'name' => 'FOO', 'title' => 'Set to 0 to foo', 'default' => 1},
+                        {'name' => 'BAR', 'title' => 'Set to 1 to bar', 'default' => 0}],
       )
     end
 
@@ -29,6 +31,8 @@ module Shipit
         steps: ['touch tmp/restart'],
         checklist: [],
         allow_concurrency: true,
+        variables: [{'name' => 'FOO', 'title' => 'Set to 0 to foo', 'default' => 1, 'value' => nil},
+                    {'name' => 'BAR', 'title' => 'Set to 1 to bar', 'default' => 0, 'value' => nil}],
       }
       assert_equal as_json, TaskDefinition.load(TaskDefinition.dump(@definition)).as_json
     end

--- a/test/unit/deploy_spec_test.rb
+++ b/test/unit/deploy_spec_test.rb
@@ -249,6 +249,35 @@ module Shipit
       assert_equal ['bundle exec foo'], definition.steps
     end
 
+    test "task definitions returns an array of VariableDefinition instances" do
+      @spec.expects(:load_config).returns('tasks' =>
+        {'restart' =>
+          {
+            'variables' => [
+              {
+                'name' => 'SAFETY_DISABLED',
+                'title' => 'Set to 1 to do dangerous things',
+                'default' => 0,
+              },
+              {
+                'name' => 'FOO',
+                'title' => 'Set to 0 to foo',
+                'default' => 1,
+              },
+            ],
+            'steps' => %w(foo),
+          },
+        })
+
+      assert_equal 2, @spec.task_definitions.first.variables.size
+      variable_definition = @spec.task_definitions.first.variables.first
+      assert_equal 'SAFETY_DISABLED', variable_definition.name
+    end
+
+    test "task definitions returns an empty array by default" do
+      assert_equal [], @spec.task_definitions
+    end
+
     test "#review_checklist returns an array" do
       @spec.expects(:load_config).returns('review' => {'checklist' => %w(foo bar)})
       assert_equal %w(foo bar), @spec.review_checklist


### PR DESCRIPTION
As a first step towards being able to set environment variables when running tasks through shipit's API, task definitions need to be able to hold a whitelist of environment variables that a user defines in their `shipit.yml` file.

Later on, we will use this whitelist to reject requests that don't conform to the defined configuration.

cc @byroot @fw42