### PR TITLE
Display tasks durations in UI and revamp commit UI for consistency

### DIFF
--- a/app/assets/stylesheets/_pages/_commits.scss
+++ b/app/assets/stylesheets/_pages/_commits.scss
@@ -12,7 +12,7 @@
 }
 
 .commit, .task {
-  padding: 1rem 0;
+  padding: .75rem 0;
   display: flex;
   flex-direction: column;
 

--- a/app/models/shipit/duration.rb
+++ b/app/models/shipit/duration.rb
@@ -1,0 +1,28 @@
+module Shipit
+  class Duration
+    UNITS = {
+      's' => :seconds,
+      'm' => :minutes,
+      'h' => :hours,
+      'd' => :days,
+    }.freeze
+
+    def initialize(seconds)
+      @seconds = seconds
+    end
+
+    def to_i
+      @seconds.to_i
+    end
+
+    def to_s
+      seconds = to_i
+      days, seconds = seconds.divmod(1.day.to_i)
+      if days > 0
+        "#{days}d#{Time.at(seconds).utc.strftime('%Hh%Mm%Ss')}"
+      else
+        Time.at(seconds).utc.strftime('%Hh%Mm%Ss')[/[^0a-z]\w+/] || '0s'
+      end
+    end
+  end
+end

--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -107,7 +107,7 @@ module Shipit
     end
 
     def duration
-      ended_at - started_at if duration?
+      Duration.new(ended_at - started_at) if duration?
     end
 
     def spec

--- a/app/views/shipit/commits/_commit.html.erb
+++ b/app/views/shipit/commits/_commit.html.erb
@@ -5,12 +5,13 @@
     <span class="commit-title"><%= render_commit_message_with_link commit %></span>
     <p class="commit-meta">
       <span class="sha"><%= render_commit_id_link(commit) %></span>
-      <%= timeago_tag(commit.committed_at, force: true) %>
-      <span class="utc-timecode">at <%= commit.committed_at.strftime('%H:%M:%S') %> UTC</span>
       <% if commit.additions? && commit.deletions? %>
         <span class="code-additions">+<%= commit.additions %></span>
         <span class="code-deletions">-<%= commit.deletions %></span>
       <% end %>
+    </p>
+    <p class="commit-meta">
+      <%= timeago_tag(commit.committed_at, force: true) %>
     </p>
   </div>
   <div class="commit-actions">

--- a/app/views/shipit/deploys/_deploy.html.erb
+++ b/app/views/shipit/deploys/_deploy.html.erb
@@ -13,11 +13,20 @@
       </a>
     </span>
     <p class="commit-meta">
+      <%= deploy.rollback? ? 'rolled back' : 'deployed' %>
       <span class="sha"><%= link_to_github_deploy(deploy) %></span>
-      <%= deploy.rollback? ? 'rolled back' : 'deployed' %> <%= timeago_tag(deploy.created_at, force: true) %>
-      <span class="utc-timecode">at <%= deploy.created_at.strftime('%H:%M:%S') %> UTC</span>
       <span class="code-additions">+<%= deploy.additions %></span>
       <span class="code-deletions">-<%= deploy.deletions %></span>
+    </p>
+    <p class="commit-meta">
+      <% if read_only %>
+        <span class="utc-timecode">on <%= deploy.created_at.strftime('%Y-%m-%d %H:%M:%S') %> UTC</span>
+      <% else %>
+        <%= timeago_tag(deploy.created_at, force: true) %>
+      <% end %>
+      <% if deploy.duration? %>
+        in <%= deploy.duration %>
+      <% end %>
     </p>
   </div>
   <% unless read_only %>

--- a/app/views/shipit/tasks/_task.html.erb
+++ b/app/views/shipit/tasks/_task.html.erb
@@ -1,3 +1,5 @@
+<%- read_only ||= false -%>
+
 <li class="task" id="task-<%= task.id %>" data-status="<%= task.status %>">
   <%= render 'shipit/commits/commit_author', commit: task %>
   <a href="<%= stack_task_path(@stack, task) %>" class="status status--<%= task.status %>" data-tooltip="<%= task.status.capitalize %>">
@@ -12,8 +14,14 @@
       </a>
     </span>
     <p class="commit-meta">
-      ran a command <%= timeago_tag(task.created_at, force: true) %>
-      <span class="utc-timecode">at <%= task.created_at.strftime('%H:%M:%S') %> UTC</span>
+      ran a command
+    </p>
+    <p class="commit-meta">
+      <% if read_only %>
+        <span class="utc-timecode">on <%= task.created_at.strftime('%Y-%m-%d %H:%M:%S') %> UTC</span>
+      <% else %>
+        <%= timeago_tag(task.created_at, force: true) %>
+      <% end %>
     </p>
   </div>
 </li>

--- a/test/models/duration_test.rb
+++ b/test/models/duration_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+module Shipit
+  class DurationTest < ActiveSupport::TestCase
+    test "#to_s is precise and readable for humans" do
+      assert_equal '1m01s', Duration.new(61).to_s
+      assert_equal '1m00s', Duration.new(60).to_s
+      assert_equal '59s', Duration.new(59).to_s
+      assert_equal '2d00h00m00s', Duration.new(2.days).to_s
+      assert_equal '0s', Duration.new(0).to_s
+    end
+  end
+end


### PR DESCRIPTION
### Deploys

Before:
![capture d ecran 2016-04-01 a 14 37 51](https://cloud.githubusercontent.com/assets/44640/14216529/56b94c98-f817-11e5-858e-5cefa318bd89.png)

After: 
![capture d ecran 2016-04-01 a 14 26 59](https://cloud.githubusercontent.com/assets/44640/14216456/e1459c28-f816-11e5-8b4e-c2ecece8d5f4.png)

### Commits

Before:
![capture d ecran 2016-04-01 a 14 39 40](https://cloud.githubusercontent.com/assets/44640/14216574/9f10c570-f817-11e5-8770-58914d8fb602.png)

After:
![capture d ecran 2016-04-01 a 14 42 22](https://cloud.githubusercontent.com/assets/44640/14216646/f590d322-f817-11e5-8cd2-53cf3dd3616c.png)

NB: The full UTC timestamp is still visible if you go on the deploy timeline:

![capture d ecran 2016-04-01 a 14 42 57](https://cloud.githubusercontent.com/assets/44640/14216684/1c9c8268-f818-11e5-8279-47c3bd9cac63.png)


@davidcornu @etiennebarrie @gmalette @rafaelfranca thoughts on this?