### PR TITLE
Remove dismiss button on CI misconfiguration

### DIFF
--- a/app/views/shipit/stacks/show.html.erb
+++ b/app/views/shipit/stacks/show.html.erb
@@ -13,7 +13,6 @@
         <%= button_to "Ignore CI", stack_path(@stack, stack: {ignore_ci: true}, return_to: stack_path(@stack)), method: :patch, class: 'banner__btn btn' %>
       </div>
     </div>
-    <a class="banner__dismiss">&times;</a>
   </div>
 <% end %>
 


### PR DESCRIPTION
This PR removes the `x` link to dismiss the "Stack with no CI but needing CI to deploy"[1].

Right now it does not work as probably it misses its javascript.
I think it would be better to 🔥  it as it's an important notice and the "Ignore CI" button it's what has the "dismiss" action 😄 

[1]:

![image](https://cloud.githubusercontent.com/assets/959128/18714928/56974c6e-7fe5-11e6-9550-b3c30b425930.png)
