### PR TITLE
Update rails version on installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,8 +45,8 @@ This guide aims to help you [set up](#installation-and-setup), [use](#using-ship
 
 Shipit provides you with a Rails template. To bootstrap your Shipit installation:
 
-1. If you don't have Rails installed, run this command: `gem install rails -v 4.2.6`
-2. Run this command:  `rails _4.2.6_ new shipit -m https://raw.githubusercontent.com/Shopify/shipit-engine/master/template.rb`
+1. If you don't have Rails installed, run this command: `gem install rails -v 5.0.0.1`
+2. Run this command:  `rails _5.0.0.1_ new shipit -m https://raw.githubusercontent.com/Shopify/shipit-engine/master/template.rb`
 3. Enter your **Client ID**, **Client Secret**, and **GitHub API access token** when prompted. These can be found on your application's GitHub page.
 4. To setup the database, run this command: `rake db:setup`
 


### PR DESCRIPTION
Running the given command gives me the error:

> The template [https://raw.githubusercontent.com/Shopify/shipit-engine/master/template.rb] could not be loaded. Error: You need at least Rails 5.0.0 to install shipit

Using the latest rails 5.0.0.1 works fine :)