### PR TITLE
Smarter k8s deploy

### DIFF
--- a/lib/snippets/kubernetes-deploy
+++ b/lib/snippets/kubernetes-deploy
@@ -45,12 +45,10 @@ class KubernetesDeploy
   ).freeze
 
   PREDEPLOY_SEQUENCE = %w(
-    configmap
-    persistentvolumeclaim
-    pod
+    ConfigMap
+    PersistentVolumeClaim
+    Pod
   )
-
-  STEP_COMPLETION_TIMEOUT_MINUTES = 20
 
   def initialize(namespace:, environment:, current_sha:, template_folder: nil, context:)
     @namespace = namespace
@@ -104,6 +102,10 @@ class KubernetesDeploy
       next if matching_resources.empty?
       deploy_resources(matching_resources)
       wait_for_completion(matching_resources)
+      fail_count = matching_resources.count { |r| r.deploy_failed? || r.deploy_timed_out? }
+      if fail_count > 0
+        raise FatalDeploymentError, "#{fail_count} priority resources failed to deploy"
+      end
     end
   end
 
@@ -143,29 +145,30 @@ class KubernetesDeploy
   end
 
   def report_final_status(resources)
-    if resources.all?(&:succeeded?)
+    if resources.all?(&:deploy_succeeded?)
       log_green("Deploy succeeded!")
     else
-      fail_list = resources.select(&:failed?).map(&:id)
+      fail_list = resources.select { |r| r.deploy_failed? || r.deploy_timed_out? }.map(&:id)
       KubernetesDeploy.logger.error("The following resources failed to deploy: #{fail_list.join(", ")}")
       raise FatalDeploymentError, "#{fail_list.length} resources failed to deploy"
     end
   end
 
-  def wait_for_completion(resources_to_deploy)
-    timeout = Time.now.utc + (60 * STEP_COMPLETION_TIMEOUT_MINUTES)
+  def wait_for_completion(watched_resources)
     delay_sync_until = Time.now.utc
-
-    while !resources_to_deploy.empty?
-      if Time.now.utc > timeout
-        Kubernetes.logger.error("Phase #{@current_phase} timed out deploying the following resources: #{resources_to_deploy.map(&:id).join(", ")}")
-        raise FatalDeploymentError, "Deploy phase #{@current_phase} failed to complete within #{STEP_COMPLETION_TIMEOUT_MINUTES} minutes"
-      elsif Time.now.utc < delay_sync_until
+    while watched_resources.present?
+      if Time.now.utc < delay_sync_until
         sleep (delay_sync_until - Time.now.utc)
       end
       delay_sync_until = Time.now.utc + 3 # don't pummel the API if the sync is fast
-      resources_to_deploy.each(&:sync)
-      resources_to_deploy = resources_to_deploy.reject(&:deployed?)
+      watched_resources.each(&:sync)
+      newly_finished_resources, watched_resources = watched_resources.partition(&:deploy_finished?)
+      newly_finished_resources.each do |resource|
+        next unless resource.deploy_failed? || resource.deploy_timed_out?
+        KubernetesDeploy.logger.error("#{resource.id} failed to deploy with status '#{resource.status}'.")
+        KubernetesDeploy.logger.warn("Continuing to poll status of other resources in this phase. You may wish to abort the deploy.")
+        KubernetesDeploy.logger.error(resource.status_data)
+      end
     end
   end
 
@@ -215,6 +218,7 @@ class KubernetesDeploy
     resources.each do |r|
       KubernetesDeploy.logger.info("- #{r.id}")
       command.push("-f", r.file.path)
+      r.deploy_started = Time.now.utc
     end
 
     if prune
@@ -276,8 +280,8 @@ class KubernetesDeploy
       l.level = ENV["DEBUG"] ? Logger::DEBUG : Logger::INFO
       l.formatter = proc do |severity, _datetime, _progname, msg|
         case severity
-        when "FATAL" then "\033[0;31m[#{severity}]\t#{msg}\x1b[0m\n" # red
-        when "ERROR", "WARN" then "\033[0;33m[#{severity}]\t#{msg}\x1b[0m\n" # yellow
+        when "FATAL", "ERROR" then "\033[0;31m[#{severity}]\t#{msg}\x1b[0m\n" # red
+        when "WARN" then "\033[0;33m[#{severity}]\t#{msg}\x1b[0m\n" # yellow
         when "INFO" then "\033[0;36m#{msg}\x1b[0m\n" # blue
         else "[#{severity}]\t#{msg}\n"
         end
@@ -290,15 +294,16 @@ class KubernetesDeploy
     extend ActiveSupport::DescendantsTracker
 
     attr_reader :name, :namespace, :file
-    attr_writer :type
+    attr_writer :type, :deploy_started
 
+    TIMEOUT = 60 * 5
 
     def self.handled_type
-      name.split('::').last.downcase
+      name.split('::').last
     end
 
     def self.for_type(type, name, namespace, file)
-      if subclass = descendants.find { |subclass| subclass.handled_type == type }
+      if subclass = descendants.find { |subclass| subclass.handled_type.downcase == type }
         subclass.new(name, namespace, file)
       else
         self.new(name, namespace, file).tap { |r| r.type = type }
@@ -318,11 +323,11 @@ class KubernetesDeploy
       log_status(status_data)
     end
 
-    def failed?
+    def deploy_failed?
       false
     end
 
-    def succeeded?
+    def deploy_succeeded?
       KubernetesDeploy.logger.warn("Don't know how to monitor resources of type #{type}. Assuming #{id} deployed successfully.")
       true
     end
@@ -332,26 +337,43 @@ class KubernetesDeploy
     end
 
     def status
-      @status || "Unknown"
+      @status ||= "Unknown"
+      deploy_timed_out? ? "Timed out with status #{@status}" : @status
     end
 
     def type
       @type || self.class.handled_type
     end
 
-    def deployed?
-      failed? || succeeded?
+    def deploy_finished?
+      deploy_failed? || deploy_succeeded? || deploy_timed_out?
+    end
+
+    def deploy_timed_out?
+      return false unless @deploy_started
+      !deploy_succeeded? && !deploy_failed? && (Time.now.utc - @deploy_started > self.class::TIMEOUT)
     end
 
     def status_data
       {
-        group: type.capitalize + "s",
+        group: group_name,
         name: name,
         status_string: status,
         exists: exists?,
-        failed: failed?,
-        succeeded: succeeded?
+        succeeded: deploy_succeeded?,
+        failed: deploy_failed?,
+        timed_out: deploy_timed_out?,
+        events: fetch_events
       }
