### PR TITLE
First class kubernetes integration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+*   Add a `kubernetes` section in `shipit.yml` for first class k8s support.
+
 *   Disregard GitHub's Cache-Control max-age directives, because they impose a 60 seconds resolution
     which is way too slow.
 

--- a/README.md
+++ b/README.md
@@ -320,6 +320,19 @@ For example:
 fetch:
   curl --silent https://app.example.com/services/ping/version
 ```
+<h3 id="kubernetes">Kubernetes</h3>
+
+**<code>kubernetes</code>** allows to specify a Kubernetes namespace and context to deploy to.
+
+For example:
+```yml
+kubernetes:
+  namespace: my-app-production
+  context: tier4
+```
+
+**<code>kubernetes.template_dir</code>** allows to specify a Kubernetes template directory. It defaults to `./config/deploy/$ENVIRONMENT`
+
 <h3 id="environment">Environment</h3>
 
 **<code>machine.environment</code>** contains the extra environment variables that you want to provide during task execution.

--- a/app/models/shipit/deploy_spec.rb
+++ b/app/models/shipit/deploy_spec.rb
@@ -186,6 +186,10 @@ module Shipit
     def discover_fetch_deployed_revision_steps
     end
 
+    def discover_machine_env
+      {}
+    end
+
     def task_not_found!(id)
       raise TaskDefinition::NotFound.new("No definition for task #{id.inspect}")
     end

--- a/app/models/shipit/deploy_spec/file_system.rb
+++ b/app/models/shipit/deploy_spec/file_system.rb
@@ -1,6 +1,7 @@
 module Shipit
   class DeploySpec
     class FileSystem < DeploySpec
+      include KubernetesDiscovery
       include PypiDiscovery
       include RubygemsDiscovery
       include CapistranoDiscovery
@@ -33,7 +34,7 @@ module Shipit
             'require' => required_statuses,
           },
           'machine' => {
-            'environment' => machine_env,
+            'environment' => discover_machine_env.merge(machine_env),
             'directory' => directory,
             'cleanup' => true,
           },

--- a/app/models/shipit/deploy_spec/kubernetes_discovery.rb
+++ b/app/models/shipit/deploy_spec/kubernetes_discovery.rb
@@ -1,0 +1,37 @@
+module Shipit
+  class DeploySpec
+    module KubernetesDiscovery
+      def discover_deploy_steps
+        discover_kubernetes || super
+      end
+
+      def discover_rollback_steps
+        discover_kubernetes || super
+      end
+
+      def discover_machine_env
+        env = super
+        env = env.merge('K8S_TEMPLATE_FOLDER' => kube_config['template_dir']) if kube_config['template_dir']
+        env
+      end
+
+      private
+
+      def discover_kubernetes
+        return unless kube_config.present?
+
+        [
+          Shellwords.join([
+            'kubernetes-deploy',
+            kube_config['namespace'],
+            kube_config['context'],
+          ]),
+        ]
+      end
+
+      def kube_config
+        @kube_config ||= config('kubernetes') || {}
+      end
+    end
+  end
+end


### PR DESCRIPTION
Fix: https://github.com/Shopify/shipit-engine/issues/632

@Shopify/cloudplatform for review please.

Note: I didn't add support for multiple namspaces as it's not well specified yet. Since `kubernetes-deploy` can only deploy to a single namespace, I don't know if you want this to happen sequentially or concurrently. I suggest we discuss that feature in another issue when needed.