### PR TITLE
Add support for GitHub's deployment API

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -14,6 +14,9 @@ AllCops:
 inherit_from:
   .rubocop_todo.yml
 
+Rails/FindEach:
+  Enabled: false
+
 Lint/AssignmentInCondition:
   Enabled: false
 

--- a/app/helpers/shipit/github_url_helper.rb
+++ b/app/helpers/shipit/github_url_helper.rb
@@ -38,7 +38,7 @@ module Shipit
     end
 
     def github_pull_request_url(commit)
-      github_repo_url(commit.stack.repo_owner, commit.stack.repo_name, 'pull', commit.pull_request_id)
+      github_repo_url(commit.stack.repo_owner, commit.stack.repo_name, 'pull', commit.pull_request_number)
     end
 
     def link_to_github_deploy(deploy)

--- a/app/helpers/shipit/stacks_helper.rb
+++ b/app/helpers/shipit/stacks_helper.rb
@@ -53,7 +53,7 @@ module Shipit
     end
 
     def pull_request_link(commit)
-      link_to("##{commit.pull_request_id}", commit.pull_request_url, target: '_blank', class: 'number')
+      link_to("##{commit.pull_request_number}", commit.pull_request_url, target: '_blank', class: 'number')
     end
 
     def render_raw_commit_id_link(commit)

--- a/app/jobs/shipit/create_on_github_job.rb
+++ b/app/jobs/shipit/create_on_github_job.rb
@@ -1,0 +1,11 @@
+module Shipit
+  class CreateOnGithubJob < BackgroundJob
+    include BackgroundJob::Unique
+
+    queue_as :default
+
+    def perform(record)
+      record.create_on_github!
+    end
+  end
+end

--- a/app/models/shipit/commit.rb
+++ b/app/models/shipit/commit.rb
@@ -117,10 +117,10 @@ module Shipit
     end
 
     def pull_request_url
-      parsed && Shipit.github_url("/#{stack.repo_owner}/#{stack.repo_name}/pull/#{pull_request_id}")
+      parsed && Shipit.github_url("/#{stack.repo_owner}/#{stack.repo_name}/pull/#{pull_request_number}")
     end
 
-    def pull_request_id
+    def pull_request_number
       parsed && parsed['pr_id'].to_i
     end
 

--- a/app/models/shipit/commit_deployment.rb
+++ b/app/models/shipit/commit_deployment.rb
@@ -1,0 +1,40 @@
+module Shipit
+  class CommitDeployment < ActiveRecord::Base
+    belongs_to :commit
+    belongs_to :task
+    has_many :statuses, class_name: 'CommitDeploymentStatus'
+
+    after_commit :schedule_create_on_github, on: :create
+
+    delegate :stack, to: :task
+
+    def create_on_github!
+      return unless commit.pull_request?
+
+      create_deployment_on_github!
+      statuses.order(id: :asc).each(&:create_on_github!)
+    end
+
+    def create_deployment_on_github!
+      return if github_id?
+
+      response = Shipit.github_api.create_deployment(
+        stack.github_repo_name,
+        pull_request_head,
+        auto_merge: false,
+        description: "Via Shipit",
+        environment: stack.environment,
+      )
+      update!(github_id: response.id, api_url: response.url)
+    end
+
+    def pull_request_head
+      pull_request = Shipit.github_api.pull_request(stack.github_repo_name, commit.pull_request_number)
+      pull_request.head.sha
+    end
+
+    def schedule_create_on_github
+      CreateOnGithubJob.perform_later(self)
+    end
+  end
+end

