### PR TITLE
Fix "Enable notifications" not showing up

### DIFF
--- a/app/assets/javascripts/shipit.js.coffee
+++ b/app/assets/javascripts/shipit.js.coffee
@@ -21,7 +21,7 @@ $(document).on 'click', '.disabled, .btn--disabled', (event) ->
   event.preventDefault()
 
 jQuery ->
-  $notificationNotice = $('.notifications')
+  $notificationNotice = $('.enable-notifications')
 
   if $.notifyCheck() == $.NOTIFY_NOT_ALLOWED
     $button = $notificationNotice.find('button')

--- a/app/views/layouts/shipit.html.erb
+++ b/app/views/layouts/shipit.html.erb
@@ -13,7 +13,7 @@
     <%= content_tag :div, msg, class: ["flash-#{name}", :flash] %>
   <% end %>
 
-  <div class="banner notification banner--blue hidden">
+  <div class="banner enable-notifications banner--blue hidden">
     <div class="banner__inner wrapper">
       <div class="banner__content">
         <h2 class="banner__title">Do you want to enable desktop notifications?</h2>


### PR DESCRIPTION
Fixes the "Enable Notifications" thingie not showing up for new users.

The CSS class names in HTML & JS were different – line 24 in [shipit.js.coffee](https://github.com/Shopify/shipit-engine/blob/223ea28/app/assets/javascripts/shipit.js.coffee#L24) tries to find `.notifications` while the [HTML layout](https://github.com/Shopify/shipit-engine/blob/b248d57/app/views/layouts/shipit.html.erb#L16) declares the div with CSS class `.notification` (missing letter `s` at the end).

This PR also makes the CSS class name more verbose so as to prevent any mishaps with using `.notification` or `.notifications` somewhere else later in development.