+    end
+
+    def group_name
+      type + "s"
+    end
+
+    def fetch_events
+      out, _ = run_kubectl("get", "events", "--output=jsonpath={range .items[?(@.involvedObject.name==\"#{name}\")]}{.involvedObject.kind}   {.metadata.creationTimestamp}  {.reason}   {.count}   {.message}{\"\\n\"}{end}")
+      out.split("\n").select { |event_log| event_log.match(/\A#{type}/i) }
     end
 
     def run_kubectl(*args)
@@ -369,7 +391,9 @@ class KubernetesDeploy
     end
   end
 
-  class Configmap < KubernetesResource
+  class ConfigMap < KubernetesResource
+    TIMEOUT = 30
+
     def initialize(name, namespace, file)
       @name, @namespace, @file = name, namespace, file
     end
@@ -381,11 +405,11 @@ class KubernetesDeploy
       log_status(status_data)
     end
 
-    def succeeded?
+    def deploy_succeeded?
       exists?
     end
 
-    def failed?
+    def deploy_failed?
       false
     end
 
@@ -395,6 +419,8 @@ class KubernetesDeploy
   end
 
   class PersistentVolumeClaim < KubernetesResource
+    TIMEOUT = 60 * 5
+
     def initialize(name, namespace, file)
       @name, @namespace, @file = name, namespace, file
     end
@@ -405,11 +431,11 @@ class KubernetesDeploy
       log_status(status_data)
     end
 
-    def succeeded?
+    def deploy_succeeded?
       @status == "Bound"
     end
 
-    def failed?
+    def deploy_failed?
       @status == "Lost"
     end
 
@@ -419,6 +445,8 @@ class KubernetesDeploy
   end
 
   class Ingress < KubernetesResource
+    TIMEOUT = 30
+
     def initialize(name, namespace, file)
       @name, @namespace, @file = name, namespace, file
     end
@@ -430,37 +458,48 @@ class KubernetesDeploy
       log_status(status_data)
     end
 
-    def succeeded?
+    def deploy_succeeded?
       exists?
     end
 
-    def failed?
+    def deploy_failed?
       false
     end
 
     def exists?
       @found
     end
+
+    def group_name
+      "Ingresses"
+    end
   end
 
   class Service < KubernetesResource
+    TIMEOUT = 60 * 15
+
     def initialize(name, namespace, file)
       @name, @namespace, @file = name, namespace, file
     end
 
     def sync
-      endpoints, st = run_kubectl("get", "endpoints", @name, "--output=jsonpath={.subsets[*].addresses[*].ip}")
-      @num_endpoints = endpoints.split.length
-      @status = "#{@num_endpoints} endpoints"
+      _, st = run_kubectl("get", type, @name)
       @found = st.success?
+      if @found
+        endpoints, st = run_kubectl("get", "endpoints", @name, "--output=jsonpath={.subsets[*].addresses[*].ip}")
+        @num_endpoints = (st.success? ? endpoints.split.length : 0)
+      else
+        @num_endpoints = 0
+      end
+      @status = "#{@num_endpoints} endpoints"
       log_status(status_data)
     end
 
-    def succeeded?
+    def deploy_succeeded?
       @num_endpoints > 0
     end
 
-    def failed?
+    def deploy_failed?
       false
     end
 
@@ -470,93 +509,130 @@ class KubernetesDeploy
   end
 
   class Pod < KubernetesResource
+    TIMEOUT = 60 * 5
+
     def initialize(name, namespace, file, parent: nil)
       @name, @namespace, @file, @parent = name, namespace, file, parent
       @bare = !@parent
     end
 
     def sync
-      out, st = run_kubectl("get", type, @name, "-a", "--output=jsonpath={.spec.containers[*].name}{\"//\"}{.status.phase}")
+      out, st = run_kubectl("get", type, @name, "-a", "--output=jsonpath={.status.phase}{\"//\"}{.spec.containers[*].name}")
       @found = st.success?
+
       if @found
-        container_list, @status = out.split("//")
-        @containers = container_list.split(/\s+/)
+        @phase, container_list = out.split("//")
+
+        if @deploy_started && @phase == "Pending"
+          container_states, st = run_kubectl("get", type, @name, "-a", "--output=jsonpath={.status.containerStatuses[*].state}")
+          container_states.split("\n").each do |state|
+            state.match(/ImagePullBackOff|RunContainerError/) do |bad_state|
+              reason_data = state.match(/message:[^\]]+/) || []
+              KubernetesDeploy.logger.warn("#{id} has container in state #{bad_state} (#{reason_data[0]}).")
+            end
+          end
+        end
+
+        @containers = container_list.split
+        if @phase == "Failed"
+          fail_reason, st = run_kubectl("get", type, @name, "-a", "--output=jsonpath={.status.reason}")
+          @status = "#{@phase} (Reason: #{fail_reason})"
+          KubernetesDeploy.logger.error("#{id} failed: #{@status}")
+        else
+          @ready, _ = run_kubectl("get", type, @name, "-a", "--output=jsonpath={.status.conditions[?(@.type==\"Ready\")].status}")
+          @status = "#{@phase} (Ready: #{@ready})"
+        end
+      else # reset
+        @status = @phase = nil
+        @ready = false
+        @containers = []
       end
+
       fetch_logs
       log_status(status_data)
     end
 
-    def succeeded?
-      @bare ? (@status == "Succeeded") : (@status == "Running")
+    def deploy_succeeded?
+      if @bare
+        @phase == "Succeeded"
+      else
+        @phase == "Running" && @ready == "True"
+      end
     end
 
-    def failed?
-      @status == "Failed"
+    def deploy_failed?
+      @phase == "Failed"
     end
 
     def exists?
       @found
     end
 
+    def group_name
+      @bare ? "Bare pods" : @parent
+    end
+
     def status_data
-      group = @bare ? "Bare pods" : @parent
-      super.merge(
-        group: group,
-        logs: @logs
-      )
+      super.merge(logs: @logs)
     end
 
     private
 
     def fetch_logs
       @logs = {}
-      return if !@found || @containers.empty?
+      return @logs unless @found && @deploy_started
+      return @logs if @containers.empty?
 
       @containers.each do |container_name|
-        out, _ = run_kubectl("logs", @name, "--timestamps=true", "--since=#{STEP_COMPLETION_TIMEOUT_MINUTES}m")
-        next if out.empty?
+        out, _ = run_kubectl("logs", @name, "--timestamps=true", "--since-time=#{@deploy_started.to_datetime.rfc3339}")
+        next if out.blank?
         @logs[container_name] = out
-        if @bare && deployed? && !@already_displayed
+        if @bare && deploy_finished? && !@already_displayed
           KubernetesDeploy.logger.info "Logs from #{id} container #{container_name}:"
           STDOUT.puts "#{out}"
           @already_displayed = true
         end
       end
+      @logs
     end
   end
 
   class Deployment < KubernetesResource
+    TIMEOUT = 60 * 15
+
     def initialize(name, namespace, file)
       @name, @namespace, @file = name, namespace, file
     end
 
     def sync
-      deployment_stats, st = run_kubectl("get", type, @name)
+      status_blob, st = run_kubectl("get", type, @name, "--output=jsonpath={.status}")
       @found = st.success?
       if @found
-        # deployment_stats looks like this:
-        # NAME                  DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
-        # jobs                  1         1         1            1           43d
-        labels, statuses = deployment_stats.split("\n")
-        labels = labels.split(/\s+/)[1..4]
-        statuses = statuses.split(/\s+/)[1..4]
-        @rollout_data = labels.zip(statuses).to_h # { "DESIRED" => 1 } etc.
+        @rollout_data = status_blob.scan(/\b([A-Za-z]*replicas)\:(\d+)/i).to_h
+        @status, _ = run_kubectl("rollout", "status", type, @name, "--watch=false")
 
-        @status, _ = run_kubectl("rollout", "status", type, @name)
         pod_names, st = run_kubectl("get", "pods", "-a", "-l", "name=#{name}", "--output=jsonpath={range .items[*]}{ .metadata.name }//{end}")
-        @pods = pod_names.split("//").map do |pod_name|
-          Pod.new(pod_name, namespace, nil, parent: "#{@name.capitalize} deployment").tap(&:sync)
-        end
+        @pods = init_pods(pod_names.split("//"))
+      else
+        @rollout_data = {}
+        @status = nil
+        @pods = []
       end
       log_status(status_data)
     end
 
-    def succeeded?
-      @rollout_data && @rollout_data.values.uniq.length == 1 # num desired, current, up-to-date and available are equal
+    def deploy_succeeded?
+      return false unless @rollout_data.key?("availableReplicas")
+      @rollout_data["availableReplicas"].to_i > 0 && # TODO: should actually ensure at least one NEW pod
+      @rollout_data.values.uniq.length == 1 # num desired, current, up-to-date and available are equal
     end
 
-    def failed?
-      @pods && @pods.all?(&:failed?) # TODO: this likely needs to be a threshold instead
+    def deploy_failed?
+      @pods.present? && @pods.all?(&:deploy_failed?) # TODO: this needs to look at the new pods only
+    end
+
+    def deploy_timed_out?
+      super || @pods.present? && @pods.all?(&:deploy_timed_out?) # TODO: this needs to look at the new pods only
     end
 
     def exists?
@@ -564,7 +640,18 @@ class KubernetesDeploy
     end
 
     def status_data
-      super.merge(pods: @rollout_data)
+      super.merge(replicas: @rollout_data)
+    end
+
+    private
+
+    def init_pods(pod_names)
+      pod_names.map do |pod_name|
+        pod = Pod.new(pod_name, namespace, nil, parent: "#{@name.capitalize} deployment")
+        pod.deploy_started = @deploy_started
+        pod.sync
+        pod
+      end
     end
   end
 end

--- a/lib/snippets/kubernetes-deploy
+++ b/lib/snippets/kubernetes-deploy
@@ -18,9 +18,39 @@ require 'yaml'
 require 'shellwords'
 require 'tempfile'
 require 'logger'
+require 'active_support/core_ext/object/blank'
+require 'active_support/descendants_tracker'
 
 class KubernetesDeploy
   class FatalDeploymentError < StandardError; end
+
+  # Things removed from default prune whitelist:
+  # core/v1/Namespace -- not namespaced
+  # core/v1/PersistentVolume -- not namespaced
+  # core/v1/Endpoints -- managed by services
+  # core/v1/PersistentVolumeClaim -- would delete data
+  # core/v1/ReplicationController -- superseded by deployments/replicasets
+  # extensions/v1beta1/ReplicaSet -- managed by deployments
+  # core/v1/Secret -- should not committed / managed by shipit
+  PRUNE_WHITELIST = %w(
+    core/v1/ConfigMap
+    core/v1/Pod
+    core/v1/Service
+    batch/v1/Job
+    extensions/v1beta1/DaemonSet
+    extensions/v1beta1/Deployment
+    extensions/v1beta1/HorizontalPodAutoscaler
+    extensions/v1beta1/Ingress
+    apps/v1beta1/StatefulSet
+  ).freeze
+
+  PREDEPLOY_SEQUENCE = %w(
+    configmap
+    persistentvolumeclaim
+    pod
+  )
+
+  STEP_COMPLETION_TIMEOUT_MINUTES = 20
 
   def initialize(namespace:, environment:, current_sha:, template_folder: nil, context:)
     @namespace = namespace
@@ -32,12 +62,30 @@ class KubernetesDeploy
   end
 
   def run
+    @current_phase = 0
+    phase_heading("Validating configuration")
     validate_configuration
+
+    phase_heading("Configuring kubectl")
     set_kubectl_context
     validate_namespace
-    apply_all_templates
+
+    phase_heading("Parsing deploy content")
+    resources = discover_resources
+
+    phase_heading("Checking initial resource statuses")
+    resources.each(&:sync)
+
+    phase_heading("Predeploying priority resources")
+    predeploy_priority_resources(resources)
+
+    phase_heading("Deploying all resources")
+    deploy_resources(resources, prune: true)
+    wait_for_completion(resources)
+
+    report_final_status(resources)
   rescue FatalDeploymentError => error
-    logger.fatal(error.message)
+    KubernetesDeploy.logger.fatal(error.message)
     exit 1
   end
 
@@ -50,13 +98,95 @@ class KubernetesDeploy
 
   private
 
+  def predeploy_priority_resources(resource_list)
+    PREDEPLOY_SEQUENCE.each do |resource_type|
+      matching_resources = resource_list.select { |r| r.type == resource_type }
+      next if matching_resources.empty?
+      deploy_resources(matching_resources)
+      wait_for_completion(matching_resources)
+    end
+  end
+
+  def discover_resources
+    resources = []
+    Dir.foreach(@template_path) do |filename|
+      next unless filename.end_with?(".yml.erb", ".yml")
+
+      split_templates(filename) do |tempfile|
+        resource_id = discover_resource_via_dry_run(tempfile)
+        type, name = resource_id.split("/", 2) # e.g. "pod/web-198612918-dzvfb"
+        resources << KubernetesResource.for_type(type, name, @namespace, tempfile)
+        KubernetesDeploy.logger.info "Discovered template for #{resource_id}"
+      end
+    end
+    resources
+  end
+
+  def discover_resource_via_dry_run(tempfile)
+    resource_id, err, st = run_kubectl("apply", "-f", tempfile.path, "--dry-run", "--output=name")
+    raise FatalDeploymentError, "Dry run failed for template #{File.basename(tempfile.path)}." unless st.success?
+    resource_id
+  end
+
+  def split_templates(filename)
+    file_content = File.read(File.join(@template_path, filename))
+    rendered_content = render_template(filename, file_content)
+    YAML.load_stream(rendered_content) do |doc|
+      f = Tempfile.new(filename)
+      f.write(YAML.dump(doc))
+      f.close
+      yield f
+    end
+  rescue Psych::SyntaxError => e
+    KubernetesDeploy.logger.error(rendered_content)
+    raise FatalDeploymentError, "Template #{filename} cannot be parsed: #{e.message}"
+  end
+
+  def report_final_status(resources)
+    if resources.all?(&:succeeded?)
+      log_green("Deploy succeeded!")
+    else
+      fail_list = resources.select(&:failed?).map(&:id)
+      KubernetesDeploy.logger.error("The following resources failed to deploy: #{fail_list.join(", ")}")
+      raise FatalDeploymentError, "#{fail_list.length} resources failed to deploy"
+    end
+  end
+
+  def wait_for_completion(resources_to_deploy)
+    timeout = Time.now.utc + (60 * STEP_COMPLETION_TIMEOUT_MINUTES)
+    delay_sync_until = Time.now.utc
+
+    while !resources_to_deploy.empty?
+      if Time.now.utc > timeout
+        Kubernetes.logger.error("Phase #{@current_phase} timed out deploying the following resources: #{resources_to_deploy.map(&:id).join(", ")}")
+        raise FatalDeploymentError, "Deploy phase #{@current_phase} failed to complete within #{STEP_COMPLETION_TIMEOUT_MINUTES} minutes"
+      elsif Time.now.utc < delay_sync_until
+        sleep (delay_sync_until - Time.now.utc)
+      end
+      delay_sync_until = Time.now.utc + 3 # don't pummel the API if the sync is fast
+      resources_to_deploy.each(&:sync)
+      resources_to_deploy = resources_to_deploy.reject(&:deployed?)
+    end
+  end
+
+  def render_template(filename, raw_template)
+    return raw_template unless File.extname(filename) == ".erb"
+
+    erb_template = ERB.new(raw_template)
+    erb_binding = binding
+    template_variables.each do |var_name, value|
+      erb_binding.local_variable_set(var_name, value)
+    end
+    erb_template.result(erb_binding)
+  end
+
   def validate_configuration
     errors = []
-    if ENV["KUBECONFIG"].nil? || !File.file?(ENV["KUBECONFIG"])
+    if ENV["KUBECONFIG"].blank? || !File.file?(ENV["KUBECONFIG"])
       errors << "Kube config not found at #{ENV["KUBECONFIG"]}"
     end
 
-    if @current_sha.nil?  || @current_sha.empty?
+    if @current_sha.blank?
       errors << "Current SHA must be specified"
     end
 
@@ -66,57 +196,37 @@ class KubernetesDeploy
       errors << "#{@template_path} doesn't contain valid templates (postfix .yml or .yml.erb)"
     end
 
-    if @namespace.nil? || @namespace.empty?
+    if @namespace.blank?
       errors << "Namespace must be specified"
     end
 
-    if @context.nil? || @context.empty?
+    if @context.blank?
       errors << "Context must be specified"
     end
 
     raise FatalDeploymentError, "Configuration invalid: #{errors.join(", ")}" unless errors.empty?
-    logger.info("All required parameters and files are present")
+    KubernetesDeploy.logger.info("All required parameters and files are present")
   end
 
-  def apply_all_templates
-    found = false
-    Dir.foreach(@template_path) do |file|
-      file_path = "#{@template_path}/#{file}"
-      case File.extname(file)
-      when '.yml'
-        found ||= true
-        apply_template(file_path)
-      when '.erb'
-        found ||= true
-        render_and_apply_template(file_path)
-      end
+  def deploy_resources(resources, prune: false)
+    command = ["apply", "--namespace=#{@namespace}"]
+    KubernetesDeploy.logger.info("Deploying resources:")
+
+    resources.each do |r|
+      KubernetesDeploy.logger.info("- #{r.id}")
+      command.push("-f", r.file.path)
     end
-    raise FatalDeploymentError, "No templates found in #{@template_path}" unless found
-  end
 
-  def render_and_apply_template(file_path)
-    erb_template = ERB.new(File.read(file_path))
-    erb_binding = binding
-    template_variables.each do |var_name, value|
-      erb_binding.local_variable_set(var_name, value)
+    if prune
+      command.push("--prune", "--all")
+      PRUNE_WHITELIST.each { |type| command.push("--prune-whitelist=#{type}") }
     end
-    content = erb_template.result(erb_binding)
 
-    f = Tempfile.new(['kube_template', '.yml'])
-    f.write(content)
-    f.close
-    apply_template(f.path, original_path: file_path)
-  end
-
-  def apply_template(path, original_path: nil)
-    logger.info("Applying #{original_path || path}")
-    out, _, status = run_kubectl('apply', '-f', path, "--namespace=#{@namespace}")
-    raise FatalDeploymentError, "Failed to apply template #{original_path || path}" unless status.success?
-    logger.info(out)
+    run_kubectl(*command)
   end
 
   def set_kubectl_context
-    out, err, st = run_kubectl("config","get-contexts", "-o", "name")
+    out, err, st = run_kubectl("config", "get-contexts", "-o", "name", namespaced: false)
     available_contexts = out.split("\n")
     if !st.success?
       raise FatalDeploymentError, err
@@ -124,39 +234,337 @@ class KubernetesDeploy
       raise FatalDeploymentError, "Context #{@context} is not available. Valid contexts: #{available_contexts}"
     end
 
-    _, err, st = run_kubectl("config", "use-context", @context)
+    _, err, st = run_kubectl("config", "use-context", @context, namespaced: false)
     raise FatalDeploymentError, "Kubectl config is not valid: #{err}" unless st.success?
-    logger.info("Kubectl configured")
+    KubernetesDeploy.logger.info("Kubectl configured to use context #{@context}")
   end
 
   def validate_namespace
-    _, _, st = run_kubectl("get", "namespace", @namespace)
+    _, _, st = run_kubectl("get", "namespace", @namespace, namespaced: false)
     raise FatalDeploymentError, "Failed to validate namespace #{@namespace}" unless st.success?
-    logger.info("Namespace validated")
+    KubernetesDeploy.logger.info("Namespace #{@namespace} validated")
   end
 
-  def run_kubectl(*args)
+  def run_kubectl(*args, namespaced: true)
     args = args.unshift("kubectl")
-    logger.debug Shellwords.join(args)
+    if namespaced
+      raise FatalDeploymentError, "Namespace missing for namespaced command" unless @namespace
+      args.push("--namespace=#{@namespace}")
+    end
+    KubernetesDeploy.logger.debug Shellwords.join(args)
     out, err, st = Open3.capture3(*args)
-    logger.debug(out.shellescape)
-    logger.warn(err) unless st.success?
+    KubernetesDeploy.logger.debug(out.shellescape)
+    KubernetesDeploy.logger.warn(err) unless st.success?
     [out.chomp, err.chomp, st]
   end
 
-  def logger
+  def phase_heading(phase_name)
+    @current_phase += 1
+    heading = "Phase #{@current_phase}: #{phase_name}"
+    padding = (100.0 - heading.length)/2
+    KubernetesDeploy.logger.info("")
+    KubernetesDeploy.logger.info("#{'-' * padding.floor}#{heading}#{'-' * padding.ceil}")
+  end
+
+  def log_green(msg)
+    STDOUT.puts "\033[0;32m#{msg}\x1b[0m\n" # green
+  end
+
+  def self.logger
     @logger ||= begin
       l = Logger.new(STDOUT)
       l.level = ENV["DEBUG"] ? Logger::DEBUG : Logger::INFO
       l.formatter = proc do |severity, _datetime, _progname, msg|
         case severity
-        when "FATAL" then "\033[0;31m[#{severity}]\t#{msg}\x1b[0m\n"
-        when "ERROR", "WARN" then "\033[0;31m[#{severity}]\t#{msg}\x1b[0m\n"
-        when "INFO" then "\033[0;36m#{msg}\x1b[0m\n"
+        when "FATAL" then "\033[0;31m[#{severity}]\t#{msg}\x1b[0m\n" # red
+        when "ERROR", "WARN" then "\033[0;33m[#{severity}]\t#{msg}\x1b[0m\n" # yellow
+        when "INFO" then "\033[0;36m#{msg}\x1b[0m\n" # blue
         else "[#{severity}]\t#{msg}\n"
         end
       end
       l
+    end
+  end
+
+  class KubernetesResource
+    extend ActiveSupport::DescendantsTracker
+
+    attr_reader :name, :namespace, :file
+    attr_writer :type
+
+
+    def self.handled_type
+      name.split('::').last.downcase
+    end
+
+    def self.for_type(type, name, namespace, file)
+      if subclass = descendants.find { |subclass| subclass.handled_type == type }
+        subclass.new(name, namespace, file)
+      else
+        self.new(name, namespace, file).tap { |r| r.type = type }
+      end
+    end
+
+    def initialize(name, namespace, file)
+      # subclasses must also set these
+      @name, @namespace, @file = name, namespace, file
+    end
+
+    def id
+      "#{type}/#{name}"
+    end
+
+    def sync
+      log_status(status_data)
+    end
+
+    def failed?
+      false
+    end
+
+    def succeeded?
+      KubernetesDeploy.logger.warn("Don't know how to monitor resources of type #{type}. Assuming #{id} deployed successfully.")
+      true
+    end
+
+    def exists?
+      nil
+    end
+
+    def status
+      @status || "Unknown"
+    end
+
+    def type
+      @type || self.class.handled_type
+    end
+
+    def deployed?
+      failed? || succeeded?
+    end
+
+    def status_data
+      {
+        group: type.capitalize + "s",
+        name: name,
+        status_string: status,
+        exists: exists?,
+        failed: failed?,
+        succeeded: succeeded?
+      }
+    end
+
+    def run_kubectl(*args)
+      raise FatalDeploymentError, "Namespace missing for namespaced command" if namespace.blank?
+      args = args.unshift("kubectl").push("--namespace=#{namespace}")
+      KubernetesDeploy.logger.debug Shellwords.join(args)
+      out, err, st = Open3.capture3(*args)
+      KubernetesDeploy.logger.debug(out.shellescape)
+      KubernetesDeploy.logger.debug("[ERROR] #{err.shellescape}") unless st.success?
+      [out.chomp, st]
+    end
+
+    def log_status(data)
+      STDOUT.puts "[KUBESTATUS] #{JSON.dump(data)}"
+    end
+  end
+
+  class Configmap < KubernetesResource
+    def initialize(name, namespace, file)
+      @name, @namespace, @file = name, namespace, file
+    end
+
+    def sync
+      _, st = run_kubectl("get", type, @name)
+      @status = st.success? ? "Available" : "Unknown"
+      @found = st.success?
+      log_status(status_data)
+    end
+
+    def succeeded?
+      exists?
+    end
+
+    def failed?
+      false
+    end
+
+    def exists?
+      @found
+    end
+  end
+
+  class PersistentVolumeClaim < KubernetesResource
+    def initialize(name, namespace, file)
+      @name, @namespace, @file = name, namespace, file
+    end
+
+    def sync
+      @status, st = run_kubectl("get", type, @name, "--output=jsonpath={.status.phase}")
+      @found = st.success?
+      log_status(status_data)
+    end
+
+    def succeeded?
+      @status == "Bound"
+    end
+
+    def failed?
+      @status == "Lost"
+    end
+
+    def exists?
+      @found
+    end
+  end
+
+  class Ingress < KubernetesResource
+    def initialize(name, namespace, file)
+      @name, @namespace, @file = name, namespace, file
+    end
+
+    def sync
+      _, st = run_kubectl("get", type, @name)
+      @status = st.success? ? "Created" : "Unknown"
+      @found = st.success?
+      log_status(status_data)
+    end
+
+    def succeeded?
+      exists?
+    end
+
+    def failed?
+      false
+    end
+
+    def exists?
+      @found
+    end
+  end
+
+  class Service < KubernetesResource
+    def initialize(name, namespace, file)
+      @name, @namespace, @file = name, namespace, file
+    end
+
+    def sync
+      endpoints, st = run_kubectl("get", "endpoints", @name, "--output=jsonpath={.subsets[*].addresses[*].ip}")
+      @num_endpoints = endpoints.split.length
+      @status = "#{@num_endpoints} endpoints"
+      @found = st.success?
+      log_status(status_data)
+    end
+
+    def succeeded?
+      @num_endpoints > 0
+    end
+
+    def failed?
+      false
+    end
+
+    def exists?
+      @found
+    end
+  end
+
+  class Pod < KubernetesResource
+    def initialize(name, namespace, file, parent: nil)
+      @name, @namespace, @file, @parent = name, namespace, file, parent
+      @bare = !@parent
+    end
+
+    def sync
+      out, st = run_kubectl("get", type, @name, "-a", "--output=jsonpath={.spec.containers[*].name}{\"//\"}{.status.phase}")
+      @found = st.success?
+      if @found
+        container_list, @status = out.split("//")
+        @containers = container_list.split(/\s+/)
+      end
+      fetch_logs
+      log_status(status_data)
+    end
+
+    def succeeded?
+      @bare ? (@status == "Succeeded") : (@status == "Running")
+    end
+
+    def failed?
+      @status == "Failed"
+    end
+
+    def exists?
+      @found
+    end
+
+    def status_data
+      group = @bare ? "Bare pods" : @parent
+      super.merge(
+        group: group,
+        logs: @logs
+      )
+    end
+
+    private
+
+    def fetch_logs
+      @logs = {}
+      return if !@found || @containers.empty?
+
+      @containers.each do |container_name|
+        out, _ = run_kubectl("logs", @name, "--timestamps=true", "--since=#{STEP_COMPLETION_TIMEOUT_MINUTES}m")
+        next if out.empty?
+        @logs[container_name] = out
+        if @bare && deployed? && !@already_displayed
+          KubernetesDeploy.logger.info "Logs from #{id} container #{container_name}:"
+          STDOUT.puts "#{out}"
+          @already_displayed = true
+        end
+      end
+    end
+  end
+
+  class Deployment < KubernetesResource
+    def initialize(name, namespace, file)
+      @name, @namespace, @file = name, namespace, file
+    end
+
+    def sync
+      deployment_stats, st = run_kubectl("get", type, @name)
+      @found = st.success?
+      if @found
+        # deployment_stats looks like this:
+        # NAME                  DESIRED   CURRENT   UP-TO-DATE   AVAILABLE   AGE
+        # jobs                  1         1         1            1           43d
+        labels, statuses = deployment_stats.split("\n")
+        labels = labels.split(/\s+/)[1..4]
+        statuses = statuses.split(/\s+/)[1..4]
+        @rollout_data = labels.zip(statuses).to_h # { "DESIRED" => 1 } etc.
+
+        @status, _ = run_kubectl("rollout", "status", type, @name)
+        pod_names, st = run_kubectl("get", "pods", "-a", "-l", "name=#{name}", "--output=jsonpath={range .items[*]}{ .metadata.name }//{end}")
+        @pods = pod_names.split("//").map do |pod_name|
+          Pod.new(pod_name, namespace, nil, parent: "#{@name.capitalize} deployment").tap(&:sync)
+        end
+      end
+      log_status(status_data)
+    end
+
+    def succeeded?
+      @rollout_data && @rollout_data.values.uniq.length == 1 # num desired, current, up-to-date and available are equal
+    end
+
+    def failed?
+      @pods && @pods.all?(&:failed?) # TODO: this likely needs to be a threshold instead
+    end
+
+    def exists?
+      @found
+    end
+
+    def status_data
+      super.merge(pods: @rollout_data)
     end
   end
 end

--- a/lib/snippets/kubernetes-deploy
+++ b/lib/snippets/kubernetes-deploy
@@ -20,6 +20,8 @@ require 'tempfile'
 require 'logger'
 require 'active_support/core_ext/object/blank'
 require 'active_support/descendants_tracker'
+require 'active_support/core_ext/hash/slice'
+require 'active_support/core_ext/numeric/time'
 
 class KubernetesDeploy
   class FatalDeploymentError < StandardError; end
@@ -166,7 +168,7 @@ class KubernetesDeploy
       newly_finished_resources.each do |resource|
         next unless resource.deploy_failed? || resource.deploy_timed_out?
         KubernetesDeploy.logger.error("#{resource.id} failed to deploy with status '#{resource.status}'.")
-        KubernetesDeploy.logger.warn("Continuing to poll status of other resources in this phase. You may wish to abort the deploy.")
+        KubernetesDeploy.logger.error("This script will continue to poll until the status of all resources deployed in this phase is resolved, but the deploy is now doomed and you may wish abort it.")
         KubernetesDeploy.logger.error(resource.status_data)
       end
     end
@@ -296,7 +298,7 @@ class KubernetesDeploy
     attr_reader :name, :namespace, :file
     attr_writer :type, :deploy_started
 
-    TIMEOUT = 60 * 5
+    TIMEOUT = 5.minutes
 
     def self.handled_type
       name.split('::').last
@@ -320,7 +322,7 @@ class KubernetesDeploy
     end
 
     def sync
-      log_status(status_data)
+      log_status
     end
 
     def deploy_failed?
@@ -328,7 +330,10 @@ class KubernetesDeploy
     end
 
     def deploy_succeeded?
-      KubernetesDeploy.logger.warn("Don't know how to monitor resources of type #{type}. Assuming #{id} deployed successfully.")
+      if @deploy_started && !@success_assumption_warning_shown
+        KubernetesDeploy.logger.warn("Don't know how to monitor resources of type #{type}. Assuming #{id} deployed successfully.")
+        @success_assumption_warning_shown = true
+      end
       true
     end
 
@@ -362,18 +367,12 @@ class KubernetesDeploy
         exists: exists?,
         succeeded: deploy_succeeded?,
         failed: deploy_failed?,
-        timed_out: deploy_timed_out?,
-        events: fetch_events
+        timed_out: deploy_timed_out?
       }
     end
 
     def group_name
       type + "s"
