### PR TITLE
downcase organization name for incoming webhook to find the correct hook

### DIFF
--- a/app/controllers/shipit/webhooks_controller.rb
+++ b/app/controllers/shipit/webhooks_controller.rb
@@ -79,7 +79,7 @@ module Shipit
       @webhook ||= if params[:stack_id]
         stack.github_hooks.find_by!(event: event)
       else
-        GithubHook::Organization.find_by!(organization: params.organization.login, event: event)
+        GithubHook::Organization.find_by!(organization: params.organization.login.downcase, event: event)
       end
     end
 

--- a/test/controllers/webhooks_controller_test.rb
+++ b/test/controllers/webhooks_controller_test.rb
@@ -160,6 +160,13 @@ module Shipit
       end
     end
 
+    test ":membership can append a user membership for an organization with capitals" do
+      assert_difference -> { Membership.count }, 1 do
+        post :membership, membership_params.merge(organization: {login: 'Shopify'}, member: {login: 'bob'})
+        assert_response :ok
+      end
+    end
+
     private
 
     def membership_params


### PR DESCRIPTION
We were having trouble with the teams webhooks and it turns out that its because of the capital letters in our organization name. When the `Shipit::Team` is created it downcases the organization, so when the organization webhook came in, it could not be found.

Here is the relevant part of the webhook payload
```
  "organization": {
    "login": "YounilityInc",
    ...
  }
```