### PR TITLE
dev.yml for internal contributors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,7 @@ tmp/*
 shared/*
 config/database.yml
 config/secrets.yml
+config/secrets.development.yml
 data/*
 coverage/*
 public/assets/*
@@ -28,6 +29,5 @@ test/dummy/log/*.log
 test/dummy/tmp/*
 test/dummy/data/*
 test/dummy/.sass-cache
-test/dummy/config/secrets.yml
 
 .byebug_history

--- a/Gemfile
+++ b/Gemfile
@@ -2,9 +2,12 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'mysql2'
-gem 'pg'
 gem 'sqlite3'
+
+group :ci do
+  gem 'mysql2'
+  gem 'pg'
+end
 
 group :development do
   gem 'sucker_punch', require: %w(sucker_punch sucker_punch/async_syntax)

--- a/bin/bootstrap
+++ b/bin/bootstrap
@@ -4,8 +4,15 @@
 set -e
 set -x
 
-cp -n test/dummy/config/secrets.example.yml test/dummy/config/secrets.yml || true
-bundle install
+profile=${1:-example}
+cp -n "config/secrets.development.${profile}.yml" config/secrets.development.yml || true
+
+bundler_flags=''
+if [[ -z "$CI" ]]; then
+  bundler_flags="--without ci"
+fi
+bundle check || bundle install $bundler_flags
+
 rm -rf test/dummy/db/migrate/*.rb
 bundle exec rake db:drop db:create db:schema:load db:migrate db:seed
 bundle exec rake db:drop db:create db:schema:load RAILS_ENV=test

--- a/config/secrets.development.example.yml
+++ b/config/secrets.development.example.yml
@@ -1,0 +1,19 @@
+host: 'http://localhost:3000'
+redis_url: 'redis://127.0.0.1:6379/0'
+
+github_api:
+  # Can be obtained there: https://github.com/settings/tokens/new
+  # The required permissions are: `admin:org_hook`, `admin:repo_hook`, `read:org` and `repo`
+  access_token:
+
+# Can be obtained there: https://github.com/settings/applications/new
+# Set the "Authorization callback URL" as `<host>/github/auth/github/callback`
+github_oauth: 
+  id:
+  secret:
+  # teams: # Optional
+
+# To work on the beta bootstrap re-write
+# features:
+#   - bootstrap
+

--- a/config/secrets.development.shopify.yml
+++ b/config/secrets.development.shopify.yml
@@ -1,0 +1,19 @@
+host: 'http://shipit-engine.localhost'
+redis_url: 'redis://shipit-engine.railgun:6379'
+
+github_api:
+  # Can be obtained there: https://github.com/settings/tokens/new
+  # The required permissions are: `admin:org_hook`, `admin:repo_hook`, `read:org` and `repo`
+  access_token:
+
+# Can be obtained there: https://github.com/settings/applications/new
+# Set the "Authorization callback URL" as `<host>/github/auth/github/callback`
+github_oauth: 
+  id:
+  secret:
+  # teams: # Optional
+
+# To work on the beta bootstrap re-write
+# features:
+#   - bootstrap
+

--- a/dev.yml
+++ b/dev.yml
@@ -1,0 +1,35 @@
+# This file is for Shopify employees development environment.
+# If you are an external contributor you don't have to bother with it.
+name: shipit-engine
+
+up:
+  - homebrew:
+    - openssl
+    - sqlite
+  - ruby:
+      version: 2.1.8
+  - railgun
+  - bundler:
+      without: ci
+
+commands:
+  bootstrap: bin/bootstrap shopify
+  console: test/dummy/bin/rails console
+  server: test/dummy/bin/rails server -b 192.168.64.1 -p 55330
+  test: bin/rake
+
+open:
+  shipit: http://shipit-engine.localhost
+
+railgun:
+  image: dev:railgun-common-services-0.2.x
+  services:
+    redis: 6379
+    nginx: 80
+  ip_address: 192.168.64.85
+  memory: 2G
+  cores: 2
+  disk: 2G
+  proxy:
+    shipit-engine.localhost: 55330
+

--- a/lib/shipit/engine.rb
+++ b/lib/shipit/engine.rb
@@ -9,6 +9,7 @@ module Shipit
     initializer 'shipit.config' do |app|
       Rails.application.routes.default_url_options[:host] = Shipit.host
       Shipit::Engine.routes.default_url_options[:host] = Shipit.host
+      Pubsubstub.redis_url = Shipit.redis_url.to_s
 
       app.config.assets.paths << Emoji.images_path
       app.config.assets.precompile += %w(

--- a/test/dummy/config/initializers/0_load_development_secrets.rb
+++ b/test/dummy/config/initializers/0_load_development_secrets.rb
@@ -1,0 +1,9 @@
+local_secrets = Shipit::Engine.root.join('config/secrets.development.yml')
+if local_secrets.exist?
+  secrets = YAML.load(local_secrets.read)
+  if Rails.env.development?
+    Rails.application.secrets.deep_merge!(secrets)
+  elsif Rails.env.test?
+    Rails.application.secrets.merge!(redis_url: secrets['redis_url'])
+  end
+end

--- a/test/dummy/config/secrets.yml
+++ b/test/dummy/config/secrets.yml
@@ -1,21 +1,5 @@
 development:
   secret_key_base: s3cr3ts3cr3ts3cr3ts3cr3ts3cr3ts3cr3t
-  github_oauth:
-    # id:
-    # secret:
-    # teams:
-    #   -
-    #   -
-  github_api:
-    # access_token:
-    # login:
-    # password:
-    # api_endpoint:
-  host: 'http://localhost:3000'
-  redis_url: "redis://127.0.0.1:6379/7"
-  # features:
-  #   - bootstrap
-
 test:
   secret_key_base: s3cr3ts3cr3ts3cr3ts3cr3ts3cr3ts3cr3t
   host: shipit.com


### PR DESCRIPTION
@burke for review please. It's not as performant as it could be as I don't want to duplicate the logic from `bin/bootstrap`, but IMO it's good enough.

For external contributors the setup stays the same (`bin/bootstrap`) but they must have sqlite3 and redis locally.

Also I moved `mysql2` and `pg` in `ci` group and ignore it by default since they are really only useful on CI unless you are debugging a DB specific bug.