### PR TITLE
Yarn deployments should not hang

### DIFF
--- a/app/models/shipit/deploy_spec/npm_discovery.rb
+++ b/app/models/shipit/deploy_spec/npm_discovery.rb
@@ -62,7 +62,8 @@ module Shipit
 
       def publish_npm_package
         check_tags = 'assert-npm-version-tag'
-        publish = js_command('publish')
+        # `yarn publish` requires user input, so always use npm.
+        publish = 'npm publish'
 
         [check_tags, publish]
       end

--- a/test/unit/deploy_spec_test.rb
+++ b/test/unit/deploy_spec_test.rb
@@ -495,9 +495,9 @@ module Shipit
       assert_equal ['yarn install --no-progress'], @spec.dependencies_steps
     end
 
-    test '#publish_yarn_package checks if version tag exists, and then invokes yarn publish script' do
+    test '#publish_yarn_package checks if version tag exists, and then invokes npm publish script' do
       @spec.stubs(:yarn?).returns(true).at_least_once
-      assert_equal ['assert-npm-version-tag', 'yarn publish'], @spec.deploy_steps
+      assert_equal ['assert-npm-version-tag', 'npm publish'], @spec.deploy_steps
     end
 
     test 'yarn checklist takes precedence over npm checklist' do


### PR DESCRIPTION
`yarn publish` [has an unskippable user input prompt](https://github.com/yarnpkg/yarn/blob/master/src/cli/commands/publish.js#L136), so always use `npm publish` for JS projects.