### PR TITLE
Properly set default env on deploys triggered by continuous delivery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+*   Properly set default env on deploys triggered by continuous delivery
+
 # 0.14.0
 
 *   Do not prepend `bundle exec` to custom tasks if `depedencies.override` is set.

--- a/app/models/shipit/deploy_spec.rb
+++ b/app/models/shipit/deploy_spec.rb
@@ -85,6 +85,10 @@ module Shipit
       Array.wrap(config('deploy', 'variables')).map(&VariableDefinition.method(:new))
     end
 
+    def default_deploy_env
+      deploy_variables.map { |v| [v.name, v.default] }.to_h
+    end
+
     def rollback_steps
       around_steps('rollback') do
         config('rollback', 'override') { discover_rollback_steps }

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -136,7 +136,7 @@ module Shipit
         return
       end
 
-      trigger_deploy(commit, Shipit.user)
+      trigger_deploy(commit, Shipit.user, env: cached_deploy_spec.default_deploy_env)
     end
 
     def next_commit_to_deploy

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -534,6 +534,13 @@ module Shipit
       end
     end
 
+    test "#trigger_continuous_delivery use default env vars" do
+      @stack.tasks.delete_all
+
+      deploy = @stack.trigger_continuous_delivery
+      assert_equal({'SAFETY_DISABLED' => '0'}, deploy.env)
+    end
+
     test "#next_commit_to_deploy returns the last deployable commit" do
       @stack.tasks.where.not(until_commit_id: shipit_commits(:second).id).destroy_all
       assert_equal shipit_commits(:second), @stack.last_deployed_commit


### PR DESCRIPTION
Even if you were to set a variable with a default, it would never be set on an automatically triggered deploy.

Now the defaults are set.

@rafaelfranca for review please.