### PR TITLE
update readme to specify rails version to use

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ This guide aims to help you [set up](#installation-and-setup), [use](#using-ship
 
 Shipit provides you with a Rails template. To bootstrap your Shipit installation:
 
-1. If you don't have Rails installed, run this command: `gem install rails`
-2. Run this command:  `rails new shipit -m https://raw.githubusercontent.com/Shopify/shipit-engine/master/template.rb`
+1. If you don't have Rails installed, run this command: `gem install rails -v 4.2.6`
+2. Run this command:  `rails _4.2.6_ new shipit -m https://raw.githubusercontent.com/Shopify/shipit-engine/master/template.rb`
 3. Enter your **Client ID**, **Client Secret**, and **GitHub API access token** when prompted. These can be found on your application's GitHub page.
 4. To setup the database, run this command: `rake db:setup`
 

--- a/template.rb
+++ b/template.rb
@@ -141,7 +141,7 @@ if yes?("Are you hosting Shipit on Heroku? (y/n)")
 end
 
 after_bundle do
-  rake 'railties:install:migrations db:create db:migrate'
+  run 'bundle exec rake railties:install:migrations db:create db:migrate'
 
   git :init
   run "echo '.env' >> .gitignore"


### PR DESCRIPTION
@byroot I went to set up a new shipit instance not to long after rails 5 came out and ran into a couple bumps. First of all I had rails 5 installed, so the application got generated differently and the shipit-engine gem has a dependency on `~> 4.2.0`, so bundler failed. Additionally I have the rake 11 gem, so the after bundle step failed.