-    end
-
-    def fetch_events
-      out, _ = run_kubectl("get", "events", "--output=jsonpath={range .items[?(@.involvedObject.name==\"#{name}\")]}{.involvedObject.kind}   {.metadata.creationTimestamp}  {.reason}   {.count}   {.message}{\"\\n\"}{end}")
-      out.split("\n").select { |event_log| event_log.match(/\A#{type}/i) }
     end
 
     def run_kubectl(*args)
@@ -386,13 +385,13 @@ class KubernetesDeploy
       [out.chomp, st]
     end
 
-    def log_status(data)
-      STDOUT.puts "[KUBESTATUS] #{JSON.dump(data)}"
+    def log_status
+      STDOUT.puts "[KUBESTATUS] #{JSON.dump(status_data)}"
     end
   end
 
   class ConfigMap < KubernetesResource
-    TIMEOUT = 30
+    TIMEOUT = 30.seconds
 
     def initialize(name, namespace, file)
       @name, @namespace, @file = name, namespace, file
@@ -402,7 +401,7 @@ class KubernetesDeploy
       _, st = run_kubectl("get", type, @name)
       @status = st.success? ? "Available" : "Unknown"
       @found = st.success?
-      log_status(status_data)
+      log_status
     end
 
     def deploy_succeeded?
@@ -419,7 +418,7 @@ class KubernetesDeploy
   end
 
   class PersistentVolumeClaim < KubernetesResource
-    TIMEOUT = 60 * 5
+    TIMEOUT = 5.minutes
 
     def initialize(name, namespace, file)
       @name, @namespace, @file = name, namespace, file
@@ -428,7 +427,7 @@ class KubernetesDeploy
     def sync
       @status, st = run_kubectl("get", type, @name, "--output=jsonpath={.status.phase}")
       @found = st.success?
-      log_status(status_data)
+      log_status
     end
 
     def deploy_succeeded?
@@ -445,7 +444,7 @@ class KubernetesDeploy
   end
 
   class Ingress < KubernetesResource
-    TIMEOUT = 30
+    TIMEOUT = 30.seconds
 
     def initialize(name, namespace, file)
       @name, @namespace, @file = name, namespace, file
@@ -455,7 +454,7 @@ class KubernetesDeploy
       _, st = run_kubectl("get", type, @name)
       @status = st.success? ? "Created" : "Unknown"
       @found = st.success?
-      log_status(status_data)
+      log_status
     end
 
     def deploy_succeeded?
@@ -476,7 +475,7 @@ class KubernetesDeploy
   end
 
   class Service < KubernetesResource
-    TIMEOUT = 60 * 15
+    TIMEOUT = 15.minutes
 
     def initialize(name, namespace, file)
       @name, @namespace, @file = name, namespace, file
@@ -492,7 +491,7 @@ class KubernetesDeploy
         @num_endpoints = 0
       end
       @status = "#{@num_endpoints} endpoints"
-      log_status(status_data)
+      log_status
     end
 
     def deploy_succeeded?
@@ -509,7 +508,8 @@ class KubernetesDeploy
   end
 
   class Pod < KubernetesResource
-    TIMEOUT = 60 * 5
+    TIMEOUT = 15.minutes
+    SUSPICIOUS_CONTAINER_STATES = %w(ImagePullBackOff RunContainerError).freeze
 
     def initialize(name, namespace, file, parent: nil)
       @name, @namespace, @file, @parent = name, namespace, file, parent
@@ -517,46 +517,48 @@ class KubernetesDeploy
     end
 
     def sync
-      out, st = run_kubectl("get", type, @name, "-a", "--output=jsonpath={.status.phase}{\"//\"}{.spec.containers[*].name}")
-      @found = st.success?
-
-      if @found
-        @phase, container_list = out.split("//")
-
-        if @deploy_started && @phase == "Pending"
-          container_states, st = run_kubectl("get", type, @name, "-a", "--output=jsonpath={.status.containerStatuses[*].state}")
-          container_states.split("\n").each do |state|
-            state.match(/ImagePullBackOff|RunContainerError/) do |bad_state|
-              reason_data = state.match(/message:[^\]]+/) || []
-              KubernetesDeploy.logger.warn("#{id} has container in state #{bad_state} (#{reason_data[0]}).")
-            end
-          end
-        end
-
-        @containers = container_list.split
-        if @phase == "Failed"
-          fail_reason, st = run_kubectl("get", type, @name, "-a", "--output=jsonpath={.status.reason}")
-          @status = "#{@phase} (Reason: #{fail_reason})"
-          KubernetesDeploy.logger.error("#{id} failed: #{@status}")
-        else
-          @ready, _ = run_kubectl("get", type, @name, "-a", "--output=jsonpath={.status.conditions[?(@.type==\"Ready\")].status}")
-          @status = "#{@phase} (Ready: #{@ready})"
-        end
+      out, st = run_kubectl("get", type, @name, "-a", "--output=json")
+      if @found = st.success?
+        pod_data = JSON.parse(out)
+        interpret_json_data(pod_data)
       else # reset
         @status = @phase = nil
         @ready = false
         @containers = []
       end
+      display_logs if @bare && deploy_finished?
+      log_status
+    end
 
-      fetch_logs
-      log_status(status_data)
+    def interpret_json_data(pod_data)
+      @phase = (pod_data["metadata"]["deletionTimestamp"] ? "Terminating" : pod_data["status"]["phase"])
+      @containers = pod_data["spec"]["containers"].map { |c| c["name"] }
+
+      if @deploy_started && pod_data["status"]["containerStatuses"]
+        pod_data["status"]["containerStatuses"].each do |status|
+          waiting_state = status["state"]["waiting"] if status["state"]
+          reason = waiting_state["reason"] if waiting_state
+          next unless SUSPICIOUS_CONTAINER_STATES.include?(reason)
+          KubernetesDeploy.logger.warn("#{id} has container in state #{reason} (#{waiting_state["message"]})")
+        end
+      end
+
+      if @phase == "Failed"
+        @status = "#{@phase} (Reason: #{pod_data["status"]["reason"]})"
+      elsif @phase == "Terminating"
+        @status = @phase
+      else
+        ready_condition = pod_data["status"]["conditions"].find { |condition| condition["type"] == "Ready" }
+        @ready = ready_condition.present? && (ready_condition["status"] == "True")
+        @status = "#{@phase} (Ready: #{@ready})"
+      end
     end
 
     def deploy_succeeded?
       if @bare
         @phase == "Succeeded"
       else
-        @phase == "Running" && @ready == "True"
+        @phase == "Running" && @ready
       end
     end
 
@@ -565,74 +567,79 @@ class KubernetesDeploy
     end
 
     def exists?
-      @found
+      @bare ? @found : true
     end
 
     def group_name
       @bare ? "Bare pods" : @parent
     end
 
-    def status_data
-      super.merge(logs: @logs)
-    end
-
     private
 
-    def fetch_logs
-      @logs = {}
-      return @logs unless @found && @deploy_started
-      return @logs if @containers.empty?
+    def display_logs
+      return {} unless exists? && @containers.present? && !@already_displayed
 
       @containers.each do |container_name|
-        out, _ = run_kubectl("logs", @name, "--timestamps=true", "--since-time=#{@deploy_started.to_datetime.rfc3339}")
-        next if out.blank?
-        @logs[container_name] = out
-        if @bare && deploy_finished? && !@already_displayed
-          KubernetesDeploy.logger.info "Logs from #{id} container #{container_name}:"
-          STDOUT.puts "#{out}"
-          @already_displayed = true
-        end
+        out, st = run_kubectl("logs", @name, "--timestamps=true", "--since-time=#{@deploy_started.to_datetime.rfc3339}")
+        next unless st.success? && out.present?
+
+        KubernetesDeploy.logger.info "Logs from #{id} container #{container_name}:"
+        STDOUT.puts "#{out}"
+        @already_displayed = true
       end
-      @logs
     end
   end
 
   class Deployment < KubernetesResource
-    TIMEOUT = 60 * 15
+    TIMEOUT = 15.minutes
 
     def initialize(name, namespace, file)
       @name, @namespace, @file = name, namespace, file
     end
 
     def sync
-      status_blob, st = run_kubectl("get", type, @name, "--output=jsonpath={.status}")
+      json_data, st = run_kubectl("get", type, @name, "--output=json")
       @found = st.success?
-      if @found
-        @rollout_data = status_blob.scan(/\b([A-Za-z]*replicas)\:(\d+)/i).to_h
-        @status, _ = run_kubectl("rollout", "status", type, @name, "--watch=false")
+      @rollout_data = {}
+      @status = nil
+      @pods = []
 
-        pod_names, st = run_kubectl("get", "pods", "-a", "-l", "name=#{name}", "--output=jsonpath={range .items[*]}{ .metadata.name }//{end}")
-        @pods = init_pods(pod_names.split("//"))
-      else
-        @rollout_data = {}
-        @status = nil
-        @pods = []
+      if @found
+        @rollout_data = JSON.parse(json_data)["status"].slice("updatedReplicas", "replicas", "availableReplicas", "unavailableReplicas")
+        @status, _ = run_kubectl("rollout", "status", type, @name, "--watch=false") if @deploy_started
+
+        pod_list, st = run_kubectl("get", "pods", "-a", "-l", "name=#{name}", "--output=json")
+        if st.success?
+          pods_json = JSON.parse(pod_list)["items"]
+          pods_json.each do |pod_json|
+            pod_name = pod_json["metadata"]["name"]
+            pod = Pod.new(pod_name, namespace, nil, parent: "#{@name.capitalize} deployment")
+            pod.deploy_started = @deploy_started
+            pod.interpret_json_data(pod_json)
+            pod.log_status
+            @pods << pod
+          end
+        end
       end
-      log_status(status_data)
+
+      log_status
     end
 
     def deploy_succeeded?
       return false unless @rollout_data.key?("availableReplicas")
-      @rollout_data["availableReplicas"].to_i > 0 && # TODO: should actually ensure at least one NEW pod
+      # TODO: this should look at the current replica set's pods too
+      @rollout_data["availableReplicas"].to_i == @pods.length &&
       @rollout_data.values.uniq.length == 1 # num desired, current, up-to-date and available are equal
     end
 
     def deploy_failed?
-      @pods.present? && @pods.all?(&:deploy_failed?) # TODO: this needs to look at the new pods only
+      # TODO: this should look at the current replica set's pods only or it'll never be true for rolling updates
+      @pods.present? && @pods.all?(&:deploy_failed?)
     end
 
     def deploy_timed_out?
-      super || @pods.present? && @pods.all?(&:deploy_timed_out?) # TODO: this needs to look at the new pods only
+      # TODO: this should look at the current replica set's pods only or it'll never be true for rolling updates
+      super || @pods.present? && @pods.all?(&:deploy_timed_out?)
     end
 
     def exists?
@@ -640,18 +647,7 @@ class KubernetesDeploy
     end
 
     def status_data
-      super.merge(replicas: @rollout_data)
-    end
-
-    private
-
-    def init_pods(pod_names)
-      pod_names.map do |pod_name|
-        pod = Pod.new(pod_name, namespace, nil, parent: "#{@name.capitalize} deployment")
-        pod.deploy_started = @deploy_started
-        pod.sync
-        pod
-      end
+      super.merge(replicas: @rollout_data, num_pods: @pods.length)
     end
   end
 end


### PR DESCRIPTION
@Shopify/cloudplatform @byroot 

**Important**: This script now requires kubectl 1.5.1+. We'll have to replace the version in Shipit before picking up these changes.

This adds a bunch of features to `kubernetes-deploy`:

- It uses `apply --dry-run` to get up-front validation and discovery of all the individual resources in the deploy
- It deploys certain resources first, waiting for all resources of a given type to be up before continuing.
- It prunes resources that were previously `kubectl apply`'d and are not present in the current set  (if they're of a whitelisted type). This notably cleans up old migration pods.
- It is aware of some basic resource types (6 for starters) and knows how to detect whether they're running or failing...
- ...and as a result can make the deploy fail/succeed appropriately!

