### PR TITLE
Use system sed absolutely in Mac OS X

### DIFF
--- a/app/models/shipit/deploy_spec/bundler_discovery.rb
+++ b/app/models/shipit/deploy_spec/bundler_discovery.rb
@@ -26,7 +26,7 @@ module Shipit
         # Heroku apps often specify a ruby version.
         if /darwin/ =~ RUBY_PLATFORM
           # OSX is nitpicky about the -i.
-          %q(sed -i '' '/^ruby\s/d' Gemfile)
+          %q(/usr/bin/sed -i '' '/^ruby\s/d' Gemfile)
         else
           %q(sed -i '/^ruby\s/d' Gemfile)
         end


### PR DESCRIPTION
hi

I use gnu-sed installed with homebrew on Max OS X. So when I deploy, the sed command is in error.

```
$ sed -i '' '/^ruby\s/d' Gemfile
pid: 36177
sed: can't read /^ruby\s/d: No such file or directory
```

I thought it is better to specify the absolute path.