### PR TITLE
add locked_since column to stacks table

### DIFF
--- a/app/controllers/shipit/api/locks_controller.rb
+++ b/app/controllers/shipit/api/locks_controller.rb
@@ -10,7 +10,7 @@ module Shipit
         if stack.locked?
           render json: {message: 'Already locked'}, status: :conflict
         else
-          stack.update(lock_reason: params.reason, lock_author: current_user)
+          stack.lock(params.reason, current_user)
           render_resource stack
         end
       end
@@ -19,12 +19,12 @@ module Shipit
         requires :reason, String, presence: true
       end
       def update
-        stack.update(lock_reason: params.reason, lock_author: current_user)
+        stack.lock(params.reason, current_user)
         render_resource stack
       end
 
       def destroy
-        stack.update(lock_reason: nil, lock_author: nil)
+        stack.unlock
         render_resource stack
       end
     end

--- a/app/controllers/shipit/stacks_controller.rb
+++ b/app/controllers/shipit/stacks_controller.rb
@@ -53,6 +53,14 @@ module Shipit
       unless @stack.update(update_params)
         options = {flash: {warning: @stack.errors.full_messages.to_sentence}}
       end
+
+      reason = params[:stack][:lock_reason]
+      if reason.present?
+        @stack.lock(reason, current_user)
+      elsif @stack.locked?
+        @stack.unlock
+      end
+
       redirect_to(params[:return_to].presence || stack_settings_path(@stack), options)
     end
 
@@ -77,10 +85,8 @@ module Shipit
     end
 
     def update_params
-      params.require(:stack).permit(:deploy_url, :lock_reason, :environment,
-                                    :continuous_deployment, :ignore_ci).tap do |params|
-        params[:lock_author_id] = params[:lock_reason].present? ? current_user.id : nil
-      end
+      params.require(:stack).permit(:deploy_url, :environment,
+                                    :continuous_deployment, :ignore_ci)
     end
   end
 end

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -317,6 +317,16 @@ module Shipit
       lock_reason.present?
     end
 
+    def lock(reason, user)
+      params = {lock_reason: reason, lock_author: user}
+      params[:locked_since] = Time.current if locked_since.nil?
+      update!(params)
+    end
+
+    def unlock
+      update!(lock_reason: nil, lock_author: nil, locked_since: nil)
+    end
+
     def to_param
       [repo_owner, repo_name, environment].join('/')
     end

--- a/app/serializers/shipit/stack_serializer.rb
+++ b/app/serializers/shipit/stack_serializer.rb
@@ -4,7 +4,8 @@ module Shipit
 
     has_one :lock_author
     attributes :id, :repo_owner, :repo_name, :environment, :html_url, :url, :tasks_url, :deploy_url, :deploy_spec,
-               :undeployed_commits_count, :is_locked, :lock_reason, :continuous_deployment, :created_at, :updated_at
+               :undeployed_commits_count, :is_locked, :lock_reason, :continuous_deployment, :created_at,
+               :updated_at, :locked_since
 
     def url
       api_stack_url(object)
@@ -27,6 +28,10 @@ module Shipit
     end
 
     def include_lock_author?
+      object.locked?
+    end
+
+    def include_locked_since?
       object.locked?
     end
 

--- a/db/migrate/20160822131405_add_locked_since_to_stacks.rb
+++ b/db/migrate/20160822131405_add_locked_since_to_stacks.rb
@@ -1,0 +1,5 @@
+class AddLockedSinceToStacks < ActiveRecord::Migration
+  def change
+    add_column :stacks, :locked_since, :datetime, null: true
+  end
+end

--- a/test/controllers/api/locks_controller_test.rb
+++ b/test/controllers/api/locks_controller_test.rb
@@ -13,6 +13,7 @@ module Shipit
         assert_response :ok
         assert_json 'is_locked', true
         assert_json 'lock_reason', 'Just for fun!'
+        assert_json { |json| assert_not_nil json['locked_since'] }
       end
 
       test "#create fails if already locked" do
@@ -36,11 +37,20 @@ module Shipit
         assert_json 'lock_reason', 'Just for fun!'
       end
 
+      test "#update does not override previous locked_since" do
+        since = Time.current.round
+        @stack.update!(lock_reason: 'Meh...', locked_since: since)
+        put :update, stack_id: @stack.to_param, reason: 'Just for fun!'
+        assert_response :ok
+        assert_json 'locked_since', since.utc.iso8601(3)
+      end
+
       test "#destroy clears the lock" do
-        @stack.update!(lock_reason: 'Meh...')
+        @stack.update!(lock_reason: 'Meh...', locked_since: Time.current)
         delete :destroy, stack_id: @stack.to_param
         assert_response :ok
         assert_json 'is_locked', false
+        assert_json { |json| assert_nil json['locked_since'] }
       end
     end
   end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160802092812) do
+ActiveRecord::Schema.define(version: 20160822131405) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text     "permissions", limit: 65535
@@ -147,6 +147,7 @@ ActiveRecord::Schema.define(version: 20160802092812) do
     t.datetime "inaccessible_since"
     t.integer  "estimated_deploy_duration",                       default: 1,            null: false
     t.datetime "continuous_delivery_delayed_since"
+    t.datetime "locked_since"
   end
 
   add_index "stacks", ["repo_owner", "repo_name", "environment"], name: "stack_unicity", unique: true


### PR DESCRIPTION
This adds a `locked_since` datetime column to the stacks table.
This will enable us to build analytics around how often certain stacks are locked.

I'm not sure if I'm doing all this migration stuff properly. Also made some small refactors.

@byroot