### PR TITLE
Fix last line hidden in deploy/task output

### DIFF
--- a/app/assets/stylesheets/_structure/_main.scss
+++ b/app/assets/stylesheets/_structure/_main.scss
@@ -60,7 +60,7 @@ pre {
   &.nowrap {
     white-space: pre;
     margin-top: -.25rem;
-    margin-bottom: -3rem;
+    margin-bottom: 0rem;
   }
 }
 


### PR DESCRIPTION
The latest line of the deploy/task log output is sometimes not visible, at least not on our browsers (OSX & latest Chrome). It's a bit confusing when the deploy is running a more lengthier process (e.g. assets:precompile) and the log doesn't show that it's doing that thing. The line is in the DOM alright, but it's hidden by the margin-bottom CSS rule.

Setting the margin-bottom to 0 seems to bring it back. I'm not sure why it was set to `-3rem` so let me know if just setting it to 0 like this is not acceptable and I can look for an alternate solution :)