### PR TITLE
Implement search query highlithing

### DIFF
--- a/app/assets/javascripts/task/tty.js.coffee
+++ b/app/assets/javascripts/task/tty.js.coffee
@@ -1,6 +1,7 @@
 class OutputLines
   constructor: (@screen, @render) ->
     @query = ''
+    @highlightRegexp = null
     @raw = []
     @renderingCache = {}
     @stripCache = {}
@@ -10,6 +11,7 @@ class OutputLines
       @screen.options.no_data_text = 'No matches'
     else
       @screen.options.no_data_text = 'Loading...'
+    @highlightRegexp = @buildHighlightRegexp(@query)
     @reset()
 
   reset: ->
@@ -28,7 +30,17 @@ class OutputLines
 
   renderLines: (lines) ->
     for line in lines
-      @renderingCache[line] ||= @render(line)
+      @highlight(@renderingCache[line] ||= @render(line))
+
+  buildHighlightRegexp: (query) ->
+    pattern = query.replace(/[|\\{}()[\]^$+*?.]/g, '\\$&').replace(/(\s+)/g, '(<[^>]+>)*$1(<[^>]+>)*')
+    new RegExp("(#{pattern})", 'g')
+
+  highlight: (renderedLine) ->
+    return renderedLine unless @query
+
+    renderedLine.replace(@highlightRegexp, '<mark>$1</mark>').replace(/(<mark>[^<>]*)((<[^>]+>)+)([^<>]*<\/mark>)/, '$1</mark>$2<mark>$4');
+
 
 class @TTY
   FORMATTERS = []


### PR DESCRIPTION
Fix: https://github.com/Shopify/shipit-engine/issues/565

![capture d ecran 2016-04-18 a 14 31 18](https://cloud.githubusercontent.com/assets/44640/14615135/432689ee-0572-11e6-9d8e-789baadedc51.png)

It's not nearly perfect though, it can highlight queries spanning multiple colors, but only if there is a space between the 2 different colors, and other small shortcomings. But I believe it's good enough as a V1, it can always be refined later. 

cc @grollest and @camilo