--- a/app/models/shipit/commit_deployment_status.rb
+++ b/app/models/shipit/commit_deployment_status.rb
@@ -1,0 +1,43 @@
+module Shipit
+  class CommitDeploymentStatus < ActiveRecord::Base
+    belongs_to :commit_deployment
+
+    after_commit :schedule_create_on_github, on: :create
+
+    delegate :stack, :task, to: :commit_deployment
+
+    def create_on_github!
+      return if github_id?
+      response = Shipit.github_api.create_deployment_status(
+        commit_deployment.api_url,
+        status,
+        target_url: url_helpers.stack_deploy_url(stack, task),
+        description: description,
+      )
+      update!(github_id: response.id, api_url: response.url)
+    end
+
+    def description
+      I18n.t(
+        "deployment_description.#{task_type}.#{status}",
+        sha: task.until_commit.sha,
+        author: task.author.login,
+        stack: stack.to_param,
+      )
+    end
+
+    def task_type
+      task.class.name.demodulize.underscore
+    end
+
+    def schedule_create_on_github
+      CreateOnGithubJob.perform_later(commit_deployment)
+    end
+
+    private
+
+    def url_helpers
+      Engine.routes.url_helpers
+    end
+  end
+end

--- a/app/serializers/shipit/commit_serializer.rb
+++ b/app/serializers/shipit/commit_serializer.rb
@@ -14,7 +14,7 @@ module Shipit
 
     def pull_request
       {
-        number: object.pull_request_id,
+        number: object.pull_request_number,
         html_url: github_pull_request_url(object),
       }
     end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -52,3 +52,14 @@ en:
     messages:
       subset: "is not a strict subset of %{of}"
       ascii: "contains non-ASCII characters"
+  deployment_description:
+    deploy:
+      pending: "%{author} triggered the deploy of %{stack} to %{sha}"
+      success: "%{author} deployed %{stack} to %{sha}"
+      failure: "Deploy of %{stack} to %{sha} by %{author} failed"
+      error: "Deploy of %{stack} to %{sha} by %{author} failed"
+    rollback:
+      pending: "%{author} triggered the rollback of %{stack} to %{sha}"
+      success: "%{author} rolled back %{stack} to %{sha}"
+      failure: "Rollback of %{stack} to %{sha} by %{author} failed"
+      error: "Rollback of %{stack} to %{sha} by %{author} failed"

--- a/db/migrate/20160303163611_create_shipit_commit_deployments.rb
+++ b/db/migrate/20160303163611_create_shipit_commit_deployments.rb
@@ -1,0 +1,14 @@
+class CreateShipitCommitDeployments < ActiveRecord::Migration
+  def change
+    create_table :commit_deployments do |t|
+      t.references :commit, foreign_key: true
+      t.references :task, index: true, foreign_key: true
+      t.integer :github_id, null: true
+      t.string :api_url, null: true
+
+      t.timestamps null: false
+
+      t.index %i(commit_id task_id), unique: true
+    end
+  end
+end

--- a/db/migrate/20160303170913_create_shipit_commit_deployment_statuses.rb
+++ b/db/migrate/20160303170913_create_shipit_commit_deployment_statuses.rb
@@ -1,0 +1,12 @@
+class CreateShipitCommitDeploymentStatuses < ActiveRecord::Migration
+  def change
+    create_table :commit_deployment_statuses do |t|
+      t.references :commit_deployment, index: true, foreign_key: true
+      t.string :status
+      t.integer :github_id
+      t.string :api_url
+
+      t.timestamps null: false
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160210185944) do
+ActiveRecord::Schema.define(version: 20160303183749) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text     "permissions", limit: 65535
@@ -23,6 +23,29 @@ ActiveRecord::Schema.define(version: 20160210185944) do
   end
 
   add_index "api_clients", ["creator_id"], name: "index_api_clients_on_creator_id"
