### PR TITLE
Add a link to the stack in the task output header

### DIFF
--- a/app/assets/stylesheets/_pages/_deploy.scss
+++ b/app/assets/stylesheets/_pages/_deploy.scss
@@ -63,7 +63,12 @@
   flex-wrap: wrap;
 
   .deploy-banner-section {
+    display: inline-block;
     padding: .95rem 1.5rem 1.125rem;
+  }
+
+  .stack-link {
+    display: none;
   }
 
   .action-buttons {
@@ -75,6 +80,10 @@
     top: 0;
     left: 0;
     right: 0;
+
+    .stack-link {
+      display: inline-block;
+    }
   }
 
   &[data-status="running"]:before,

--- a/app/views/shipit/tasks/_task_output.html.erb
+++ b/app/views/shipit/tasks/_task_output.html.erb
@@ -9,26 +9,29 @@
 <div class="deploy-main" data-task="<%= {repo: @stack.github_repo_name, description: task_description(task)}.to_json %>">
   <span class="deploy-tasks"></span>
   <div class="deploy-banner" data-status="<%= task.status %>">
-      <div class="deploy-banner-section">
-        <a href="#" class="user main-user disabled"><%= task.author.name %></a>
-        <span class="deploy-status">
-          <%= content_for :task_title %>
-        </span>
-      </div>
+    <div class="deploy-banner-section stack-link">
+      <%= link_to "Return to #{@stack.repo_name}/#{@stack.environment}", stack_path(@stack) %>
+    </div>
+    <div class="deploy-banner-section">
+      <a href="#" class="user main-user disabled"><%= task.author.name %></a>
+      <span class="deploy-status">
+        <%= content_for :task_title %>
+      </span>
+    </div>
 
-      <div class="deploy-banner-section action-buttons">
-        <%= link_to abort_stack_task_path(@stack, task), class: "btn btn--alert action-button", data: { action: "abort", status: task.status } do %>
-          <span class="caption--ready">Abort</span>
-          <span class="caption--pending">Aborting...</span>
-        <% end %>
+    <div class="deploy-banner-section action-buttons">
+      <%= link_to abort_stack_task_path(@stack, task), class: "btn btn--alert action-button", data: { action: "abort", status: task.status } do %>
+        <span class="caption--ready">Abort</span>
+        <span class="caption--pending">Aborting...</span>
+      <% end %>
 
-        <% if task.supports_rollback? %>
-          <%= link_to abort_stack_task_path(@stack, task, rollback: true), class: "btn btn--delete action-button", data: { action: "abort", rollback: true, status: task.status } do %>
-            <span class="caption--ready">Abort and Rollback</span>
-            <span class="caption--pending">Aborting with Rollback...</span>
-          <% end %>
+      <% if task.supports_rollback? %>
+        <%= link_to abort_stack_task_path(@stack, task, rollback: true), class: "btn btn--delete action-button", data: { action: "abort", rollback: true, status: task.status } do %>
+          <span class="caption--ready">Abort and Rollback</span>
+          <span class="caption--pending">Aborting with Rollback...</span>
         <% end %>
-      </div>
+      <% end %>
+    </div>
   </div>
 
   <pre class="nowrap" data-status="<%= task.status %>"><code data-next-chunks-url="<%= next_chunks_url(task) %>"><%= task.chunk_output %></code></pre>


### PR DESCRIPTION
Fix: https://github.com/Shopify/shipit-engine/issues/516

When the banner isn't sticky yet the link is not displayed so it's not redondant with the page header:
![capture d ecran 2016-03-04 a 13 27 43](https://cloud.githubusercontent.com/assets/44640/13536288/1536499e-e20d-11e5-9b21-dfd9cf59b807.png)

Once you are scrolled the link appear:
![capture d ecran 2016-03-04 a 13 27 32](https://cloud.githubusercontent.com/assets/44640/13536289/1536e246-e20d-11e5-9558-b870645827ab.png)

@eapache hope it suits your need.