### PR TITLE
Allowing stack creation from API

### DIFF
--- a/app/controllers/shipit/api/base_controller.rb
+++ b/app/controllers/shipit/api/base_controller.rb
@@ -8,7 +8,6 @@ module Shipit
 
       rescue_from ApiClient::InsufficientPermission, with: :insufficient_permission
       rescue_from EnvironmentVariables::NotPermitted, with: :validation_error
-      rescue_from ActiveRecord::RecordInvalid, with: :validation_error
       rescue_from TaskDefinition::NotFound, with: :not_found
 
       class << self

--- a/app/controllers/shipit/api/base_controller.rb
+++ b/app/controllers/shipit/api/base_controller.rb
@@ -8,6 +8,7 @@ module Shipit
 
       rescue_from ApiClient::InsufficientPermission, with: :insufficient_permission
       rescue_from EnvironmentVariables::NotPermitted, with: :validation_error
+      rescue_from ActiveRecord::RecordInvalid, with: :validation_error
       rescue_from TaskDefinition::NotFound, with: :not_found
 
       class << self

--- a/app/controllers/shipit/api/stacks_controller.rb
+++ b/app/controllers/shipit/api/stacks_controller.rb
@@ -17,9 +17,7 @@ module Shipit
         accepts :ignore_ci, Boolean
       end
       def create
-        @stack = Stack.new(params)
-        @stack.save!
-        render_resource @stack
+        render_resource Stack.create(params)
       end
 
       def show

--- a/app/controllers/shipit/api/stacks_controller.rb
+++ b/app/controllers/shipit/api/stacks_controller.rb
@@ -8,8 +8,16 @@ module Shipit
         render_resources stacks
       end
 
+      params do
+        requires :repo_owner, String
+        requires :repo_name, String
+        accepts :environment, String
+        accepts :branch, String
+        accepts :deploy_url, String
+        accepts :ignore_ci, Boolean
+      end
       def create
-        @stack = Stack.new(create_params)
+        @stack = Stack.new(params)
         @stack.save!
         render_resource @stack
       end
@@ -22,10 +30,6 @@ module Shipit
 
       def stack
         @stack ||= stacks.from_param!(params[:id])
-      end
-
-      def create_params
-        params.require(:stack).permit(:repo_name, :repo_owner, :environment, :branch, :deploy_url, :ignore_ci)
       end
     end
   end

--- a/app/controllers/shipit/api/stacks_controller.rb
+++ b/app/controllers/shipit/api/stacks_controller.rb
@@ -1,10 +1,17 @@
 module Shipit
   module Api
     class StacksController < BaseController
-      require_permission :read, :stack
+      require_permission :read, :stack, only: %i(index show)
+      require_permission :write, :stack, only: %i(create)
 
       def index
         render_resources stacks
+      end
+
+      def create
+        @stack = Stack.new(create_params)
+        @stack.save!
+        render_resource @stack
       end
 
       def show
@@ -15,6 +22,10 @@ module Shipit
 
       def stack
         @stack ||= stacks.from_param!(params[:id])
+      end
+
+      def create_params
+        params.require(:stack).permit(:repo_name, :repo_owner, :environment, :branch, :deploy_url, :ignore_ci)
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -24,7 +24,7 @@ Shipit::Engine.routes.draw do
   # API
   namespace :api do
     root to: 'base#index'
-    resources :stacks, only: :index
+    resources :stacks, only: %i(index create)
     scope '/stacks/*id', id: stack_id_format, as: :stack do
       get '/' => 'stacks#show'
     end

--- a/test/controllers/api/stacks_controller_test.rb
+++ b/test/controllers/api/stacks_controller_test.rb
@@ -12,15 +12,8 @@ module Shipit
         @client.permissions.delete('write:stack')
         @client.save!
 
-        params = {
-          repo_name: "rails",
-          repo_owner: "rails",
-          environment: "staging",
-          branch: "staging",
-        }
-
         assert_no_difference 'Stack.count' do
-          post :create, params
+          post :create, repo_name: 'rails', repo_owner: 'rails', environment: 'staging', branch: 'staging'
         end
 
         assert_response :forbidden
@@ -32,18 +25,12 @@ module Shipit
           post :create, repo_owner: 'some', repo_name: 'owner/path'
         end
         assert_response :unprocessable_entity
+        assert_json 'errors', 'repo_name' => ['is invalid']
       end
 
       test "#create creates a stack and renders it back" do
-        params = {
-          repo_name: "rails",
-          repo_owner: "rails",
-          environment: "staging",
-          branch: "staging",
-        }
-
-        assert_difference "Stack.count" do
-          post :create, params
+        assert_difference -> { Stack.count } do
+          post :create, repo_name: 'rails', repo_owner: 'rails', environment: 'staging', branch: 'staging'
         end
 
         assert_response :ok
@@ -51,25 +38,19 @@ module Shipit
       end
 
       test "#create fails to create stack if it already exists" do
-        params = {
-          repo_name: "rails",
-          repo_owner: "rails",
-          environment: "staging",
-          branch: "staging",
-        }
+        Stack.create!(
+          repo_name: 'rails',
+          repo_owner: 'rails',
+          environment: 'staging',
+          branch: 'staging',
+        )
 
-        assert_difference "Stack.count" do
-          post :create, params
-        end
-
-        assert_response :ok
-        assert_json 'id', Stack.last.id
-
-        assert_no_difference "Stack.count" do
-          post :create, params
+        assert_no_difference -> { Stack.count } do
+          post :create, repo_name: 'rails', repo_owner: 'rails', environment: 'staging', branch: 'staging'
         end
 
         assert_response :unprocessable_entity
+        assert_json 'errors', 'repo_name' => ['cannot be used more than once with this environment']
       end
 
       test "#index returns a list of stacks" do

--- a/test/controllers/api/stacks_controller_test.rb
+++ b/test/controllers/api/stacks_controller_test.rb
@@ -12,8 +12,7 @@ module Shipit
         @client.permissions.delete('write:stack')
         @client.save!
 
-        params = {}
-        params[:stack] = {
+        params = {
           repo_name: "rails",
           repo_owner: "rails",
           environment: "staging",
@@ -30,14 +29,13 @@ module Shipit
 
       test "#create fails with invalid stack" do
         assert_no_difference "Stack.count" do
-          post :create, stack: {repo_owner: 'some', repo_name: 'owner/path'}
+          post :create, repo_owner: 'some', repo_name: 'owner/path'
         end
         assert_response :unprocessable_entity
       end
 
       test "#create creates a stack and renders it back" do
-        params = {}
-        params[:stack] = {
+        params = {
           repo_name: "rails",
           repo_owner: "rails",
           environment: "staging",
@@ -53,8 +51,7 @@ module Shipit
       end
 
       test "#create fails to create stack if it already exists" do
-        params = {}
-        params[:stack] = {
+        params = {
           repo_name: "rails",
           repo_owner: "rails",
           environment: "staging",


### PR DESCRIPTION
Seems like permission `write:stack` wasn't being used anywhere, so I used it instead of creating `create:stack`.
