### PR TITLE
Peek to the last deployed commit on merge_status

### DIFF
--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -144,6 +144,8 @@ module Shipit
         'locked'
       else
         significant_statuses = undeployed_commits.map(&:significant_status)
+        significant_statuses << last_deployed_commit.significant_status unless last_deployed_commit.blank?
+
         last_finalized_status = significant_statuses.reject { |s| %w(pending unknown).include?(s.state) }.first
         last_finalized_status.try!(:simple_state) || 'pending'
       end


### PR DESCRIPTION
Currently `merge_status` only looks at the undeployed commits. `merge_status` doesn't send a `success` webhook when there are no undeployed commits and shipit gets unlocked. 

In those cases, I think it's logical to look at the last deployed commit's status in order to see if the stack is mergeable or not.

/cc @Amos47 @casperisfine