### PR TITLE
Clean up new stack UI

### DIFF
--- a/app/assets/stylesheets/_pages/_stacks.scss
+++ b/app/assets/stylesheets/_pages/_stacks.scss
@@ -146,11 +146,15 @@
 
 .new_stack {
   input.repo {
-    width: 150px;
+    width: 200px;
+    display: inline;
 
     &:focus {
       padding-right: 30px !important;
     }
+  }
+  input:focus {
+    border-color: #248af2;
   }
 }
 

--- a/app/views/shipit/stacks/new.html.erb
+++ b/app/views/shipit/stacks/new.html.erb
@@ -8,7 +8,9 @@
       <%= form_for @stack do |f| %>
         <p>
           <%= label_tag "Repo" %>
+          <br>
           <%= Shipit.github_url %>
+          /
           <%= f.text_field :repo_owner, placeholder: 'e.g. Shopify', required: true, class: "repo" %>
           /
           <%= f.text_field :repo_name, required: true, pattern: "^[a-zA-Z0-9\-_\.]+$", class: "repo" %>
@@ -27,8 +29,8 @@
           <span class="form-hint">Where is this stack deployed to?</span>
         </p>
         <p>
-          <%= f.label :ignore_ci, "Allow deploys regardless of CI status" %>
           <%= f.check_box :ignore_ci %>
+          <%= f.label :ignore_ci, "Allow deploys regardless of CI status" %>
         </p>
         <p><%= f.submit class: 'btn' %></p>
       <% end %>


### PR DESCRIPTION
I cleaned up the new stack UI a little bit to address some of the comments in #448 

I did not come up with anything better for the help text of the deploy url, but its bothering me too so I may figure out something yet.

Heres what it looks like:

![screenshot from 2016-03-12 09 39 38](https://cloud.githubusercontent.com/assets/4596632/13723543/bba803b0-e836-11e5-99ec-af4bd1e7ef0b.png)

@dwradcliffe @davidcornu