+
+  create_table "commit_deployment_statuses", force: :cascade do |t|
+    t.integer  "commit_deployment_id"
+    t.string   "status"
+    t.integer  "github_id"
+    t.string   "api_url"
+    t.datetime "created_at",           null: false
+    t.datetime "updated_at",           null: false
+  end
+
+  add_index "commit_deployment_statuses", ["commit_deployment_id"], name: "index_commit_deployment_statuses_on_commit_deployment_id"
+
+  create_table "commit_deployments", force: :cascade do |t|
+    t.integer  "commit_id"
+    t.integer  "task_id"
+    t.integer  "github_id"
+    t.string   "api_url"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+  end
+
+  add_index "commit_deployments", ["commit_id", "task_id"], name: "index_commit_deployments_on_commit_id_and_task_id", unique: true
+  add_index "commit_deployments", ["task_id"], name: "index_commit_deployments_on_task_id"
 
   create_table "commits", force: :cascade do |t|
     t.integer  "stack_id",     limit: 4,                     null: false

--- a/test/fixtures/shipit/commit_deployment_statuses.yml
+++ b/test/fixtures/shipit/commit_deployment_statuses.yml
@@ -1,0 +1,19 @@
+shipit_deploy_second_pending:
+  commit_deployment: shipit_deploy_second
+  status: pending
+  github_id: 42
+  api_url: https://api.github.com/repos/shopify/shipit-engine/deployments/1/statuses/42
+
+shipit_deploy_second_success:
+  commit_deployment: shipit_deploy_second
+  status: success
+  github_id: 43
+  api_url: https://api.github.com/repos/shopify/shipit-engine/deployments/1/statuses/43
+
+shipit2_deploy_third_pending:
+  commit_deployment: shipit2_deploy_third
+  status: pending
+
+shipit2_deploy_third_failure:
+  commit_deployment: shipit2_deploy_third
+  status: failure

--- a/test/fixtures/shipit/commit_deployments.yml
+++ b/test/fixtures/shipit/commit_deployments.yml
@@ -1,0 +1,37 @@
+shipit_deploy_second:
+  commit_id: 2 # second
+  task: shipit
+  api_url: https://api.github.com/repos/shopify/shipit-engine/deployments/1
+  github_id: 1
+
+shipit2_deploy_third:
+  commit_id: 3 # third
+  task: shipit2
+  api_url: https://api.github.com/repos/shopify/shipit-engine/deployments/2
+  github_id: 2
+
+shipit_pending_third:
+  commit_id: 3 # third
+  task: shipit_pending
+  api_url: https://api.github.com/repos/shopify/shipit-engine/deployments/3
+  github_id: 3
+
+shipit_pending_fourth:
+  commit_id: 4 # fourth
+  task: shipit_pending
+
+shipit_running_fourth:
+  commit_id: 4 # fourth
+  task: shipit_running
+
+shipit_complete_fourth:
+  commit_id: 4 # fourth
+  task: shipit_complete
+
+shipit_aborted_fourth:
+  commit_id: 4 # fourth
+  task: shipit_aborted
+
+shipit_rollback_fourth:
+  commit_id: 4 # fourth
+  task: shipit_rollback

--- a/test/fixtures/shipit/commits.yml
+++ b/test/fixtures/shipit/commits.yml
@@ -40,7 +40,7 @@ third:
 fourth:
   id: 4
   sha: 467578b362bf2b4df5903e1c7960929361c3435a
-  message: "#yoloshipit!"
+  message: "Merge pull request #7 from shipit-engine/yoloshipit\n\nyoloshipit!"
   stack: shipit
   author: walrus
   committer: walrus

--- a/test/models/commit_deployment_status_test.rb
+++ b/test/models/commit_deployment_status_test.rb
@@ -1,0 +1,26 @@
+require 'test_helper'
+
+module Shipit
+  class CommitDeploymentStatusTest < ActiveSupport::TestCase
+    setup do
+      @status = shipit_commit_deployment_statuses(:shipit2_deploy_third_pending)
+      @deployment = @status.commit_deployment
+      @task = @deployment.task
+      @commit = @deployment.commit
+    end
+
+    test 'creation on GitHub' do
+      response = stub(id: 44, url: 'https://example.com')
+      Shipit.github_api.expects(:create_deployment_status).with(
+        @deployment.api_url,
+        'pending',
+        target_url: "http://shipit.com/shopify/shipit-engine/production/deploys/#{@task.id}",
+        description: "walrus triggered the deploy of shopify/shipit-engine/production to #{@commit.sha}",
+      ).returns(response)
+
+      @status.create_on_github!
+      assert_equal response.id, @status.github_id
+      assert_equal response.url, @status.api_url
+    end
+  end
+end