Notes:

- Only certain resource types are recognized. Theoretically this should match the prune whitelist, but for now I've got the set we're commonly providing: pods, deployments, configmaps, ingress, persistentvolumeclaims and services. Unrecognized types are applied during the bulk apply/prune and immediately considered to have been successful (though a warning is logged about this assumption).
- The script assumes that bare pods are always priority resources that should run to completion (e.g. migrations).
- If you kubectl apply something locally that isn't committed to the repo, and then deploy with this script, that thing will get pruned if it is of one of the types on the `PRUNE_WHITELIST`. If its type isn't on the list or you create it with a command other than `apply`, it will stick around.
- The script times out eventually if it can't determine all resources are up. (`STEP_COMPLETION_TIMEOUT_MINUTES=20`... too long?)
- The predeployed resources are re-applied during the bulk apply that uses prune (if they weren't included, they'd get pruned). This should be a no-op.
- The `[KUBESTATUS]` logging is really for the planned JS-based visualization (which doesn't exist at all yet), but could also be useful for debugging in the meantime.
- I still haven't added any tests. Since they'll be a huge pain to write and likely very stubbed, I'd like to continue deferring this until the script is more stable.

Please give this a try locally! I'm going to spend more time testing tomorrow as well, including the following scenarios I haven't tried recently:
- [x] invalid yaml - fails deploy during content parsing
- [x] valid yaml that is not a valid kube template - fails deploy during content parsing
- [x] unrecognized resource type (used a secret)
- [x] image pull error - warns on discovery, fails deploy as a timeout
- [x] configmap required by pod missing - warns on discovery, fails deploy as a timeout
- [x] failed bare pod - fails the predeploy phase
- [ ] "lost" pvc
- [x] massive scale up/down (that takes a while)
- [x] deploy with multiple bad resources
- [x] timeout - logs an error when it happens, then fails the phase
- [x] ingress template - works fine
- [x] rollback -- notably, does rolling back a deployment create a new rs or scale up the old one? Scales up the old one