### PR TITLE
Raw output feature for deploys and tasks

### DIFF
--- a/app/controllers/shipit/deploys_controller.rb
+++ b/app/controllers/shipit/deploys_controller.rb
@@ -13,6 +13,10 @@ module Shipit
     end
 
     def show
+      respond_to do |format|
+        format.html
+        format.text { render plain: @deploy.chunk_output }
+      end
     end
 
     def create

--- a/app/controllers/shipit/tasks_controller.rb
+++ b/app/controllers/shipit/tasks_controller.rb
@@ -19,6 +19,10 @@ module Shipit
 
     def show
       task
+      respond_to do |format|
+        format.html
+        format.text { render plain: @task.chunk_output }
+      end
     end
 
     def create

--- a/app/views/shipit/deploys/show.html.erb
+++ b/app/views/shipit/deploys/show.html.erb
@@ -5,7 +5,7 @@
     deploying
   <% end %>
   <span class="short-sha"><%= render_commit_id_link(@deploy.until_commit) %></span>
-  <%= timeago_tag(@deploy.created_at, force: true) %> at <%= @deploy.created_at %>
+  <%= timeago_tag(@deploy.created_at, force: true) %>
 <% end %>
 
 <%= render partial: 'shipit/tasks/task_output', locals: {task: @deploy} %>

--- a/app/views/shipit/tasks/_task_output.html.erb
+++ b/app/views/shipit/tasks/_task_output.html.erb
@@ -20,6 +20,7 @@
       <span class="deploy-status">
         <%= content_for :task_title %>
       </span>
+      <%= link_to('(view raw output)', { format: :txt }) %>
     </div>
 
     <div class="deploy-banner-section action-buttons">

--- a/app/views/shipit/tasks/show.html.erb
+++ b/app/views/shipit/tasks/show.html.erb
@@ -1,6 +1,6 @@
 <% content_for :task_title do %>
   executing <%= @task.definition.id %>
-  <%= timeago_tag(@task.created_at, force: true) %> at <%= @task.created_at %>
+  <%= timeago_tag(@task.created_at, force: true) %>
 <% end %>
 
 <%= render partial: 'shipit/tasks/task_output', locals: {task: @task} %>

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -15,6 +15,12 @@ module Shipit
       assert_response :success
     end
 
+    test "deploys can be observed as raw text" do
+      get :show, stack_id: @stack, id: @deploy.id, format: "txt"
+      assert_response :success
+      assert_equal("text/plain", @response.content_type)
+    end
+
     test ":new is success" do
       get :new, stack_id: @stack.to_param, sha: @commit.sha
       assert_response :success

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -52,6 +52,12 @@ module Shipit
       assert_response :ok
     end
 
+    test "triggered tasks can be observed as raw text" do
+      get :show, stack_id: @stack, id: @task.id, format: "txt"
+      assert_response :success
+      assert_equal("text/plain", @response.content_type)
+    end
+
     test ":abort call abort! on the deploy" do
       @task = shipit_deploys(:shipit_running)
       @task.pid = 42


### PR DESCRIPTION
Addresses concerns raised by @grollest et al. @byroot for review. To quickly test this in a working instance of Shipit, add `gem 'shipit-engine', git: 'git@github.com:Shopify/shipit-engine', branch: 'raw-output'` to the Gemfile and `bundle update`.

Because of #560, searching through Shipit deploy/task logs got a little clumsy for some use cases. This PR addresses that by adding a link in the deploy/task header to a plain text version of the logs.

For instance (note the link in the header):
<img width="1440" alt="screen shot 2016-04-04 at 3 45 05 pm" src="https://cloud.githubusercontent.com/assets/16654100/14261112/3d598552-fa7d-11e5-971f-92b1d0a73e15.png">

The link leads to the same page, but with a `.txt` extension. The entire log file is rendered verbatim as `text/plain`.
<img width="1440" alt="screen shot 2016-04-04 at 3 45 41 pm" src="https://cloud.githubusercontent.com/assets/16654100/14261133/4aa9c00a-fa7d-11e5-897c-55461c51cad9.png">

This also applies to tasks:
<img width="1440" alt="screen shot 2016-04-04 at 3 46 07 pm" src="https://cloud.githubusercontent.com/assets/16654100/14261136/51b63d92-fa7d-11e5-9367-374cd3c3864c.png">

The rendering also behaves sanely when the task or deploy is still producing output.
<img width="1440" alt="screen shot 2016-04-04 at 3 46 14 pm" src="https://cloud.githubusercontent.com/assets/16654100/14261140/5915dc78-fa7d-11e5-8e4b-fa76cd54ad34.png">