### PR TITLE
When generating hooks, new URLs should use HTTPS

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,8 @@ Shipit::Engine.routes.draw do
   sha_format = /[\da-f]{6,40}/
   root to: 'stacks#index'
 
+  default_url_options protocol: :https if Rails.env.production?
+
   mount Pubsubstub::StreamAction.new, at: "/events", as: :events
 
   # Robots


### PR DESCRIPTION
This instructs `url_helper` to force 'https' as the protocol when generating new URLs

```
Loading development environment (Rails 5.0.0.1)
>> hook = Shipit::Stack.first.github_hooks.first
  Shipit::Stack Load (0.1ms)  SELECT  "stacks".* FROM "stacks" ORDER BY "stacks"."id" ASC LIMIT ?  [["LIMIT", 1]]
  Shipit::GithubHook::Repo Load (0.2ms)  SELECT  "github_hooks".* FROM "github_hooks" WHERE "github_hooks"."type" IN ('Shipit::GithubHook::Repo') AND "github_hooks"."stack_id" = ? ORDER BY "github_hooks"."id" ASC LIMIT ?  [["stack_id", 1], ["LIMIT", 1]]
=> #<Shipit::GithubHook::Repo id: 1, stack_id: 1, github_id: nil, event: "push", created_at: "2016-11-23 16:48:17", updated_at: "2016-11-23 16:48:17", secret: "xyzabc", api_url: nil, type: "Shipit::GithubHook::Repo", organization: nil>
>> hook.send(:properties)
Generating endpoint_url
=> {:url=>"https://localhost:3000/stacks/1/webhooks/push", :content_type=>"json", :secret=>"xyzabc"}
```

To avoid setting up https locally, this is only active on production.