### PR TITLE
Allow variable in task to be a dropdown

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,3 +3,5 @@
 *   Do not prepend `bundle exec` to custom tasks if `depedencies.override` is set.
 
     Otherwise there isn't any way to opt-out from automatic bundler discovery.
+
+*   Command `variable` now allows a `select` to take a list of values, rather than a text field.

--- a/README.md
+++ b/README.md
@@ -250,6 +250,23 @@ deploy:
 ```
 <br>
 
+**<code>deploy.variables.select</code>** will turn the input into a `<select>` of values.
+
+For example:
+
+```yaml
+deploy:
+  variables:
+    -
+      name: REGION
+      title: Run a deploy in a given region
+      select:
+        - east
+        - west
+        - north
+```
+<br>
+
 **<code>deploy.max_commits</code>** allows you to set a limit to the number of commits being shipped per deploys.
 
 Human users will be warned that they are not respecting the recommendation, but allowed to continue.

--- a/app/assets/stylesheets/_pages/_deploy.scss
+++ b/app/assets/stylesheets/_pages/_deploy.scss
@@ -15,7 +15,7 @@
 }
 
 .variables-fields {
-  input {
+  input, select {
     display: inline-block;
     width: inherit;
     margin-right: 1rem;

--- a/app/models/shipit/variable_definition.rb
+++ b/app/models/shipit/variable_definition.rb
@@ -1,11 +1,12 @@
 module Shipit
   class VariableDefinition
-    attr_reader :name, :title, :default
+    attr_reader :name, :title, :default, :select
 
     def initialize(attributes)
       @name = attributes.fetch('name')
       @title = attributes['title']
       @default = attributes['default'].to_s
+      @select = attributes['select'].presence
     end
 
     def to_h
@@ -13,6 +14,7 @@ module Shipit
         'name' => @name,
         'title' => @title,
         'default' => @default,
+        'select' => @select,
       }
     end
   end

--- a/app/views/shipit/_variables.html.erb
+++ b/app/views/shipit/_variables.html.erb
@@ -6,7 +6,11 @@
     <%= form.fields_for field_name do |field| %>
       <% variables.each do |variable| %>
         <p class="variables-fields">
-          <%= field.text_field variable.name, value: variable.default %>
+          <% if variable.select %>
+            <%= field.select variable.name, options_for_select([["Please select...", { disabled: "disabled", selected: true }]] + variable.select) %>
+          <% else %>
+            <%= field.text_field variable.name, value: variable.default %>
+          <% end %>
           <%= field.label variable.name, variable.title || variable.name %>
         </p>
       <% end %>

--- a/test/models/task_definitions_test.rb
+++ b/test/models/task_definitions_test.rb
@@ -34,8 +34,8 @@ module Shipit
         checklist: [],
         allow_concurrency: true,
         variables: [
-          {'name' => 'FOO', 'title' => 'Set to 0 to foo', 'default' => '1'},
-          {'name' => 'BAR', 'title' => 'Set to 1 to bar', 'default' => '0'},
+          {'name' => 'FOO', 'title' => 'Set to 0 to foo', 'default' => '1', 'select' => nil},
+          {'name' => 'BAR', 'title' => 'Set to 1 to bar', 'default' => '0', 'select' => nil},
         ],
       }
       assert_equal as_json, TaskDefinition.load(TaskDefinition.dump(@definition)).as_json

--- a/test/unit/variable_definition_test.rb
+++ b/test/unit/variable_definition_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+module Shipit
+  class VariableDefinitionTest < ActiveSupport::TestCase
+    setup do
+      @attributes = {
+        "name" => "Variable name",
+        "title" => "Variable title",
+        "default" => "Variable default",
+      }
+      @select = %w(var1 var2 var3)
+    end
+
+    test "#initialize sets up the expected values" do
+      subject = Shipit::VariableDefinition.new(@attributes)
+
+      assert_equal "Variable name", subject.name
+      assert_equal "Variable title", subject.title
+      assert_equal "Variable default", subject.default
+      assert_nil subject.select
+    end
+
+    test "#initialize name is required" do
+      assert_raises KeyError do
+        @attributes.delete("name")
+        Shipit::VariableDefinition.new(@attributes)
+      end
+    end
+
+    test "#initialize stringifies the default" do
+      @attributes["default"] = :value
+      subject = Shipit::VariableDefinition.new(@attributes)
+
+      assert_equal "value", subject.default
+    end
+
+    test "#initialize sets the select if present" do
+      @attributes["select"] = @select
+      subject = Shipit::VariableDefinition.new(@attributes)
+
+      assert_equal @select, subject.select
+    end
+
+    test "#initialize sets nil for select if the array is empty" do
+      @attributes["select"] = []
+      subject = Shipit::VariableDefinition.new(@attributes)
+
+      assert_nil subject.select
+    end
+
+    test "#to_h returns hash version" do
+      assert_equal @attributes.merge("select" => nil), Shipit::VariableDefinition.new(@attributes).to_h
+    end
+
+    test "#to_h returns hash version that includes select" do
+      assert_equal @attributes.merge("select" => @select), Shipit::VariableDefinition.new(@attributes.merge("select" => @select)).to_h
+    end
+  end
+end


### PR DESCRIPTION
@byroot @jules2689 @jonathankwok 

## Problem

In a few places we are using a `<input type="text">` to define a variable in a task. But that variable only has a few fixed values. Think regions, providers, caches, etc..

## Solution

If present, the `select:` key will replace it with a `<select>` dropdown with the preset values.

<img width="476" alt="shipit_-_shipit-test" src="https://cloud.githubusercontent.com/assets/84159/20759440/f355ad0c-b6ea-11e6-9248-85c7498082cf.png">
