### PR TITLE
Add proper error handling for stacks, allow editing environment

### DIFF
--- a/app/assets/stylesheets/_base/_forms.scss
+++ b/app/assets/stylesheets/_base/_forms.scss
@@ -27,3 +27,8 @@ textarea {
 .field-wrapper {
   margin-bottom: 1.5rem;
 }
+
+.field_with_errors {
+  border: 1px solid $red;
+  display: inline-block;
+}

--- a/app/assets/stylesheets/_pages/_settings.scss
+++ b/app/assets/stylesheets/_pages/_settings.scss
@@ -8,4 +8,9 @@
   & + & {
     border-top: 1px solid #e5e5e5;
   }
+
+  .form-hint {
+    font-size: smaller;
+    font-style: italic;
+  }
 }

--- a/app/controllers/shipit/stacks_controller.rb
+++ b/app/controllers/shipit/stacks_controller.rb
@@ -25,7 +25,10 @@ module Shipit
     end
 
     def create
-      @stack = Stack.create(create_params)
+      @stack = Stack.new(create_params)
+      unless @stack.save
+        flash[:warning] = @stack.errors.full_messages.to_sentence
+      end
       respond_with(@stack)
     end
 
@@ -73,7 +76,8 @@ module Shipit
     end
 
     def update_params
-      params.require(:stack).permit(:deploy_url, :lock_reason, :continuous_deployment, :ignore_ci).tap do |params|
+      params.require(:stack).permit(:deploy_url, :lock_reason, :environment,
+                                    :continuous_deployment, :ignore_ci).tap do |params|
         params[:lock_author_id] = params[:lock_reason].present? ? current_user.id : nil
       end
     end

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -36,7 +36,8 @@ module Shipit
     after_commit :setup_hooks, :sync_github, on: :create
     after_touch :clear_cache
 
-    validates :repo_name, uniqueness: {scope: %i(repo_owner environment)}
+    validates :repo_name, uniqueness: {scope: %i(repo_owner environment),
+                                       message: 'cannot be used more than once with this environment'}
     validates :repo_owner, :repo_name, :environment, presence: true, ascii_only: true
     validates :repo_owner, format: {with: /\A[a-z0-9_\-\.]+\z/}, length: {maximum: REPO_OWNER_MAX_SIZE}
     validates :repo_name, format: {with: /\A[a-z0-9_\-\.]+\z/}, length: {maximum: REPO_NAME_MAX_SIZE}

--- a/app/views/shipit/stacks/new.html.erb
+++ b/app/views/shipit/stacks/new.html.erb
@@ -6,7 +6,7 @@
   <section>
     <div class="setting-section">
       <%= form_for @stack do |f| %>
-        <p>
+        <div class="field-wrapper">
           <%= label_tag "Repo" %>
           <br>
           <%= Shipit.github_url %>
@@ -14,25 +14,25 @@
           <%= f.text_field :repo_owner, placeholder: 'e.g. Shopify', required: true, class: "repo" %>
           /
           <%= f.text_field :repo_name, required: true, pattern: "^[a-zA-Z0-9\-_\.]+$", class: "repo" %>
-        </p>
-        <p>
+        </div>
+        <div class="field-wrapper">
           <%= f.label :branch %>
           <%= f.text_field :branch, placeholder: 'master' %>
-        </p>
-        <p>
+        </div>
+        <div class="field-wrapper">
           <%= f.label :environment %>
           <%= f.text_field :environment, placeholder: 'production' %>
-        </p>
-        <p>
+        </div>
+        <div class="field-wrapper">
           <%= f.label :deploy_url %>
+          <span class="form-hint"><small>Where is this stack deployed to?</small></span>
           <%= f.text_field :deploy_url, placeholder: 'https://' %>
-          <span class="form-hint">Where is this stack deployed to?</span>
-        </p>
-        <p>
+        </div>
+        <div class="field-wrapper">
           <%= f.check_box :ignore_ci %>
           <%= f.label :ignore_ci, "Allow deploys regardless of CI status" %>
-        </p>
-        <p><%= f.submit class: 'btn' %></p>
+        </div>
+        <div class="field-wrapper"><%= f.submit class: 'btn' %></div>
       <% end %>
     </div>
   </section>

--- a/app/views/shipit/stacks/settings.html.erb
+++ b/app/views/shipit/stacks/settings.html.erb
@@ -9,6 +9,11 @@
     <div class="setting-section">
       <%= form_for @stack do |f| %>
         <div class="field-wrapper">
+          <%= f.label :environment %>
+          <%= f.text_field :environment, placeholder: 'production' %>
+        </div>
+
+        <div class="field-wrapper">
           <%= f.label :deploy_url, 'Deploy URL (Where is this stack deployed to?)' %>
           <%= f.text_field :deploy_url, placeholder: 'https://' %>
         </div>

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -11,7 +11,7 @@ module Shipit
     test "repo_owner, repo_name and environment uniqueness is enforced" do
       clone = Stack.new(@stack.attributes.except('id'))
       refute clone.save
-      assert_equal ["has already been taken"], clone.errors[:repo_name]
+      assert_equal ["cannot be used more than once with this environment"], clone.errors[:repo_name]
     end
 
     test "repo_owner, repo_name, and environment can only be ASCII" do
@@ -28,7 +28,7 @@ module Shipit
             environment: @stack.environment,
           )
         end
-        assert_equal 'Validation failed: Repo name has already been taken', error.message
+        assert_equal 'Validation failed: Repo name cannot be used more than once with this environment', error.message
       end
 
       new_stack = Stack.create!(repo_owner: 'FOO', repo_name: 'BAR')


### PR DESCRIPTION
What this does
---
- Adds errors on stack creation
- Allows you to edit the environment after the stack has been created

![image](https://cloud.githubusercontent.com/assets/3074765/14542099/247e6544-025b-11e6-85f1-884928f559b2.png)

![image](https://cloud.githubusercontent.com/assets/3074765/14541862/ff3ab324-0259-11e6-8cd7-8c02e896dffa.png)


cc @byroot 