--- a/test/models/commit_deployment_test.rb
+++ b/test/models/commit_deployment_test.rb
@@ -1,0 +1,36 @@
+require 'test_helper'
+
+module Shipit
+  class CommitDeploymentTest < ActiveSupport::TestCase
+    setup do
+      @deployment = shipit_commit_deployments(:shipit_pending_fourth)
+      @commit = @deployment.commit
+      @task = @deployment.task
+      @stack = @task.stack
+    end
+
+    test "there can only be one record per deploy and commit pair" do
+      assert_raises ActiveRecord::RecordNotUnique do
+        CommitDeployment.create!(task: @deployment.task, commit: @deployment.commit)
+      end
+    end
+
+    test "creation on GitHub" do
+      pull_request_response = stub(head: stub(sha: '6dcb09b5b57875f334f61aebed695e2e4193db5e'))
+      Shipit.github_api.expects(:pull_request).with('shopify/shipit-engine', 7).returns(pull_request_response)
+
+      deployment_response = stub(id: 42, url: 'https://example.com')
+      Shipit.github_api.expects(:create_deployment).with(
+        'shopify/shipit-engine',
+        pull_request_response.head.sha,
+        auto_merge: false,
+        description: "Via Shipit",
+        environment: @stack.environment,
+      ).returns(deployment_response)
+
+      @deployment.create_on_github!
+      assert_equal deployment_response.id, @deployment.github_id
+      assert_equal deployment_response.url, @deployment.api_url
+    end
+  end
+end

--- a/test/models/commits_test.rb
+++ b/test/models/commits_test.rb
@@ -20,9 +20,9 @@ module Shipit
       assert_equal "Bump to v1.0.1", @pr.pull_request_title
     end
 
-    test "#pull_request_id extract the pull request id from the message" do
-      assert_equal 31, @pr.pull_request_id
-      assert_nil @commit.pull_request_id
+    test "#pull_request_number extract the pull request id from the message" do
+      assert_equal 31, @pr.pull_request_number
+      assert_nil @commit.pull_request_number
     end
 
     test "#pull_request_title extract the pull request title from the message" do

--- a/test/models/deploys_test.rb
+++ b/test/models/deploys_test.rb
@@ -211,6 +211,18 @@ module Shipit
       end
     end
 
+    test "creating a deploy creates one CommitDeployment per commit" do
+      shipit = shipit_stacks(:shipit)
+      deploy = shipit.deploys.build(
+        since_commit: shipit.commits.first,
+        until_commit: shipit.commits.last,
+      )
+
+      assert_difference -> { CommitDeployment.count }, deploy.commits.size do
+        deploy.save!
+      end
+    end
+
     test "#build_rollback returns an unsaved record" do
       assert @deploy.build_rollback.new_record?
     end


### PR DESCRIPTION
Fix: https://github.com/Shopify/shipit-engine/issues/23

![capture d ecran 2016-03-03 a 14 55 30](https://cloud.githubusercontent.com/assets/44640/13507296/01069978-e150-11e5-9df1-e5c4e7819927.png)
See: https://github.com/byroot/junk/pull/9

So we're not really using it as it is intended to be, but it does work good enough to have the little squirrels in the PRs that link to the deploys and make it easy to know when a feature was actually shipped.

@rafaelfranca @gmalette @davidcornu @etiennebarrie mind taking a quick :eyes: ?