### PR TITLE
Allow accepting environment variables through Shipit's API

### DIFF
--- a/app/assets/stylesheets/_pages/_deploy.scss
+++ b/app/assets/stylesheets/_pages/_deploy.scss
@@ -9,11 +9,12 @@
   display: flex;
 }
 
-.environment-variables {
+.variables-header {
   margin: 1rem 0;
+  padding-top: 1rem;
 }
 
-.environment-variable {
+.variables-fields {
   input {
     display: inline-block;
     width: inherit;

--- a/app/controllers/shipit/api/base_controller.rb
+++ b/app/controllers/shipit/api/base_controller.rb
@@ -7,6 +7,7 @@ module Shipit
       include Paginable
 
       rescue_from ApiClient::InsufficientPermission, with: :insufficient_permission
+      rescue_from EnvironmentVariables::NotPermitted, with: :validation_error
       rescue_from TaskDefinition::NotFound, with: :not_found
 
       class << self
@@ -58,6 +59,10 @@ module Shipit
 
       def insufficient_permission(error)
         render status: :forbidden, json: {message: error.message}
+      end
+
+      def validation_error(error)
+        render status: :unprocessable_entity, json: {message: error.message}
       end
 
       def not_found(_error)

--- a/app/controllers/shipit/api/deploys_controller.rb
+++ b/app/controllers/shipit/api/deploys_controller.rb
@@ -6,11 +6,12 @@ module Shipit
       params do
         requires :sha, String, length: {in: 6..40}
         accepts :force, Boolean, default: false
+        accepts :env, Hash, default: {}
       end
       def create
         commit = stack.commits.by_sha(params.sha) || param_error!(:sha, 'Unknown revision')
         param_error!(:force, "Can't deploy a locked stack") if !params.force && stack.locked?
-        render_resource stack.trigger_deploy(commit, current_user), status: :accepted
+        render_resource stack.trigger_deploy(commit, current_user, env: params.env), status: :accepted
       end
     end
   end

--- a/app/controllers/shipit/api/tasks_controller.rb
+++ b/app/controllers/shipit/api/tasks_controller.rb
@@ -12,8 +12,11 @@ module Shipit
         render_resource stack.tasks.find(params[:id])
       end
 
+      params do
+        accepts :env, Hash, default: {}
+      end
       def trigger
-        render_resource stack.trigger_task(params[:task_name], current_user), status: :accepted
+        render_resource stack.trigger_task(params[:task_name], current_user, env: params.env), status: :accepted
       end
     end
   end

--- a/app/controllers/shipit/tasks_controller.rb
+++ b/app/controllers/shipit/tasks_controller.rb
@@ -25,7 +25,7 @@ module Shipit
       @definition = stack.find_task_definition(params[:definition_id])
 
       if @definition.allow_concurrency? || params[:force] || !@stack.active_task?
-        @task = stack.trigger_task(params[:definition_id], current_user)
+        @task = stack.trigger_task(params[:definition_id], current_user, env: task_params[:env])
         redirect_to [stack, @task]
       else
         redirect_to new_stack_tasks_path(stack, @definition)
@@ -49,6 +49,12 @@ module Shipit
 
     def stack
       @stack ||= Stack.from_param!(params[:stack_id])
+    end
+
+    def task_params
+      return {} unless params[:task]
+      @definition = stack.find_task_definition(params[:definition_id])
+      @task_params ||= params.require(:task).permit(env: @definition.variables.map(&:name))
     end
   end
 end

--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -13,7 +13,7 @@ module Shipit
     before_create :denormalize_commit_stats
     after_commit :broadcast_update
 
-    delegate :broadcast_update, to: :stack
+    delegate :broadcast_update, :filter_deploy_envs, to: :stack
 
     def build_rollback(user = nil, env: nil)
       Rollback.new(

--- a/app/models/shipit/deploy_spec.rb
+++ b/app/models/shipit/deploy_spec.rb
@@ -90,6 +90,14 @@ module Shipit
       TaskDefinition.new(id, coerce_task_definition(config('tasks', id)) || task_not_found!(id))
     end
 
+    def filter_deploy_envs(env)
+      EnvironmentVariables.with(env).permit(deploy_variables)
+    end
+
+    def filter_task_envs(id, env)
+      find_task_definition(id).filter_envs(env)
+    end
+
     def review_checklist
       (config('review', 'checklist') || discover_review_checklist || []).map(&:strip).select(&:present?)
     end

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -55,13 +55,14 @@ module Shipit
       undeployed_commits_count > 0
     end
 
-    def trigger_task(definition_id, user)
+    def trigger_task(definition_id, user, env: nil)
       commit = last_deployed_commit
       task = tasks.create(
         user_id: user.id,
         definition: find_task_definition(definition_id),
         until_commit_id: commit.id,
         since_commit_id: commit.id,
+        env: filter_task_envs(definition_id, (env || {})),
       )
       task.enqueue
       task
@@ -74,7 +75,7 @@ module Shipit
         user_id: user.id,
         until_commit: until_commit,
         since_commit: since_commit,
-        env: env || {},
+        env: filter_deploy_envs(env || {}),
       )
       deploy.enqueue
       deploy
@@ -217,7 +218,7 @@ module Shipit
     end
 
     delegate :plugins, :task_definitions, :hidden_statuses, :required_statuses, :soft_failing_statuses,
-             :deploy_variables, to: :cached_deploy_spec
+             :deploy_variables, :filter_task_envs, :filter_deploy_envs, to: :cached_deploy_spec
 
     def monitoring?
       monitoring.present?

--- a/app/models/shipit/task_definition.rb
+++ b/app/models/shipit/task_definition.rb
@@ -44,6 +44,10 @@ module Shipit
       }
     end
 
+    def filter_envs(env)
+      EnvironmentVariables.with(env).permit(variables)
+    end
+
     private
 
     def task_variables(config_variables)

--- a/app/views/shipit/_variables.html.erb
+++ b/app/views/shipit/_variables.html.erb
@@ -1,0 +1,15 @@
+<% unless variables.empty? %>
+  <section>
+    <header class="section-header variables-header">
+      <h2><%= header %></h2>
+    </header>
+    <%= form.fields_for field_name do |field| %>
+      <% variables.each do |variable| %>
+        <p class="variables-fields">
+          <%= field.text_field variable.name, value: variable.default %>
+          <%= field.label variable.name, variable.title || variable.name %>
+        </p>
+      <% end %>
+    <% end %>
+  </section>
+<% end %>

--- a/app/views/shipit/deploys/new.html.erb
+++ b/app/views/shipit/deploys/new.html.erb
@@ -28,21 +28,7 @@
   <%= render_checklist @stack.checklist %>
 
   <%= form_for [@stack, @deploy] do |f| %>
-    <% unless @deploy.variables.empty? %>
-      <section>
-        <header class="section-header environment-variables">
-          <h2>Environment variables</h2>
-        </header>
-        <%= f.fields_for :env do |env_fields| %>
-          <% @deploy.variables.each do |variable| %>
-            <p class="environment-variable">
-              <%= env_fields.text_field variable.name, value: variable.default %>
-              <%= env_fields.label variable.name, variable.title || variable.name %>
-            </p>
-          <% end %>
-        <% end %>
-      </section>
-    <% end %>
+    <%= render partial: 'shipit/variables', locals: { variables: @deploy.variables, form: f, header: "Environment Variables", field_name: :env}  %>
 
     <%= render 'concurrent_deploy_warning' if @stack.active_task? %>
 

--- a/app/views/shipit/deploys/rollback.html.erb
+++ b/app/views/shipit/deploys/rollback.html.erb
@@ -24,21 +24,7 @@
   <%= render_checklist @stack.checklist %>
 
   <%= form_for [@stack, @rollback] do |f| %>
-    <% unless @rollback.variables.empty? %>
-      <section>
-        <header class="section-header environment-variables">
-          <h2>Environment variables</h2>
-        </header>
-        <%= f.fields_for :env do |env_fields| %>
-          <% @rollback.variables.each do |variable| %>
-            <p class="environment-variable">
-              <%= env_fields.text_field variable.name, value: variable.default %>
-              <%= env_fields.label variable.name, variable.title || variable.name %>
-            </p>
-          <% end %>
-        <% end %>
-      </section>
-    <% end %>
+    <%= render partial: 'shipit/variables', locals: { variables: @rollback.variables, form: f, header: "Environment Variables", field_name: :env}  %>
 
     <%= render 'concurrent_deploy_warning' if @stack.active_task? %>
 

--- a/app/views/shipit/tasks/new.html.erb
+++ b/app/views/shipit/tasks/new.html.erb
@@ -13,13 +13,17 @@
 
   <%= render_checklist @task.checklist %>
 
-  <section class="submit-section">
-    <%= form_for @task, url: stack_tasks_path(@stack, definition_id: @task.definition.id) do |f| %>
+  <%= form_for @task, url: stack_tasks_path(@stack, definition_id: @task.definition.id) do |f| %>
+
+    <%= render partial: 'shipit/variables', locals: { variables: @task.definition.variables, form: f, header: "Environment Variables", field_name: :env}  %>
+
+    <section class="submit-section">
       <% if !@task.definition.allow_concurrency? && @stack.active_task? %>
         <%= render 'shipit/deploys/concurrent_deploy_warning' %>
       <% end %>
 
       <%= f.submit @task.definition.action, :class => ['btn', 'primary', 'trigger-deploy'] %>
-    <% end %>
-  </section>
+    </section>
+
+  <% end %>
 </div>

--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -37,6 +37,7 @@ require 'shipit/stack_commands'
 require 'shipit/task_commands'
 require 'shipit/deploy_commands'
 require 'shipit/rollback_commands'
+require 'shipit/environment_variables'
 
 SafeYAML::OPTIONS[:default_mode] = :safe
 SafeYAML::OPTIONS[:deserialize_symbols] = false

--- a/lib/shipit/environment_variables.rb
+++ b/lib/shipit/environment_variables.rb
@@ -1,0 +1,34 @@
+module Shipit
+  class EnvironmentVariables
+    NotPermitted = Class.new(StandardError)
+
+    class << self
+      def with(env)
+        EnvironmentVariables.new(env)
+      end
+    end
+
+    def permit(variable_definitions)
+      return {} unless @env
+      raise "A whitelist is required to sanitize environment variables" unless variable_definitions
+      sanitize_env_vars(variable_definitions)
+    end
+
+    private
+
+    def initialize(env)
+      @env = env
+    end
+
+    def sanitize_env_vars(variable_definitions)
+      allowed_variables = variable_definitions.map(&:name)
+
+      allowed, disallowed = @env.partition { |k, _| allowed_variables.include?(k) }.map(&:to_h)
+
+      error_message = "Variables #{disallowed.keys.to_sentence} have not been whitelisted"
+      raise NotPermitted.new(error_message) unless disallowed.empty?
+
+      allowed
+    end
+  end
+end

--- a/test/controllers/api/deploys_controller_test.rb
+++ b/test/controllers/api/deploys_controller_test.rb
@@ -18,6 +18,21 @@ module Shipit
         assert_json 'status', 'pending'
       end
 
+      test "#create triggers a new deploy for whitelisted variables" do
+        correct_env = {'SAFETY_DISABLED' => 1}
+        post :create, stack_id: @stack.to_param, sha: @commit.sha, env: correct_env
+        assert_response :accepted
+        assert_json 'type', 'deploy'
+        assert_json 'status', 'pending'
+      end
+
+      test "#create refuses to trigger a new deploy with incorrect variables" do
+        incorrect_env = {'DANGEROUS_VARIABLE' => 1}
+        post :create, stack_id: @stack.to_param, sha: @commit.sha, env: incorrect_env
+        assert_response :unprocessable_entity
+        assert_json 'message', 'Variables DANGEROUS_VARIABLE have not been whitelisted'
+      end
+
       test "#create use the claimed user as author" do
         request.headers['X-Shipit-User'] = @user.login
         post :create, stack_id: @stack.to_param, sha: @commit.sha

--- a/test/controllers/api/tasks_controller_test.rb
+++ b/test/controllers/api/tasks_controller_test.rb
@@ -31,6 +31,21 @@ module Shipit
         assert_json 'status', 'pending'
       end
 
+      test "#trigger refuses to trigger a task with tasks not whitelisted" do
+        env = {'DANGEROUS_VARIABLE' => 'bar'}
+        post :trigger, stack_id: @stack.to_param, task_name: 'restart', env: env
+        assert_response :unprocessable_entity
+        assert_json 'message', 'Variables DANGEROUS_VARIABLE have not been whitelisted'
+      end
+
+      test "#trigger triggers a task with only whitelisted env variables" do
+        env = {'FOO' => 'bar'}
+        post :trigger, stack_id: @stack.to_param, task_name: 'restart', env: env
+        assert_response :accepted
+        assert_json 'type', 'task'
+        assert_json 'status', 'pending'
+      end
+
       test "#trigger returns a 404 when the task doesn't exist" do
         post :trigger, stack_id: @stack.to_param, task_name: 'doesnt_exist'
         assert_response :not_found

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -39,6 +39,14 @@ module Shipit
       assert_redirected_to stack_task_path(@stack, Task.last)
     end
 
+    test "tasks with variables defined in the shipit.yml can be triggered with their variables set" do
+      env = {"FOO" => "0"}
+
+      post :create, stack_id: @stack, definition_id: @definition.id, task: {env: env}, force: 'true'
+
+      assert_redirected_to stack_tasks_path(@stack, Task.last)
+    end
+
     test "triggered tasks can be observed" do
       get :show, stack_id: @stack, id: @task.id
       assert_response :ok

--- a/test/fixtures/shipit/stacks.yml
+++ b/test/fixtures/shipit/stacks.yml
@@ -23,6 +23,10 @@ shipit:
         "restart": {
           "action": "Restart application",
           "description": "Restart app and job servers",
+          "variables": [
+            {"name": "FOO", "title": "Set to 0 to foo", "default": 1},
+            {"name": "BAR", "title": "Set to 1 to bar", "default": 0}
+          ],
           "steps": [
             "cap $ENVIRONMENT deploy:restart"
           ]

--- a/test/fixtures/shipit/tasks.yml
+++ b/test/fixtures/shipit/tasks.yml
@@ -32,6 +32,10 @@ shipit_restart:
       "id": "restart",
       "action": "Restart application",
       "description": "Restart app and job servers",
+      "variables": [
+        {"name": "FOO", "title": "Set to 0 to foo", "default": 1},
+        {"name": "BAR", "title": "Set to 1 to bar", "default": 0}
+      ],
       "steps": [
         "cap $ENVIRONMENT deploy:restart"
       ]

--- a/test/unit/environment_variables_test.rb
+++ b/test/unit/environment_variables_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+module Shipit
+  class EnvironmentVariablesTest < ActiveSupport::TestCase
+    def setup
+      variable_defs = [
+        {"name" => "FOO", "title" => "Set to 0 to foo", "default" => 1},
+        {"name" => "BAR", "title" => "Set to 1 to bar", "default" => 0},
+      ]
+      @variable_definitions = variable_defs.map(&VariableDefinition.method(:new))
+    end
+    test 'empty env returns empty hash' do
+      empty = {}
+      assert_equal empty, EnvironmentVariables.with(nil).permit(@variable_definitions)
+      assert_equal empty, EnvironmentVariables.with({}).permit(@variable_definitions)
+    end
+
+    test 'correctly sanitizes env variables' do
+      env = {'FOO' => 1, 'BAR' => 1}
+      assert_equal env, EnvironmentVariables.with(env).permit(@variable_definitions)
+    end
+
+    test 'empty permit raises not permitted error' do
+      assert_raises(EnvironmentVariables::NotPermitted) do
+        EnvironmentVariables.with('FOO' => 1).permit({})
+      end
+    end
+
+    test 'throws an exception when a variable is not whitelisted' do
+      env = {'UNSAFE_VARIABLE' => 1}
+      assert_raises(EnvironmentVariables::NotPermitted) do
+        EnvironmentVariables.with(env).permit(@variable_definitions)
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a continuation of #524 in an effort to allow setting environment variables through shipit's API endpoints.

I achieved this by 
* having a whitelist of allowed variables per #524 
* ensuring all variables being set are checked before we trigger a deploy/rollback/task
* creating a small helper library for sanitizing environment variables similar to Rails' strong parameters

cc @fw42 @byroot @gmalette 