### PR TITLE
Added a js runtime

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -6,6 +6,7 @@ gemspec
 gem 'mysql2'
 gem 'pg'
 gem 'sqlite3'
+gem 'therubyracer', platform: :ruby
 
 group :development do
   gem 'sucker_punch', require: %w(sucker_punch sucker_punch/async_syntax)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -132,6 +132,7 @@ GEM
       thor (>= 0.14, < 2.0)
     json (1.8.3)
     jwt (1.5.1)
+    libv8 (3.16.14.13)
     lodash-rails (4.6.1)
       railties (>= 3.1)
     loofah (2.0.3)
@@ -224,6 +225,7 @@ GEM
       redis (~> 3.0, >= 3.0.4)
     redis-objects (1.2.1)
       redis (>= 3.0.2)
+    ref (2.0.0)
     responders (2.1.2)
       railties (>= 4.2.0, < 5.1)
     rubocop (0.34.0)
@@ -275,6 +277,9 @@ GEM
       concurrent-ruby (~> 1.0.0)
     test_after_commit (0.4.2)
       activerecord (>= 3.2)
+    therubyracer (0.12.2)
+      libv8 (~> 3.16.14.0)
+      ref
     thor (0.19.1)
     thread_safe (0.3.5)
     tilt (2.0.2)
@@ -307,6 +312,7 @@ DEPENDENCIES
   sqlite3
   sucker_punch
   test_after_commit
+  therubyracer
 
 BUNDLED WITH
    1.11.2


### PR DESCRIPTION
I needed to add a js runtime in order to run the tests locally on a Fedora box. It was unclear to me if this should actually be in the `gemspec` as a development dependency instead of in the `Gemfile`.