### PR TITLE
Add option to skip post-migration restart

### DIFF
--- a/lib/snippets/push-to-heroku
+++ b/lib/snippets/push-to-heroku
@@ -13,7 +13,7 @@ function yellow() {
 HEROKU_APP=$1
 HEROKU_RELEASES=`heroku releases --app $HEROKU_APP 2>&1`
 GIT_COMMAND=${GIT_COMMAND:="git push git@heroku.com:$HEROKU_APP.git $SHA:master $GIT_FLAGS"}
-POST_MIGRATION_DEPLOY="${POST_MIGRATION_DEPLOY:=true}"
+POST_MIGRATION_DEPLOY=${POST_MIGRATION_DEPLOY:="true"}
 
 if [[ -z "${HEROKU_APP}" ]]; then
   red "Usage: $0 <app-name>"
@@ -33,7 +33,7 @@ if [[ $? -ne 0 ]]; then
   exit 1;
 fi
 
-HEROKU_LAST_GOOD_RELEASE=`echo "${HEROKU_RELEASES}" | head -n2 | tail -n1 | sed -e 's/^\(v[0-9]\+\).*/\1/'`
+HEROKU_LAST_GOOD_RELEASE=`echo "$HEROKU_RELEASES" | head -n2 | tail -n1 | sed -e 's/^\(v[0-9]\+\).*/\1/'`
 green "Current heroku release: ${HEROKU_LAST_GOOD_RELEASE}"
 
 green "Pushing to heroku."
@@ -63,7 +63,7 @@ if [[ "${MIGRATIONS}" != "" ]]; then
     exit 1
   fi
 
-  if [[ "${POST_MIGRATION_DEPLOY}" ]]; then
+  if [[ "${POST_MIGRATION_DEPLOY}" == "true" ]]; then
     green "Post-migration dyno restart."
     heroku restart --app $HEROKU_APP
   fi

--- a/lib/snippets/push-to-heroku
+++ b/lib/snippets/push-to-heroku
@@ -13,8 +13,9 @@ function yellow() {
 HEROKU_APP=$1
 HEROKU_RELEASES=`heroku releases --app $HEROKU_APP 2>&1`
 GIT_COMMAND=${GIT_COMMAND:="git push git@heroku.com:$HEROKU_APP.git $SHA:master $GIT_FLAGS"}
+POST_MIGRATION_DEPLOY="${POST_MIGRATION_DEPLOY:=true}"
 
-if [ -z $HEROKU_APP ]; then
+if [[ -z "${HEROKU_APP}" ]]; then
   red "Usage: $0 <app-name>"
   red "Supported environment variables:"
   red "  - GIT_COMMAND: override the entire 'git push' command."
@@ -24,45 +25,45 @@ fi
 
 echo "$HEROKU_RELEASES" | head -n2 | tail -n1 | grep '^\(v[0-9]\+\)' >/dev/null
 
-if [ $? -ne 0 ]; then
+if [[ $? -ne 0 ]]; then
   red "Error detecting current heroku release. Message from 'heroku releases':"
-  echo "$HEROKU_RELEASES"
-  red "Please contact a heroku collaborator for $HEROKU_APP:"
+  echo "${HEROKU_RELEASES}"
+  red "Please contact a heroku collaborator for ${HEROKU_APP}:"
   heroku sharing --app $HEROKU_APP
   exit 1;
 fi
 
-HEROKU_LAST_GOOD_RELEASE=`echo "$HEROKU_RELEASES" | head -n2 | tail -n1 | sed -e 's/^\(v[0-9]\+\).*/\1/'`
-green "Current heroku release: $HEROKU_LAST_GOOD_RELEASE"
+HEROKU_LAST_GOOD_RELEASE=`echo "${HEROKU_RELEASES}" | head -n2 | tail -n1 | sed -e 's/^\(v[0-9]\+\).*/\1/'`
+green "Current heroku release: ${HEROKU_LAST_GOOD_RELEASE}"
 
 green "Pushing to heroku."
 $GIT_COMMAND
-if [ $? -ne 0 ]; then
+if [[ $? -ne 0 ]]; then
   red "Heroku push rejected. See message above."
-  red "Please contact a heroku collaborator for $HEROKU_APP:"
+  red "Please contact a heroku collaborator for ${HEROKU_APP}:"
   heroku sharing --app $HEROKU_APP
   exit 1;
 fi
 
 MIGRATIONS=`heroku run rake db:migrate:status --app $HEROKU_APP | grep -e '^\s*down'`
 
-if [ "$MIGRATIONS" != "" ]; then
+if [[ "${MIGRATIONS}" != "" ]]; then
   green "There are pending migrations to apply:"
   echo $MIGRATIONS
 
   green "Migrating database."
   heroku run rake db:migrate --app $HEROKU_APP
-  if [ $? -ne 0 ]; then
+  if [[ $? -ne 0 ]]; then
     red "Migration failed! This is bad."
-    red "Please contact a heroku collaborator for $HEROKU_APP:"
+    red "Please contact a heroku collaborator for ${HEROKU_APP}:"
     heroku sharing --app $HEROKU_APP
-    red "The app $HEROKU_APP will now be reverted to its last working version $HEROKU_LAST_GOOD_RELEASE."
+    red "The app ${HEROKU_APP} will now be reverted to its last working version ${HEROKU_LAST_GOOD_RELEASE}."
     heroku releases:rollback $HEROKU_LAST_GOOD_RELEASE --app $HEROKU_APP
     red "Abort."
     exit 1
   fi
 
-  if [ -z $NO_POST_MIGRATION_RESTART ]; then
+  if [[ "${POST_MIGRATION_DEPLOY}" ]]; then
     green "Post-migration dyno restart."
     heroku restart --app $HEROKU_APP
   fi

--- a/lib/snippets/push-to-heroku
+++ b/lib/snippets/push-to-heroku
@@ -62,11 +62,12 @@ if [ "$MIGRATIONS" != "" ]; then
     exit 1
   fi
 
-  green "Post-migration dyno restart."
-  heroku restart --app $HEROKU_APP
+  if [ -z $NO_POST_MIGRATION_RESTART ]; then
+    green "Post-migration dyno restart."
+    heroku restart --app $HEROKU_APP
+  fi
 else
   green "There are no pending migrations."
 fi
 
 green "All done."
-


### PR DESCRIPTION
For Reference: https://github.com/Shopify/service-disruptions/issues/497

Post-migration restarts for apps with preboot enabled can lead to problems when removing columns, because there could be more than 2 versions of an app running at the same time.

This PR adds a way to skip post-migration restarts by setting `POST_MIGRATION_RESTART=false`.

**I have no idea about bash, please make sure my code is right.**

--

@davidcornu @EiNSTeiN- @Hammadk @kevinhughes27 @shawnfrench 