### PR TITLE
Remove kubernetes-deploy as a dependency

### DIFF
--- a/app/models/shipit/deploy_spec/kubernetes_discovery.rb
+++ b/app/models/shipit/deploy_spec/kubernetes_discovery.rb
@@ -22,7 +22,7 @@ module Shipit
 
         [
           Shellwords.join([
-            Gem.bin_path("kubernetes-deploy"),
+            "kubernetes-deploy",
             kube_config['namespace'],
             kube_config['context'],
           ]),

--- a/shipit-engine.gemspec
+++ b/shipit-engine.gemspec
@@ -55,5 +55,4 @@ Gem::Specification.new do |s|
   s.add_dependency 'faraday-http-cache', '~> 1.2.2'
   s.add_dependency 'redis-objects', '~> 1.2.1'
   s.add_dependency 'redis-namespace', '~> 1.5.2'
-  s.add_dependency 'kubernetes-deploy', '~> 0.1'
 end

--- a/test/unit/deploy_spec_test.rb
+++ b/test/unit/deploy_spec_test.rb
@@ -123,7 +123,7 @@ module Shipit
           'context' => 'bar',
         },
       )
-      assert_equal ["#{Gem.bin_path('kubernetes-deploy')} foo bar"], @spec.deploy_steps
+      assert_equal ["kubernetes-deploy foo bar"], @spec.deploy_steps
     end
 
     test "#deploy_steps prepend and append pre and post steps" do
@@ -165,7 +165,7 @@ module Shipit
           'context' => 'bar',
         },
       )
-      assert_equal ["#{Gem.bin_path('kubernetes-deploy')} foo bar"], @spec.rollback_steps
+      assert_equal ["kubernetes-deploy foo bar"], @spec.rollback_steps
     end
 
     test '#machine_env returns an environment hash' do


### PR DESCRIPTION
As discussed, we decided to stop shipping `kubernetes-deploy` as a dependency of Shipit. Instead, we expect developers to prepare `gem install kubernetes-deploy` in the environment where Shipit is hosted.

review @casperisfine
vv @KnVerey 