### PR TITLE
Stack merge status hooks

### DIFF
--- a/app/models/shipit/commit.rb
+++ b/app/models/shipit/commit.rb
@@ -92,7 +92,7 @@ module Shipit
 
       payload = {commit: self, stack: stack, status: new_status.state}
       Hook.emit(:commit_status, stack, payload.merge(commit_status: new_status)) if previous_status != new_status
-      if simple_state(previous_status) != simple_state(new_status) && !new_status.pending?
+      if previous_status.simple_state != new_status.simple_state && !new_status.pending?
         Hook.emit(:deployable_status, stack, payload.merge(deployable_status: new_status))
       end
       new_status
@@ -198,10 +198,6 @@ module Shipit
 
     def touch_stack
       stack.touch
-    end
-
-    def simple_state(status)
-      status.state == 'error' ? 'failure' : status.state
     end
   end
 end

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -125,7 +125,7 @@ module Shipit
         significant_statuses = significant_commits.map(&:significant_status)
         return 'pending' if significant_statuses.empty? || significant_statuses.all?(&:pending?)
 
-        significant_commits.map(&:significant_status).detect { |status| !status.pending? }
+        significant_commits.map(&:significant_status).detect { |status| !status.pending? }.simple_state
       end
     end
 

--- a/app/models/shipit/status.rb
+++ b/app/models/shipit/status.rb
@@ -27,6 +27,10 @@ module Shipit
       false
     end
 
+    def simple_state
+      state == 'error' ? 'failure' : state
+    end
+
     private
 
     def enable_ci_on_stack

--- a/app/models/shipit/unknown_status.rb
+++ b/app/models/shipit/unknown_status.rb
@@ -3,6 +3,7 @@ module Shipit
     def state
       'unknown'
     end
+    alias_method :simple_state, :state
 
     def pending?
       false

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -373,14 +373,6 @@ module Shipit
       assert_equal 'success', @stack.merge_status
     end
 
-    test "#merge_status returns state of last deployed commit if there are no undeployed commits" do
-      last_commit = shipit_commits(:fifth)
-      last_commit.statuses.create!(state: 'failure', context: 'ci/valid')
-
-      @stack.expects(:last_deployed_commit).returns(last_commit)
-      assert_equal 'failure', @stack.merge_status
-    end
-
     test "#merge_status returns pending if all commits have pending state" do
       @stack.commits.each { |commit| commit.destroy if commit.statuses.empty? }
       Status.update_all(state: 'pending')

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -366,11 +366,28 @@ module Shipit
       assert_equal 'locked', @stack.merge_status
     end
 
-    test "#merge_status returns state of last non pending undeployed commit" do
-      shipit_commits(:fifth).statuses.create!(state: 'pending', context: 'ci/valid')
-      shipit_commits(:fourth).statuses.update_all(state: 'success')
+    test "#merge_status returns state of last finalized undeployed commit" do
+      @stack.deploys_and_rollbacks.destroy_all
+      shipit_commits(:fifth).statuses.destroy_all
+      shipit_commits(:fourth).statuses.update_all(state: 'pending')
+      shipit_commits(:third).statuses.update_all(state: 'success')
+      shipit_commits(:second).statuses.update_all(state: 'failure')
 
       assert_equal 'success', @stack.merge_status
+    end
+
+    test "#merge_status returns pending if all undeployed commits are in pending or unknown state" do
+      shipit_commits(:fifth).statuses.destroy_all
+      shipit_commits(:fourth).statuses.update_all(state: 'pending')
+      @stack.expects(:last_deployed_commit).returns(shipit_commits(:third))
+
+      assert_equal 'pending', @stack.merge_status
+    end
+
+    test "#merge_status returns pending if there are no undeployed commits" do
+      @stack.expects(:last_deployed_commit).returns(shipit_commits(:fifth))
+
+      assert_equal 'pending', @stack.merge_status
     end
 
     test "#merge_status returns pending if all commits have pending state" do

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -389,11 +389,5 @@ module Shipit
 
       assert_equal 'pending', @stack.merge_status
     end
-
-    test "#merge_status returns pending if all commits have pending state" do
-      @stack.commits.each { |commit| commit.destroy if commit.statuses.empty? }
-      Status.update_all(state: 'pending')
-      assert_equal 'pending', @stack.merge_status
-    end
   end
 end

--- a/test/models/status_test.rb
+++ b/test/models/status_test.rb
@@ -32,6 +32,15 @@ module Shipit
       assert_not_equal stack_last_updated_at, @stack.reload.updated_at
     end
 
+    test ".simple_state returns failure when status is error" do
+      assert_equal 'failure', Status.new(state: 'error').simple_state
+    end
+
+    test ".simple_state returns status when status is not error" do
+      assert_equal 'success', Status.new(state: 'success').simple_state
+      assert_equal 'failure', Status.new(state: 'failure').simple_state
+    end
+
     private
 
     def github_status


### PR DESCRIPTION
@byroot @gmalette 

This PR adds a hook called `merge_status` that gets emitted after stack is updated. `merge_status` contains the stack parameters and last significant commit status as `merge_status` attribute.

`merge_status` can be any of these: `['locked', 'success', 'failure', 'pending']`
it falls back to the last deployed commit status when all of the undeployed commits are pending or when there is no undeployed commits.

One thing to mention is that it fires this hook after each commit to `stack`. An improvement could be that it only emits this hook after only if merge_status changes.