### PR TITLE
Improve the abort process

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,9 @@ inherit_from:
 Rails/FindEach:
   Enabled: false
 
+Lint/RescueException:
+  Enabled: false
+
 Lint/AssignmentInCondition:
   Enabled: false
 

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -60,7 +60,7 @@ module Shipit
 
     test ":abort call abort! on the deploy" do
       @task = shipit_deploys(:shipit_running)
-      @task.pid = 42
+      @task.ping
       post :abort, stack_id: @stack.to_param, id: @task.id
 
       @task.reload
@@ -71,7 +71,7 @@ module Shipit
 
     test ":abort schedule the rollback if `rollback` is present" do
       @task = shipit_deploys(:shipit_running)
-      @task.pid = 42
+      @task.ping
       post :abort, stack_id: @stack.to_param, id: @task.id, rollback: 'true'
 
       @task.reload

--- a/test/fixtures/timeout
+++ b/test/fixtures/timeout
@@ -1,0 +1,15 @@
+#!/usr/bin/env ruby
+
+trap('INT') do
+  puts "Recieved SIGINT, aborting."
+  exit 1
+end
+
+trap('TERM') do
+  puts "Recieved SIGTERM, aborting."
+  exit 1
+end
+
+puts "Sleeping for 10 seconds"
+sleep 10
+puts "I wasn't killed? WTF"

--- a/test/jobs/perform_task_job_test.rb
+++ b/test/jobs/perform_task_job_test.rb
@@ -65,13 +65,13 @@ module Shipit
     end
 
     test "mark deploy as error if a command timeout" do
-      Timeout.expects(:timeout).raises(Timeout::Error.new)
+      Command.any_instance.expects(:timed_out?).returns(true)
       Command.any_instance.expects(:terminate!)
       assert_nothing_raised do
         @job.perform(@deploy)
       end
-      assert @deploy.reload.error?
-      assert_includes @deploy.chunk_output, 'Timeout::Error'
+      assert_equal 'failed', @deploy.reload.status
+      assert_includes @deploy.chunk_output, 'TimedOut'
     end
 
     test "records stack support for rollbacks and fetching deployed revision" do

--- a/test/test_command_integration.rb
+++ b/test/test_command_integration.rb
@@ -1,0 +1,28 @@
+#!/usr/bin/env ruby
+
+path = './fixtures/timeout'
+buffer = []
+command = Shipit::Command.new({path => {'timeout' => 2}}, env: {}, chdir: __dir__)
+begin
+  command.stream! do |chunk|
+    buffer << chunk
+  end
+rescue Shipit::Command::TimedOut
+  # expected
+end
+
+expected_output = [
+  "Sleeping for 10 seconds\r\n",
+  "\e[1;31mNo output received in the last 2 seconds.\e[0m\n",
+  "\e[1;31mSending SIGINT to PID #{command.pid}\n\e[0m",
+  "Recieved SIGINT, aborting.\r\n",
+]
+
+unless buffer.join == expected_output.join
+  puts "Expected: -------"
+  puts expected_output.map(&:inspect).join("\n")
+  puts "Got: ------------"
+  puts buffer.map(&:inspect).join("\n")
+  puts "-----------------"
+  exit 1
+end

--- a/test/unit/command_test.rb
+++ b/test/unit/command_test.rb
@@ -39,9 +39,18 @@ module Shipit
       assert_equal 5, command.timeout
     end
 
-    test "#timeout returnsthe command option timeout over the `default_timeout` if present" do
+    test "#timeout returns the command option timeout over the `default_timeout` if present" do
       command = Command.new({'cap $LANG deploy' => {'timeout' => 10}}, default_timeout: 5, env: {}, chdir: '.')
       assert_equal 10, command.timeout
+    end
+
+    test "the process is properly terminated if it times out" do
+      # Minitest being run in an at_exit callback, signal handling etc is unreliable
+      assert system(
+        Engine.root.join('test/dummy/bin/rails').to_s,
+        'runner',
+        Engine.root.join('test/test_command_integration.rb').to_s,
+      )
     end
 
     test "command not found" do


### PR DESCRIPTION
Fix: #562 
Fix: #520
Ref: #572 (we use `Timeout.timeout` less)

### Problems

- Until now `Task#abort!` assumed all the shipit processes (web and job) were on the same host. Web processed had to be able to send signal to processes spawned by the jobs.
- If for some reason a `PerformTaskJob` was lost (e.g. sidekiq restart timeout), the task be stuck in the `running` state without any proper way to be marked as failed, see https://github.com/Shopify/shipit-engine/issues/562 

### Solution

- `Shipit::Command` (the class responsible for spawning an monitoring sub processes) now use non-blocking IOs and allows to perform actions at regular intervals.
- That new ability is used by `PerformTaskJob` to report it's still alive back into Redis and to check if the deploy must be aborted (in another redis key).
- The TERM and KILL signals are now sent by the thread which spawned the subprocess, so Shipit an be deployed on multiple hosts or inside containers.
- If a `PerformTaskJob` haven't reported back in the last 15 seconds, `Task#abort!` will assume it's lost and mark the task as errored. While this should theorically only happen in extreme cases, it at least allow to recover from such bad state.

### ETA

I'll test this further on our production deployment of Shipit. I'll merge when I'm confident enough with that new code.

cc @angelini @jules2689 @teu @sgringwe because you suffered from those bugs recently.