### PR TITLE
Prevent race condition when continuous delivery is enabled

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -94,3 +94,6 @@ Style/TrivialAccessors:
 
 Style/ExtraSpacing:
   AllowForAlignment: false
+
+Style/GuardClause:
+  Enabled: false

--- a/app/jobs/shipit/continuous_delivery_job.rb
+++ b/app/jobs/shipit/continuous_delivery_job.rb
@@ -1,0 +1,11 @@
+module Shipit
+  class ContinuousDeliveryJob < BackgroundJob
+    include BackgroundJob::Unique
+
+    queue_as :default
+
+    def perform(stack)
+      stack.trigger_continuous_deploy
+    end
+  end
+end

--- a/test/models/commits_test.rb
+++ b/test/models/commits_test.rb
@@ -69,7 +69,10 @@ module Shipit
       @stack.deploys.destroy_all
 
       assert_difference "Deploy.count" do
-        @stack.commits.last.statuses.create!(state: 'success', context: 'ci/travis')
+        assert_enqueued_with(job: ContinuousDeliveryJob, args: [@stack]) do
+          @stack.commits.last.statuses.create!(state: 'success', context: 'ci/travis')
+        end
+        ContinuousDeliveryJob.new.perform(@stack)
       end
     end
 


### PR DESCRIPTION
### Context

CircleCI is a bit drunk and sometimes send the same status twice in a very short timeframe:

```ruby
=> [{:url=>
  "https://api.github.com/repos/Shopify/starscream/statuses/3c28bfdcc48fae50d0192aa7ce64742c9c89aedc",
 :id=>453068457,
 :state=>"success",
 :description=>"Your tests passed on CircleCI!",
 :target_url=>"https://circleci.com/gh/Shopify/starscream/43380",
 :context=>"ci/circleci",
 :created_at=>2016-02-16 19:19:18 UTC,
 :updated_at=>2016-02-16 19:19:18 UTC,
 ...
, {:url=>
  "https://api.github.com/repos/Shopify/starscream/statuses/3c28bfdcc48fae50d0192aa7ce64742c9c89aedc4742c9c89aedc",
 :id=>453068453,
 :state=>"success",
 :description=>"Your tests passed on CircleCI!",
 :target_url=>"https://circleci.com/gh/Shopify/starscream/43380",
 :context=>"ci/circleci",
 :created_at=>2016-02-16 19:19:18 UTC,
 :updated_at=>2016-02-16 19:19:18 UTC,
 ...
```

In those cases Shipit is subject to a race condition and can trigger two deploys for the same commit.
While there is clearly a problem on CircleCI side, Shipit should not be subject to such race condition.

### Solution

This PR move the code responsible for triggering automatic deploys in a background job, and `BackgroundJob::Unique` prevent any kind of concurrency.

@angelini @rafaelfranca @etiennebarrie @gmalette for review please.