### PR TITLE
Make desktop notifications banner dismissable

### DIFF
--- a/app/assets/javascripts/shipit.js.coffee
+++ b/app/assets/javascripts/shipit.js.coffee
@@ -20,7 +20,13 @@
 $(document).on 'click', '.disabled, .btn--disabled', (event) ->
   event.preventDefault()
 
+$(document).on 'click', '.enable-notifications .banner__dismiss', (event) ->
+  $(event.target).closest('.banner').addClass('hidden')
+  localStorage.setItem("dismissed-enable-notifications", true)
+
 jQuery ->
+  if(localStorage.getItem("dismissed-enable-notifications"))
+    return
   $notificationNotice = $('.enable-notifications')
 
   if $.notifyCheck() == $.NOTIFY_NOT_ALLOWED

--- a/app/views/layouts/shipit.html.erb
+++ b/app/views/layouts/shipit.html.erb
@@ -17,10 +17,12 @@
     <div class="banner__inner wrapper">
       <div class="banner__content">
         <h2 class="banner__title">Do you want to enable desktop notifications?</h2>
+        <div class="banner__accessory">
+          <button class="banner__btn btn">Enable notifications</button>
+        </div>
       </div>
-      <div class="banner__accessory">
-        <button class="banner__btn btn">Enable notifications</button>
-      </div>
+
+      <a class="banner__dismiss">&times;</a>
     </div>
   </div>
 


### PR DESCRIPTION
This adds a dismiss option to the desktop notifications banner:
<img width="1135" alt="screen shot 2016-06-09 at 4 40 32 pm" src="https://cloud.githubusercontent.com/assets/60324/15945525/ebf53306-2e60-11e6-8bcf-eda06635b436.png">

Clicking it hides the banner until the next time you visit; if we like this I can look into cookieing or something so that it stays out of your way for a while.

@casperisfine @pseudomuto 