### PR TITLE
Report github status if something is wrong

### DIFF
--- a/app/assets/javascripts/shipit.js.coffee
+++ b/app/assets/javascripts/shipit.js.coffee
@@ -20,19 +20,26 @@
 $(document).on 'click', '.disabled, .btn--disabled', (event) ->
   event.preventDefault()
 
-$(document).on 'click', '.enable-notifications .banner__dismiss', (event) ->
+$(document).on 'click', '.banner__dismiss', (event) ->
   $(event.target).closest('.banner').addClass('hidden')
+
+$(document).on 'click', '.enable-notifications .banner__dismiss', (event) ->
   localStorage.setItem("dismissed-enable-notifications", true)
 
-jQuery ->
-  if(localStorage.getItem("dismissed-enable-notifications"))
-    return
-  $notificationNotice = $('.enable-notifications')
+$(document).on 'click', '.github-status .banner__dismiss', (event) ->
+  localStorage.setItem("dismissed-github-status", true)
 
-  if $.notifyCheck() == $.NOTIFY_NOT_ALLOWED
-    $button = $notificationNotice.find('button')
-    $button.on 'click', ->
-      $.notifyRequest()
-      $notificationNotice.addClass('hidden')
-    $notificationNotice.removeClass('hidden')
+jQuery ->
+  unless(localStorage.getItem("dismissed-enable-notifications"))
+    $notificationNotice = $('.enable-notifications')
+
+    if $.notifyCheck() == $.NOTIFY_NOT_ALLOWED
+      $button = $notificationNotice.find('button')
+      $button.on 'click', ->
+        $.notifyRequest()
+        $notificationNotice.addClass('hidden')
+      $notificationNotice.removeClass('hidden')
+
+  unless(localStorage.getItem("dismissed-github-status"))
+    $('.github-status').removeClass('hidden')
 

--- a/app/controllers/shipit/shipit_controller.rb
+++ b/app/controllers/shipit/shipit_controller.rb
@@ -17,7 +17,7 @@ module Shipit
       :ensure_required_settings,
       :force_github_authentication,
       :set_variant,
-      :check_github_status
+      :check_github_status,
     )
 
     # Respond to HTML by default

--- a/app/controllers/shipit/shipit_controller.rb
+++ b/app/controllers/shipit/shipit_controller.rb
@@ -10,12 +10,14 @@ module Shipit
 
     helper Shipit::Engine.routes.url_helpers
     include Shipit::Engine.routes.url_helpers
+    include ActionView::Helpers::DateHelper
 
     before_action(
       :toogle_bootstrap_feature,
       :ensure_required_settings,
       :force_github_authentication,
       :set_variant,
+      :check_github_status
     )
 
     # Respond to HTML by default
@@ -65,6 +67,15 @@ module Shipit
 
       request.format = :html
       request.variant = :partial
+    end
+
+    def check_github_status
+      github_status = Rails.cache.read('github::status')
+      return if github_status.nil? || github_status[:status] == 'good'
+
+      flash[:warning] = "It seems that GitHub is having issues:
+        status: #{github_status[:status]} '#{github_status[:body]}'
+        updated: #{time_ago_in_words(github_status[:last_updated])} ago"
     end
   end
 end

--- a/app/controllers/shipit/shipit_controller.rb
+++ b/app/controllers/shipit/shipit_controller.rb
@@ -69,7 +69,7 @@ module Shipit
     end
 
     def check_github_status
-      github_status = Rails.cache.read('github::status')
+      github_status = Shipit::GithubStatus.status
       return if github_status.nil? || github_status[:status] == 'good'
 
       flash[:warning] = "It seems that GitHub is having issues:

--- a/app/controllers/shipit/shipit_controller.rb
+++ b/app/controllers/shipit/shipit_controller.rb
@@ -16,7 +16,6 @@ module Shipit
       :ensure_required_settings,
       :force_github_authentication,
       :set_variant,
-      :check_github_status,
     )
 
     # Respond to HTML by default
@@ -66,15 +65,6 @@ module Shipit
 
       request.format = :html
       request.variant = :partial
-    end
-
-    def check_github_status
-      github_status = Shipit::GithubStatus.status
-      return if github_status.nil? || github_status[:status] == 'good'
-
-      flash[:warning] = "It seems that GitHub is having issues:
-        status: #{github_status[:status]} '#{github_status[:body]}'
-        updated: #{self.class.helpers.time_ago_in_words(github_status[:last_updated])} ago"
     end
   end
 end

