### PR TITLE
Create Deployment and DeploymentStatus with the task author

### DIFF
--- a/app/models/shipit/anonymous_user.rb
+++ b/app/models/shipit/anonymous_user.rb
@@ -39,5 +39,9 @@ module Shipit
     def read_attribute_for_serialization(attr)
       public_send(attr)
     end
+
+    def github_api
+      Shipit.github_api
+    end
   end
 end

--- a/app/models/shipit/rollback.rb
+++ b/app/models/shipit/rollback.rb
@@ -27,5 +27,15 @@ module Shipit
     def to_partial_path
       'deploys/deploy'
     end
+
+    private
+
+    def create_commit_deployments
+      # Rollback events are confusing in GitHub
+    end
+
+    def update_commit_deployments
+      # Rollback events are confusing in GitHub
+    end
   end
 end

--- a/app/models/shipit/user.rb
+++ b/app/models/shipit/user.rb
@@ -35,6 +35,22 @@ module Shipit
       end
     end
 
+    def github_api
+      return Shipit.github_api unless github_access_token
+
+      @github_api ||= begin
+        client = Octokit::Client.new(access_token: github_access_token)
+        client.middleware.use(
+          Faraday::HttpCache,
+          shared_cache: false,
+          store: Rails.cache,
+          logger: Rails.logger,
+          serializer: NullSerializer,
+        )
+        client
+      end
+    end
+
     def identifiers_for_ping
       {github_id: github_id, name: name, email: email, github_login: login}
     end

--- a/app/models/shipit/user.rb
+++ b/app/models/shipit/user.rb
@@ -38,17 +38,7 @@ module Shipit
     def github_api
       return Shipit.github_api unless github_access_token
 
-      @github_api ||= begin
-        client = Octokit::Client.new(access_token: github_access_token)
-        client.middleware.use(
-          Faraday::HttpCache,
-          shared_cache: false,
-          store: Rails.cache,
-          logger: Rails.logger,
-          serializer: NullSerializer,
-        )
-        client
-      end
+      @github_api ||= Octokit::Client.new(access_token: github_access_token)
     end
 
     def identifiers_for_ping

--- a/test/fixtures/shipit/users.yml
+++ b/test/fixtures/shipit/users.yml
@@ -2,6 +2,8 @@ walrus:
   name:  Lando Walrussian
   email: walrus@shopify.com
   login: walrus
+  encrypted_github_access_token: FuQv9jpHmMZ8Px64xmqASJtKlefv # t0k3n
+  encrypted_github_access_token_iv: "QNS4smChXEXtOjxb\n"
 
 bob:
   name:  Bob the Builder

--- a/test/models/commit_deployment_status_test.rb
+++ b/test/models/commit_deployment_status_test.rb
@@ -7,11 +7,12 @@ module Shipit
       @deployment = @status.commit_deployment
       @task = @deployment.task
       @commit = @deployment.commit
+      @author = @deployment.author
     end
 
     test 'creation on GitHub' do
       response = stub(id: 44, url: 'https://example.com')
-      Shipit.github_api.expects(:create_deployment_status).with(
+      @author.github_api.expects(:create_deployment_status).with(
         @deployment.api_url,
         'pending',
         target_url: "http://shipit.com/shopify/shipit-engine/production/deploys/#{@task.id}",

--- a/test/models/commit_deployment_test.rb
+++ b/test/models/commit_deployment_test.rb
@@ -7,6 +7,7 @@ module Shipit
       @commit = @deployment.commit
       @task = @deployment.task
       @stack = @task.stack
+      @author = @deployment.author
     end
 
     test "there can only be one record per deploy and commit pair" do
@@ -17,10 +18,10 @@ module Shipit
 
     test "creation on GitHub" do
       pull_request_response = stub(head: stub(sha: '6dcb09b5b57875f334f61aebed695e2e4193db5e'))
-      Shipit.github_api.expects(:pull_request).with('shopify/shipit-engine', 7).returns(pull_request_response)
+      @author.github_api.expects(:pull_request).with('shopify/shipit-engine', 7).returns(pull_request_response)
 
       deployment_response = stub(id: 42, url: 'https://example.com')
-      Shipit.github_api.expects(:create_deployment).with(
+      @author.github_api.expects(:create_deployment).with(
         'shopify/shipit-engine',
         pull_request_response.head.sha,
         auto_merge: false,

--- a/test/models/users_test.rb
+++ b/test/models/users_test.rb
@@ -81,6 +81,18 @@ module Shipit
       assert_equal 'george@cyclim.se', user.email
     end
 
+    test "#github_api uses the user's access token" do
+      assert_equal @user.github_access_token, @user.github_api.access_token
+    end
+
+    test "#github_api fallbacks to Shipit.github_api if the user doesn't have an access_token" do
+      assert_equal Shipit.github_api, shipit_users(:bob).github_api
+    end
+
+    test "#github_api fallbacks to Shipit.github_api for anonymous users" do
+      assert_equal Shipit.github_api, AnonymousUser.new.github_api
+    end
+
     private
 
     def fetch_user


### PR DESCRIPTION
This is the completion of #545 and #543. 

Now Shipit attempt to create deployments and deployments statuses on behalf of the user that triggered the deploy.

any of @rafaelfranca @etiennebarrie @davidcornu @gmalette for review please.