### PR TITLE
Fixes for GKE script

### DIFF
--- a/lib/snippets/deploy-to-gke
+++ b/lib/snippets/deploy-to-gke
@@ -75,7 +75,7 @@ class GKEDeployment
       file_path = "#{@template_path}/#{file}"
       if File.extname(file) == '.yml'
         found += 1
-        run_command('kubectl', 'apply', '-f', file_path, "--namespace=#{@namespace}")
+        apply_template(file_path)
       elsif File.extname(file) == '.erb'
         found += 1
         render_and_apply_template(file_path)
@@ -95,9 +95,14 @@ class GKEDeployment
     f = Tempfile.new(['kube_template', '.yml'])
     f.write(content)
     f.close
-    run_command('kubectl', 'apply', '-f', f.path, "--namespace=#{@namespace}")
+    apply_template(f.path, original_path: file_path)
   ensure
     f.unlink if f
+  end
+
+  def apply_template(path, original_path: nil)
+    status = run_command('kubectl', 'apply', '-f', path, "--namespace=#{@namespace}")
+    raise FatalDeploymentError, "Failed to apply template #{original_path || path}" unless status
   end
 
   def authorize_gcloud

--- a/lib/snippets/deploy-to-gke
+++ b/lib/snippets/deploy-to-gke
@@ -106,6 +106,7 @@ class GKEDeployment
   end
 
   def authorize_gcloud
+    ENV['GOOGLE_APPLICATION_CREDENTIALS'] = @key_file
     status = run_command('gcloud', '-q', 'auth', 'activate-service-account', '--key-file', @key_file)
     status = run_command('gcloud', '-q', 'config', 'set', 'project', @gcloud_project) if status
     raise FatalDeploymentError, "Failed to set gcloud project #{@gcloud_project}" unless status


### PR DESCRIPTION
@Shopify/cloudplatform 
cc @byroot 

This fixes two things I noticed while trying out this script with my test app:
1) The deploy didn't fail when `kubectl apply` (i.e. the actual deploying) threw an error
2) `ENV["GOOGLE_APPLICATION_CREDENTIALS"]` needs to be set to the current key file, or else you get `error: google: could not find default credentials. See https://developers.google.com/accounts/docs/application-default-credentials for more information.`

I've tested these changes with my local shipit setup. I've also tested that the env var solves the second problem in production by adding it to the machine environment section of my app's `shipit.yml`.