--- a/app/controllers/shipit/shipit_controller.rb
+++ b/app/controllers/shipit/shipit_controller.rb
@@ -10,7 +10,6 @@ module Shipit
 
     helper Shipit::Engine.routes.url_helpers
     include Shipit::Engine.routes.url_helpers
-    include ActionView::Helpers::DateHelper
 
     before_action(
       :toogle_bootstrap_feature,
@@ -75,7 +74,7 @@ module Shipit
 
       flash[:warning] = "It seems that GitHub is having issues:
         status: #{github_status[:status]} '#{github_status[:body]}'
-        updated: #{time_ago_in_words(github_status[:last_updated])} ago"
+        updated: #{self.class.helpers.time_ago_in_words(github_status[:last_updated])} ago"
     end
   end
 end

--- a/app/models/shipit/github_status.rb
+++ b/app/models/shipit/github_status.rb
@@ -1,0 +1,11 @@
+module Shipit
+  class GithubStatus
+    class << self
+      def refresh_status
+        Rails.cache.fetch('github::status') do
+          Shipit.github_api.github_status
+        end
+      end
+    end
+  end
+end

--- a/app/models/shipit/github_status.rb
+++ b/app/models/shipit/github_status.rb
@@ -8,9 +8,7 @@ module Shipit
       end
 
       def refresh_status
-        Rails.cache.fetch(CACHE_KEY) do
-          Shipit.github_api.github_status
-        end
+        Rails.cache.write(CACHE_KEY, Shipit.github_api.github_status)
       end
     end
   end

--- a/app/models/shipit/github_status.rb
+++ b/app/models/shipit/github_status.rb
@@ -1,8 +1,14 @@
 module Shipit
-  class GithubStatus
+  module GithubStatus
+    CACHE_KEY = 'github::status'.freeze
+
     class << self
+      def status
+        Rails.cache.read(CACHE_KEY)
+      end
+
       def refresh_status
-        Rails.cache.fetch('github::status') do
+        Rails.cache.fetch(CACHE_KEY) do
           Shipit.github_api.github_status
         end
       end

--- a/app/views/layouts/shipit.html.erb
+++ b/app/views/layouts/shipit.html.erb
@@ -28,7 +28,7 @@
 
   <% github_status = Shipit::GithubStatus.status
      unless github_status.nil? || github_status[:status] == 'good' %>
-    <div class="banner github-status banner--red">
+    <div class="banner github-status banner--orange hidden">
       <div class="banner__inner wrapper">
         <div class="banner__content">
           <h2 class="banner__title">GitHub is having issues</h2>

--- a/app/views/layouts/shipit.html.erb
+++ b/app/views/layouts/shipit.html.erb
@@ -26,6 +26,23 @@
     </div>
   </div>
 
+  <% github_status = Shipit::GithubStatus.status
+     unless github_status.nil? || github_status[:status] == 'good' %>
+    <div class="banner github-status banner--red">
+      <div class="banner__inner wrapper">
+        <div class="banner__content">
+          <h2 class="banner__title">GitHub is having issues</h2>
+            "<i><%= github_status[:body] %></i>"
+            <% unless github_status[:last_updated].nil? %>
+              <%= time_ago_in_words(github_status[:last_updated]) %> ago
+            <% end %>
+        </div>
+
+        <a class="banner__dismiss">&times;</a>
+      </div>
+    </div>
+  <% end %>
+
   <header class="header">
     <%= link_to "Shipit v#{Shipit::VERSION}", "https://github.com/Shopify/shipit-engine/tree/v#{Shipit::VERSION}", class: 'powered-by' %>
     <div class="wrapper">

--- a/lib/tasks/cron.rake
+++ b/lib/tasks/cron.rake
@@ -3,6 +3,7 @@ namespace :cron do
   task minutely: :environment do
     Shipit::Stack.refresh_deployed_revisions
     Shipit::Stack.schedule_continuous_delivery
+    Shipit::GithubStatus.refresh_status
   end
 
   desc "Rolls-up output chunks for completed deploys older than an hour"


### PR DESCRIPTION
When GitHub's having some issue, Shipit may not properly work as it relies on lots of the GitHub's machinery such as webhooks, its REST API, etc.

This PR attempts to provide more information to the engineers by showing a small flash message whenever GitHub is in trouble indicating its current status and when was updated for the last time.

@byroot :)