### PR TITLE
Fix heroku db migration failure detection

### DIFF
--- a/lib/snippets/push-to-heroku
+++ b/lib/snippets/push-to-heroku
@@ -45,15 +45,17 @@ if [[ $? -ne 0 ]]; then
   exit 1;
 fi
 
-MIGRATIONS=`heroku run rake db:migrate:status --app $HEROKU_APP | grep -e '^\s*down'`
+MIGRATION_STATUS=`heroku run rake db:migrate:status --app $HEROKU_APP | grep -e '^\s*down'`
 
-if [[ "${MIGRATIONS}" != "" ]]; then
+if [[ "${MIGRATION_STATUS}" != "" ]]; then
   green "There are pending migrations to apply:"
-  echo $MIGRATIONS
+  echo $MIGRATION_STATUS
 
   green "Migrating database."
   heroku run rake db:migrate --app $HEROKU_APP
-  if [[ $? -ne 0 ]]; then
+
+  POST_MIGRATION_STATUS=`heroku run rake db:migrate:status --app $HEROKU_APP | grep -e '^\s*down'`
+  if [[ "${POST_MIGRATION_STATUS}" != "" ]]; then
     red "Migration failed! This is bad."
     red "Please contact a heroku collaborator for ${HEROKU_APP}:"
     heroku sharing --app $HEROKU_APP


### PR DESCRIPTION
Fixes https://github.com/Shopify/shipit/issues/99

> If you deploy a PR that has a failure in the migration, the [`push-to-heroku` snippet](https://github.com/Shopify/shipit-engine/blob/master/lib/snippets/push-to-heroku) no longer results in a failed build: [example](https://shipit.shopify.io/shopify/services-db/production/deploys/165709).

> That is because the `heroku` command line tool does not propagate the exit code. I believe it used to, that must have changed recently.

> In any case, using `rake db:migrate:status` again, we should be able to know if there are still pending migrations after, and we should fail the build.

Fixes heroku db migration failure detection by using `db:migrate:status` after running migration instead of relying on heroku-cli's exit code.

For Review: @casperisfine @hammadk @kevinhughes27 
CC: @shawnfrench @etiennebarrie