### PR TITLE
Display link to sha range instead of last sha

### DIFF
--- a/app/views/shipit/deploys/show.html.erb
+++ b/app/views/shipit/deploys/show.html.erb
@@ -4,7 +4,7 @@
   <% else %>
     deploying
   <% end %>
-  <span class="short-sha"><%= render_commit_id_link(@deploy.until_commit) %></span>
+  <span class="short-sha"><%= link_to_github_deploy(@deploy) %></span>
   <%= timeago_tag(@deploy.created_at, force: true) %>
 <% end %>
 


### PR DESCRIPTION
On the deploy/show page we only show a link to the last commit that's getting deployed.

I think instead we can show the sha range that's getting deployed.

@byroot 