### PR TITLE
Force Encoding.default_internal and Encoding.default_external to UTF8

### DIFF
--- a/lib/shipit/engine.rb
+++ b/lib/shipit/engine.rb
@@ -2,6 +2,8 @@ module Shipit
   class Engine < ::Rails::Engine
     isolate_namespace Shipit
 
+    Encoding.default_internal = Encoding.default_external = Encoding::UTF_8
+
     paths['app/models'] << 'app/serializers' << 'app/serializers/concerns'
 
     initializer 'shipit.config' do |app|


### PR DESCRIPTION
Might fix: https://github.com/Shopify/shipit-engine/issues/538#issuecomment-190497682

@teu could you please try this branch on your Shipit installation?

To do so:

Edit the `Gemfile` so that `gem 'shipit'` look like:

```ruby
gem 'shipit', github: 'Shopify/shipit-engine', branch: 'force-utf8'
```

then run `bundle install`.

Please let me know if it fixes your issue.