### PR TITLE
Experimental merge queue

### DIFF
--- a/README.md
+++ b/README.md
@@ -268,9 +268,10 @@ deploy:
 ```
 <br>
 
-**<code>deploy.max_commits</code>** allows you to set a limit to the number of commits being shipped per deploys.
+**<code>deploy.max_commits</code>** define the maximum number of commits that should be shipped per deploys. Defaults to `8`.
 
 Human users will be warned that they are not respecting the recommendation, but allowed to continue.
+However continuous delivery will respect this limit. If there is no deployable commits in this range, a human intervention will be required.
 
 For example:
 

--- a/app/controllers/shipit/api/base_controller.rb
+++ b/app/controllers/shipit/api/base_controller.rb
@@ -25,9 +25,13 @@ module Shipit
       private
 
       def authenticate_api_client
-        @current_api_client = authenticate_with_http_basic do |*parts|
-          token = parts.select(&:present?).join('--')
-          ApiClient.authenticate(token)
+        @current_api_client = if Shipit.disable_api_authentication
+          UnlimitedApiClient.new
+        else
+          authenticate_with_http_basic do |*parts|
+            token = parts.select(&:present?).join('--')
+            ApiClient.authenticate(token)
+          end
         end
         return if @current_api_client
         headers['WWW-Authenticate'] = 'Basic realm="Authentication token"'

--- a/app/controllers/shipit/api/pull_requests_controller.rb
+++ b/app/controllers/shipit/api/pull_requests_controller.rb
@@ -1,0 +1,36 @@
+module Shipit
+  module Api
+    class PullRequestsController < BaseController
+      require_permission :read, :stack
+      require_permission :deploy, :stack, only: %i(update destroy)
+
+      def index
+        render_resources stack.pull_requests.includes(:head).order(id: :desc)
+      end
+
+      def show
+        render_resource stack.pull_requests.find_by_number!(params[:id])
+      end
+
+      def update
+        pull_request = PullRequest.request_merge!(stack, params[:id], current_user)
+        if pull_request.waiting?
+          head :accepted
+        elsif pull_request.merged?
+          render status: :method_not_allowed, json: {
+            message: "This pull request was already merged.",
+          }
+        else
+          raise "Pull Request is neither waiting nor merged, this should be impossible"
+        end
+      end
+
+      def destroy
+        if pull_request = stack.pull_requests.where(number: params[:id]).first
+          pull_request.cancel! if pull_request.waiting?
+        end
+        head :no_content
+      end
+    end
+  end
+end

--- a/app/controllers/shipit/webhooks_controller.rb
+++ b/app/controllers/shipit/webhooks_controller.rb
@@ -27,8 +27,7 @@ module Shipit
       end
     end
     def state
-      if params.branches.map(&:name).include?(stack.branch)
-        commit = stack.commits.find_by_sha!(params.sha)
+      if commit = stack.commits.find_by_sha(params.sha)
         commit.create_status_from_github!(params)
       end
       head :ok

--- a/app/jobs/shipit/cache_deploy_spec_job.rb
+++ b/app/jobs/shipit/cache_deploy_spec_job.rb
@@ -6,7 +6,7 @@ module Shipit
       return if stack.inaccessible?
 
       commands = Commands.for(stack)
-      commands.with_temporary_working_directory(commit: stack.commits.last) do |path|
+      commands.with_temporary_working_directory(commit: stack.commits.reachable.last) do |path|
         stack.update!(cached_deploy_spec: DeploySpec::FileSystem.new(path, stack.environment))
       end
     end

--- a/app/jobs/shipit/merge_pull_requests_job.rb
+++ b/app/jobs/shipit/merge_pull_requests_job.rb
@@ -1,0 +1,19 @@
+module Shipit
+  class MergePullRequestsJob < BackgroundJob
+    include BackgroundJob::Unique
+
+    def perform(stack)
+      pull_requests = stack.pull_requests.to_be_merged.to_a
+      pull_requests.each do |pull_request|
+        pull_request.refresh!
+        pull_request.reject_unless_mergeable!
+      end
+
+      return false unless stack.allows_merges?
+
+      pull_requests.select(&:pending?).each do |pull_request|
+        return false unless pull_request.merge!
+      end
+    end
+  end
+end

--- a/app/jobs/shipit/refresh_pull_request_job.rb
+++ b/app/jobs/shipit/refresh_pull_request_job.rb
@@ -2,6 +2,7 @@ module Shipit
   class RefreshPullRequestJob < BackgroundJob
     def perform(pull_request)
       pull_request.refresh!
+      MergePullRequestsJob.perform_later(pull_request.stack)
     end
   end
 end

--- a/app/jobs/shipit/refresh_pull_request_job.rb
+++ b/app/jobs/shipit/refresh_pull_request_job.rb
@@ -1,0 +1,7 @@
+module Shipit
+  class RefreshPullRequestJob < BackgroundJob
+    def perform(pull_request)
+      pull_request.refresh!
+    end
+  end
+end

--- a/app/models/shipit/anonymous_user.rb
+++ b/app/models/shipit/anonymous_user.rb
@@ -1,5 +1,9 @@
 module Shipit
   class AnonymousUser
+    def present?
+      false
+    end
+
     def email
       'anonymous@example.com'
     end

--- a/app/models/shipit/application_record.rb
+++ b/app/models/shipit/application_record.rb
@@ -1,0 +1,5 @@
+module Shipit
+  class ApplicationRecord < ActiveRecord::Base
+    self.abstract_class = true
+  end
+end

--- a/app/models/shipit/commit.rb
+++ b/app/models/shipit/commit.rb
@@ -74,8 +74,10 @@ module Shipit
       super
     end
 
-    def self.create_from_github!(commit)
-      from_github(commit).save!
+    def self.create_from_github!(commit, extra_attributes = {})
+      record = from_github(commit)
+      record.update!(extra_attributes)
+      record
     end
 
     def schedule_refresh_statuses!

--- a/app/models/shipit/deploy_spec.rb
+++ b/app/models/shipit/deploy_spec.rb
@@ -143,6 +143,22 @@ module Shipit
       Array.wrap(config('ci', 'allow_failures'))
     end
 
+    def pull_request_required_statuses
+      if config('ci', 'pr')
+        Array.wrap(config('ci', 'pr', 'require'))
+      else
+        required_statuses
+      end
+    end
+
+    def pull_request_ignored_statuses
+      if config('ci', 'pr')
+        Array.wrap(config('ci', 'pr', 'ignore'))
+      else
+        soft_failing_statuses | hidden_statuses
+      end
+    end
+
     def review_checks
       config('review', 'checks') || []
     end

--- a/app/models/shipit/deploy_spec.rb
+++ b/app/models/shipit/deploy_spec.rb
@@ -64,7 +64,7 @@ module Shipit
     alias_method :dependencies_steps!, :dependencies_steps
 
     def maximum_commits_per_deploy
-      config('deploy', 'max_commits')
+      config('deploy', 'max_commits') { 8 }
     end
 
     def pause_between_deploys

--- a/app/models/shipit/deploy_spec/file_system.rb
+++ b/app/models/shipit/deploy_spec/file_system.rb
@@ -30,6 +30,10 @@ module Shipit
       def cacheable_config
         (config || {}).deep_merge(
           'ci' => {
+            'pr' => {
+              'require' => pull_request_required_statuses,
+              'ignore' => pull_request_ignored_statuses,
+            },
             'hide' => hidden_statuses,
             'allow_failures' => soft_failing_statuses,
             'require' => required_statuses,

--- a/app/models/shipit/pull_request.rb
+++ b/app/models/shipit/pull_request.rb
@@ -1,0 +1,84 @@
+module Shipit
+  class PullRequest < ApplicationRecord
+    belongs_to :stack
+    belongs_to :head, class_name: 'Shipit::Commit'
+
+    validates :number, presence: true, uniqueness: {scope: :stack_id}
+
+    state_machine :merge_status, initial: :fetching do
+      state :fetching
+      state :pending
+      state :rejected
+      state :canceled
+      state :merged
+
+      event :fetched do
+        transition fetching: :pending
+      end
+
+      event :reject do
+        transition pending: :rejected
+      end
+
+      event :cancel do
+        transition pending: :canceled
+      end
+
+      event :complete do
+        transition pending: :complete
+      end
+
+      event :retry do
+        transition %i(rejected canceled) => :pending
+      end
+    end
+
+    def self.request_merge!(stack, number)
+      pull_request = begin
+        create_with(merge_requested_at: Time.now.utc).find_or_create_by!(
+          stack: stack,
+          number: number,
+        )
+      rescue ActiveRecord::RecordNotUnique
+        retry
+      end
+
+      pull_request.schedule_refresh!
+      pull_request
+    end
+
+    def schedule_refresh!
+      RefreshPullRequestJob.perform_later(self)
+    end
+
+    def refresh!
+      update!(github_pull_request: Shipit.github_api.pull_request(stack.github_repo_name, number))
+      head.refresh_statuses!
+      fetched! if fetching?
+    end
+
+    def github_pull_request=(github_pull_request)
+      self.github_id = github_pull_request.id
+      self.api_url = github_pull_request.url
+      self.title = github_pull_request.title
+      self.state = github_pull_request.state
+      self.mergeable = github_pull_request.mergeable
+      self.additions = github_pull_request.additions
+      self.deletions = github_pull_request.deletions
+      self.head = find_or_create_commit_from_github_by_sha!(github_pull_request.head.sha, detached: true)
+    end
+
+    private
+
+    def find_or_create_commit_from_github_by_sha!(sha, attributes)
+      if commit = stack.commits.by_sha(sha)
+        return commit
+      else
+        github_commit = Shipit.github_api.commit(stack.github_repo_name, sha)
+        stack.commits.create_from_github!(github_commit, attributes)
+      end
+    rescue ActiveRecord::RecordNotUnique
+      retry
+    end
+  end
+end

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -21,7 +21,6 @@ module Shipit
     REPO_OWNER_MAX_SIZE = 39
     REPO_NAME_MAX_SIZE = 100
     ENVIRONMENT_MAX_SIZE = 50
-    DEFAULT_MAX_COMMITS_PER_DEPLOY = 8
     REQUIRED_HOOKS = %i(push status).freeze
 
     has_many :commits, dependent: :destroy
@@ -183,7 +182,7 @@ module Shipit
     def merge_status
       return 'locked' if locked?
       return 'failure' if branch_status == 'failure'
-      if undeployed_commits_count > (maximum_commits_per_deploy || DEFAULT_MAX_COMMITS_PER_DEPLOY) * 1.5
+      if undeployed_commits_count > maximum_commits_per_deploy * 1.5
         'backlogged'
       else
         'success'

--- a/app/models/shipit/status/group.rb
+++ b/app/models/shipit/status/group.rb
@@ -1,6 +1,8 @@
 module Shipit
   class Status
     class Group
+      include Common
+
       attr_reader :commit, :statuses
 
       class << self
@@ -20,8 +22,8 @@ module Shipit
       def initialize(commit, statuses)
         @commit = commit
 
-        visible_statuses = statuses.to_a.uniq(&:context).reject(&:hidden?)
-        missing_contexts = commit.required_statuses - visible_statuses.map(&:context)
+        visible_statuses = reject_hidden(statuses.to_a.uniq(&:context))
+        missing_contexts = required_statuses - visible_statuses.map(&:context)
         visible_statuses += missing_contexts.map { |c| Status::Missing.new(commit, c) }
 
         @statuses = visible_statuses.sort_by!(&:context)
@@ -29,6 +31,7 @@ module Shipit
 
       delegate :pending?, :success?, :error?, :failure?, :unknown?, :state, :simple_state, to: :significant_status
       delegate :each, :size, :map, to: :statuses
+      delegate :required_statuses, to: :commit
 
       def to_a
         @statuses.dup
@@ -51,12 +54,20 @@ module Shipit
 
       private
 
+      def reject_hidden(statuses)
+        statuses.reject(&:hidden?)
+      end
+
+      def reject_allowed_to_fail(statuses)
+        statuses.reject(&:allowed_to_fail?)
+      end
+
       def significant_status
         @significant_status ||= select_significant_status(statuses)
       end
 
       def select_significant_status(statuses)
-        statuses = statuses.reject(&:allowed_to_fail?)
+        statuses = reject_allowed_to_fail(statuses)
         return Status::Unknown.new(commit) if statuses.empty?
         non_success_statuses = statuses.reject(&:success?)
         return statuses.first if non_success_statuses.empty?

--- a/app/models/shipit/unlimited_api_client.rb
+++ b/app/models/shipit/unlimited_api_client.rb
@@ -1,0 +1,10 @@
+module Shipit
+  class UnlimitedApiClient
+    def stack_id?
+      false
+    end
+
+    def check_permissions!(*)
+    end
+  end
+end

--- a/app/serializers/shipit/pull_request_serializer.rb
+++ b/app/serializers/shipit/pull_request_serializer.rb
@@ -1,0 +1,15 @@
+module Shipit
+  class PullRequestSerializer < ActiveModel::Serializer
+    include ConditionalAttributes
+
+    has_one :merge_requested_by
+    has_one :head, serializer: ShortCommitSerializer
+
+    attributes :id, :number, :title, :github_id, :additions, :deletions, :state, :merge_status, :mergeable,
+               :merge_requested_at
+
+    def include_rejection_reason?
+      object.rejection_reason?
+    end
+  end
+end

--- a/app/serializers/shipit/stack_serializer.rb
+++ b/app/serializers/shipit/stack_serializer.rb
@@ -3,8 +3,8 @@ module Shipit
     include ConditionalAttributes
 
     has_one :lock_author
-    attributes :id, :repo_owner, :repo_name, :environment, :html_url, :url, :tasks_url, :deploy_url, :deploy_spec,
-               :undeployed_commits_count, :is_locked, :lock_reason, :continuous_deployment, :created_at,
+    attributes :id, :repo_owner, :repo_name, :environment, :html_url, :url, :tasks_url, :deploy_url, :pull_requests_url,
+               :deploy_spec, :undeployed_commits_count, :is_locked, :lock_reason, :continuous_deployment, :created_at,
                :updated_at, :locked_since
 
     def url
@@ -17,6 +17,10 @@ module Shipit
 
     def tasks_url
       api_stack_tasks_url(object)
+    end
+
+    def pull_requests_url
+      api_stack_pull_requests_url(object)
     end
 
     def is_locked

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,6 +36,7 @@ Shipit::Engine.routes.draw do
       end
       resources :deploys, only: %i(create)
       resources :commits, only: %i(index)
+      resources :pull_requests, only: %i(index show update destroy)
       post '/task/:task_name' => 'tasks#trigger', as: :trigger_task
       resources :hooks, only: %i(index create show update destroy)
     end

--- a/db/migrate/20170130113633_create_shipit_pull_requests.rb
+++ b/db/migrate/20170130113633_create_shipit_pull_requests.rb
@@ -12,7 +12,9 @@ class CreateShipitPullRequests < ActiveRecord::Migration[5.0]
       t.integer :additions, null: false, default: 0
       t.integer :deletions, null: false, default: 0
       t.string :merge_status, null: false
+      t.string :rejection_reason, null: true
       t.datetime :merge_requested_at, null: false
+      t.references :merge_requested_by
       t.timestamps
 
       t.index [:stack_id, :number], unique: true

--- a/db/migrate/20170130113633_create_shipit_pull_requests.rb
+++ b/db/migrate/20170130113633_create_shipit_pull_requests.rb
@@ -1,0 +1,23 @@
+class CreateShipitPullRequests < ActiveRecord::Migration[5.0]
+  def change
+    create_table :pull_requests do |t|
+      t.references :stack, foreign_key: true, null: false
+      t.integer :number, null: false
+      t.string :title, limit: 256
+      t.integer :github_id, limit: 8
+      t.string :api_url, limit: 1024
+      t.string :state
+      t.references :head, foreign_key: true
+      t.boolean :mergeable, null: true
+      t.integer :additions, null: false, default: 0
+      t.integer :deletions, null: false, default: 0
+      t.string :merge_status, null: false
+      t.datetime :merge_requested_at, null: false
+      t.timestamps
+
+      t.index [:stack_id, :number], unique: true
+      t.index [:stack_id, :github_id], unique: true
+      t.index [:stack_id, :merge_status]
+    end
+  end
+end

--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -56,6 +56,8 @@ module Shipit
 
   delegate :table_name_prefix, to: :secrets
 
+  attr_accessor :disable_api_authentication
+
   def app_name
     @app_name ||= secrets.app_name || Rails.application.class.name.split(':').first || 'Shipit'
   end

--- a/test/controllers/api/commits_controller_test.rb
+++ b/test/controllers/api/commits_controller_test.rb
@@ -9,7 +9,7 @@ module Shipit
       end
 
       test "#index returns a list of commits" do
-        commit = @stack.commits.last
+        commit = @stack.commits.reachable.last
 
         get :index, params: {stack_id: @stack.to_param}
         assert_response :ok

--- a/test/controllers/api/pull_requests_controller_test.rb
+++ b/test/controllers/api/pull_requests_controller_test.rb
@@ -1,0 +1,59 @@
+require 'test_helper'
+
+module Shipit
+  module Api
+    class PullRequestsControllerTest < ActionController::TestCase
+      setup do
+        @stack = shipit_stacks(:shipit)
+        @pull_request = shipit_pull_requests(:shipit_pending)
+        authenticate!
+      end
+
+      test "#index returns a list of pull requests" do
+        pull_request = @stack.pull_requests.last
+
+        get :index, params: {stack_id: @stack.to_param}
+        assert_response :ok
+        assert_json '0.id', pull_request.id
+      end
+
+      test "#show returns a single pull requests" do
+        get :show, params: {stack_id: @stack.to_param, id: @pull_request.number.to_s}
+        assert_response :ok
+        assert_json 'id', @pull_request.id
+      end
+
+      test "#update responds with Accepted if the pull request was queued" do
+        assert_enqueued_with(job: RefreshPullRequestJob) do
+          put :update, params: {stack_id: @stack.to_param, id: '64'}
+        end
+        assert_response :accepted
+      end
+
+      test "#update responds with Accepted if the pull request was already queued" do
+        assert_enqueued_with(job: RefreshPullRequestJob) do
+          put :update, params: {stack_id: @stack.to_param, id: '65'}
+        end
+        assert_response :accepted
+      end
+
+      test "#update responds with method not allowed if the pull request was already merged" do
+        @pull_request.complete!
+        put :update, params: {stack_id: @stack.to_param, id: @pull_request.number.to_s}
+        assert_response :method_not_allowed
+        assert_json 'message', 'This pull request was already merged.'
+      end
+
+      test "#destroy cancels the merge if the pull request was waiting" do
+        delete :destroy, params: {stack_id: @stack.to_param, id: @pull_request.number.to_s}
+        assert_response :no_content
+        assert_predicate @pull_request.reload, :canceled?
+      end
+
+      test "#destroy silently fail if the pull request was unknown" do
+        delete :destroy, params: {stack_id: @stack.to_param, id: '83453489'}
+        assert_response :no_content
+      end
+    end
+  end
+end

--- a/test/controllers/webhooks_controller_test.rb
+++ b/test/controllers/webhooks_controller_test.rb
@@ -42,12 +42,11 @@ module Shipit
       assert_equal status_payload['created_at'], status.created_at.iso8601
     end
 
-    test ":state with a unexisting commit trows ActiveRecord::RecordNotFound" do
+    test ":state with a unexisting commit respond with 200 OK" do
       request.headers['X-Github-Event'] = 'status'
       params = {'sha' => 'notarealcommit', 'state' => 'pending', 'branches' => [{'name' => 'master'}]}
-      assert_raises ActiveRecord::RecordNotFound do
-        post :state, params: {stack_id: @stack.id}.merge(params)
-      end
+      post :state, params: {stack_id: @stack.id}.merge(params)
+      assert_response :ok
     end
 
     test ":state in an untracked branche bails out" do

--- a/test/dummy/config/environments/development.rb
+++ b/test/dummy/config/environments/development.rb
@@ -42,6 +42,8 @@ Rails.application.configure do
     Shipit::DeferredTouch.enabled = false
   end
   config.active_job.queue_adapter = :async
-  
+
   Pubsubstub.use_persistent_connections = false
+
+  Shipit.disable_api_authentication = true if ENV['PUBLIC_API']
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20161206105318) do
+ActiveRecord::Schema.define(version: 20170130113633) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text     "permissions", limit: 65535
@@ -121,6 +121,28 @@ ActiveRecord::Schema.define(version: 20161206105318) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.index ["task_id"], name: "index_output_chunks_on_task_id"
+  end
+
+  create_table "pull_requests", force: :cascade do |t|
+    t.integer  "stack_id",                                    null: false
+    t.integer  "number",                                      null: false
+    t.string   "title",              limit: 256
+    t.integer  "github_id",          limit: 8
+    t.string   "api_url",            limit: 1024
+    t.string   "state"
+    t.integer  "head_id"
+    t.boolean  "mergeable"
+    t.integer  "additions",                       default: 0, null: false
+    t.integer  "deletions",                       default: 0, null: false
+    t.string   "merge_status",                                null: false
+    t.datetime "merge_requested_at",                          null: false
+    t.datetime "created_at",                                  null: false
+    t.datetime "updated_at",                                  null: false
+    t.index ["head_id"], name: "index_pull_requests_on_head_id"
+    t.index ["stack_id", "github_id"], name: "index_pull_requests_on_stack_id_and_github_id", unique: true
+    t.index ["stack_id", "merge_status"], name: "index_pull_requests_on_stack_id_and_merge_status"
+    t.index ["stack_id", "number"], name: "index_pull_requests_on_stack_id_and_number", unique: true
+    t.index ["stack_id"], name: "index_pull_requests_on_stack_id"
   end
 
   create_table "stacks", force: :cascade do |t|

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -124,21 +124,24 @@ ActiveRecord::Schema.define(version: 20170130113633) do
   end
 
   create_table "pull_requests", force: :cascade do |t|
-    t.integer  "stack_id",                                    null: false
-    t.integer  "number",                                      null: false
-    t.string   "title",              limit: 256
-    t.integer  "github_id",          limit: 8
-    t.string   "api_url",            limit: 1024
+    t.integer  "stack_id",                                       null: false
+    t.integer  "number",                                         null: false
+    t.string   "title",                 limit: 256
+    t.integer  "github_id",             limit: 8
+    t.string   "api_url",               limit: 1024
     t.string   "state"
     t.integer  "head_id"
     t.boolean  "mergeable"
-    t.integer  "additions",                       default: 0, null: false
-    t.integer  "deletions",                       default: 0, null: false
-    t.string   "merge_status",                                null: false
-    t.datetime "merge_requested_at",                          null: false
-    t.datetime "created_at",                                  null: false
-    t.datetime "updated_at",                                  null: false
+    t.integer  "additions",                          default: 0, null: false
+    t.integer  "deletions",                          default: 0, null: false
+    t.string   "merge_status",                                   null: false
+    t.string   "rejection_reason"
+    t.datetime "merge_requested_at",                             null: false
+    t.integer  "merge_requested_by_id"
+    t.datetime "created_at",                                     null: false
+    t.datetime "updated_at",                                     null: false
     t.index ["head_id"], name: "index_pull_requests_on_head_id"
+    t.index ["merge_requested_by_id"], name: "index_pull_requests_on_merge_requested_by_id"
     t.index ["stack_id", "github_id"], name: "index_pull_requests_on_stack_id_and_github_id", unique: true
     t.index ["stack_id", "merge_status"], name: "index_pull_requests_on_stack_id_and_merge_status"
     t.index ["stack_id", "number"], name: "index_pull_requests_on_stack_id_and_number", unique: true

--- a/test/fixtures/shipit/commits.yml
+++ b/test/fixtures/shipit/commits.yml
@@ -88,3 +88,17 @@ undeployed_stack_first:
   additions: 1
   deletions: 24
   updated_at: <%= 8.days.ago.to_s(:db) %>
+
+shipit_pending_pr_head:
+  id: 8
+  sha: 424278037b872fd9a6690523e411ecb3aa181355
+  message: "Super feature"
+  stack: shipit
+  author: walrus
+  committer: walrus
+  authored_at: <%= 10.days.ago.to_s(:db) %>
+  committed_at: <%= 9.days.ago.to_s(:db) %>
+  additions: 42
+  deletions: 24
+  updated_at: <%= 8.days.ago.to_s(:db) %>
+  detached: true

--- a/test/fixtures/shipit/pull_requests.yml
+++ b/test/fixtures/shipit/pull_requests.yml
@@ -43,4 +43,3 @@ shipit_pending_not_mergeable_yet:
   mergeable: null
   additions: 23
   deletions: 43
-

--- a/test/fixtures/shipit/pull_requests.yml
+++ b/test/fixtures/shipit/pull_requests.yml
@@ -3,3 +3,44 @@ shipit_fetching:
   number: 63
   merge_status: fetching
   merge_requested_at: <%= 1.minute.ago.to_s(:db) %>
+  merge_requested_by: walrus
+
+shipit_pending:
+  stack: shipit
+  number: 62
+  merge_status: pending
+  merge_requested_at: <%= 5.minute.ago.to_s(:db) %>
+  github_id: 42424424242424
+  api_url: https://api.github.com/repos/shopify/shipit-engine/pulls/62
+  state: open
+  head_id: 8
+  mergeable: true
+  additions: 23
+  deletions: 43
+
+shipit_pending_unmergeable:
+  stack: shipit
+  number: 61
+  merge_status: pending
+  merge_requested_at: <%= 4.minute.ago.to_s(:db) %>
+  github_id: 43434434343434
+  api_url: https://api.github.com/repos/shopify/shipit-engine/pulls/61
+  state: open
+  head_id: 8
+  mergeable: false
+  additions: 23
+  deletions: 43
+
+shipit_pending_not_mergeable_yet:
+  stack: shipit
+  number: 64
+  merge_status: pending
+  merge_requested_at: <%= 3.minute.ago.to_s(:db) %>
+  github_id: 45454454545454
+  api_url: https://api.github.com/repos/shopify/shipit-engine/pulls/64
+  state: open
+  head_id: 8
+  mergeable: null
+  additions: 23
+  deletions: 43
+

--- a/test/fixtures/shipit/pull_requests.yml
+++ b/test/fixtures/shipit/pull_requests.yml
@@ -1,0 +1,5 @@
+shipit_fetching:
+  stack: shipit
+  number: 63
+  merge_status: fetching
+  merge_requested_at: <%= 1.minute.ago.to_s(:db) %>

--- a/test/fixtures/shipit/stacks.yml
+++ b/test/fixtures/shipit/stacks.yml
@@ -16,7 +16,7 @@ shipit:
         ]
       },
       "dependencies": {"override": []},
-      "deploy": {"override": null, "interval": 60, "variables": [{"name": "SAFETY_DISABLED", "title": "Set to 1 to do dangerous things", "default": 0}]},
+      "deploy": {"override": null, "interval": 60, "max_commits": 3, "variables": [{"name": "SAFETY_DISABLED", "title": "Set to 1 to do dangerous things", "default": 0}]},
       "rollback": {"override": ["echo 'Rollback!'"]},
       "fetch": ["echo '42'"],
       "tasks": {

--- a/test/fixtures/shipit/statuses.yml
+++ b/test/fixtures/shipit/statuses.yml
@@ -98,4 +98,3 @@ shipit_pending_pr_success_travis:
   created_at: <%= 9.days.ago.to_s(:db) %>
   state: success
   target_url: "http://www.example.com"
-  

--- a/test/fixtures/shipit/statuses.yml
+++ b/test/fixtures/shipit/statuses.yml
@@ -90,3 +90,12 @@ cyclimse_success_travis:
   state: success
   target_url: "http://www.example.com"
 
+shipit_pending_pr_success_travis:
+  stack: shipit
+  commit_id: 8 # shipit_pending_pr_head
+  description: Super feature
+  context: ci/travis
+  created_at: <%= 9.days.ago.to_s(:db) %>
+  state: success
+  target_url: "http://www.example.com"
+  

--- a/test/helpers/json_helper.rb
+++ b/test/helpers/json_helper.rb
@@ -4,7 +4,7 @@ module JSONHelper
     if block_given?
       yield value
     elsif args.size == 1
-      if args.first == nil
+      if args.first.nil?
         assert_nil value
       else
         assert_equal args.first, value

--- a/test/jobs/merge_pull_requests_job_test.rb
+++ b/test/jobs/merge_pull_requests_job_test.rb
@@ -1,0 +1,47 @@
+require 'test_helper'
+
+module Shipit
+  class MergePullRequestsJobTest < ActiveSupport::TestCase
+    setup do
+      @stack = shipit_stacks(:shipit)
+      @job = MergePullRequestsJob.new
+
+      @pending_pr = shipit_pull_requests(:shipit_pending)
+      @unmergeable_pr = shipit_pull_requests(:shipit_pending_unmergeable)
+      @not_ready_pr = shipit_pull_requests(:shipit_pending_not_mergeable_yet)
+    end
+
+    test "#perform rejects unmergeable PRs and merge the others" do
+      PullRequest.any_instance.stubs(:refresh!)
+      FakeWeb.register_uri(:put, "#{@pending_pr.api_url}/merge", status: %w(200 OK), body: {
+        sha: "6dcb09b5b57875f334f61aebed695e2e4193db5e",
+        merged: true,
+        message: "Pull Request successfully merged",
+      }.to_json)
+
+      @job.perform(@stack)
+
+      assert_predicate @pending_pr.reload, :merged?
+      assert_predicate @unmergeable_pr.reload, :rejected?
+    end
+
+    test "#perform rejects PRs if the merge attempt fails" do
+      PullRequest.any_instance.stubs(:refresh!)
+      FakeWeb.register_uri(:put, "#{@pending_pr.api_url}/merge", status: %w(405 Method not allowed), body: {
+        message: "Pull Request is not mergeable",
+        documentation_url: "https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button",
+      }.to_json)
+
+      @job.perform(@stack)
+
+      assert_predicate @pending_pr.reload, :rejected?
+    end
+
+    test "perform rejects PRs but do not attempt to merge any if the stack doesn't allow merges" do
+      PullRequest.any_instance.stubs(:refresh!)
+      @stack.update!(lock_reason: 'Maintenance')
+      @job.perform(@stack)
+      assert_predicate @pending_pr.reload, :pending?
+    end
+  end
+end

--- a/test/models/shipit/pull_request_test.rb
+++ b/test/models/shipit/pull_request_test.rb
@@ -1,0 +1,83 @@
+require 'test_helper'
+
+module Shipit
+  class PullRequestTest < ActiveSupport::TestCase
+    setup do
+      @stack = shipit_stacks(:shipit)
+    end
+
+    test ".request_merge! creates a record and schedule a refresh" do
+      pull_request = nil
+      assert_enqueued_with(job: RefreshPullRequestJob) do
+        pull_request = PullRequest.request_merge!(@stack, 64)
+      end
+      assert_predicate pull_request, :persisted?
+    end
+
+    test ".request_merge! only track pull requests once" do
+      assert_difference -> { PullRequest.count }, +1 do
+        5.times { PullRequest.request_merge!(@stack, 64) }
+      end
+    end
+
+    test "refresh! pulls state from GitHub" do
+      pull_request = shipit_pull_requests(:shipit_fetching)
+
+      head_sha = '64b3833d39def7ec65b57b42f496eb27ab4980b6'
+      Shipit.github_api.expects(:pull_request).with(@stack.github_repo_name, pull_request.number).returns(
+        stub(
+          id: 4_857_578,
+          url: 'https://api.github.com/repos/Shopify/shipit-engine/pulls/64',
+          title: 'Great feature',
+          state: 'open',
+          mergeable: true,
+          additions: 24,
+          deletions: 5,
+          head: stub(
+            sha: head_sha,
+          ),
+        ),
+      )
+
+      author = stub(
+        id: 1234,
+        login: 'bob',
+        name: 'Bob the Builder',
+        email: 'bob@bob.com',
+      )
+      Shipit.github_api.expects(:commit).with(@stack.github_repo_name, head_sha).returns(
+        stub(
+          sha: head_sha,
+          author: author,
+          committer: author,
+          commit: stub(
+            message: 'Great feature',
+            author: stub(date: 1.day.ago),
+            committer: stub(date: 1.day.ago),
+          ),
+          stats: stub(
+            additions: 24,
+            deletions: 5,
+          ),
+        ),
+      )
+
+      Shipit.github_api.expects(:statuses).with(@stack.github_repo_name, head_sha).returns([stub(
+        state: 'success',
+        description: nil,
+        context: 'default',
+        target_url: 'http://example.com',
+        created_at: 1.day.ago,
+      )])
+
+      pull_request.refresh!
+
+      assert_predicate pull_request, :mergeable?
+      assert_predicate pull_request, :pending?
+
+      assert_not_nil pull_request.head
+      assert_predicate pull_request.head, :detached?
+      assert_predicate pull_request.head, :success?
+    end
+  end
+end

--- a/test/unit/csv_serializer_test.rb
+++ b/test/unit/csv_serializer_test.rb
@@ -27,7 +27,7 @@ module Shipit
 
     def assert_dumped(expected, object)
       message = "Expected CSVSerializer.dump(#{object.inspect}) to eq #{expected.inspect}"
-      if expected == nil
+      if expected.nil?
         assert_nil Shipit::CSVSerializer.dump(object), message
       else
         assert_equal(expected, Shipit::CSVSerializer.dump(object), message)
@@ -36,7 +36,7 @@ module Shipit
 
     def assert_loaded(expected, payload)
       message = "Expected CSVSerializer.load(#{payload.inspect}) to eq #{expected.inspect}"
-      if expected == nil
+      if expected.nil?
         assert_nil Shipit::CSVSerializer.load(payload), message
       else
         assert_equal(expected, Shipit::CSVSerializer.load(payload), message)

--- a/test/unit/deploy_spec_test.rb
+++ b/test/unit/deploy_spec_test.rb
@@ -269,7 +269,7 @@ module Shipit
         'review' => {'checklist' => [], 'monitoring' => [], 'checks' => []},
         'dependencies' => {'override' => []},
         'plugins' => {},
-        'deploy' => {'override' => nil, 'variables' => [], 'max_commits' => nil, 'interval' => 0},
+        'deploy' => {'override' => nil, 'variables' => [], 'max_commits' => 8, 'interval' => 0},
         'rollback' => {'override' => nil},
         'fetch' => nil,
         'tasks' => {},


### PR DESCRIPTION
This implements a simple merge queue for stacks.
  - Pull Requests registered
  - If the stack allows merges (is not locked, is not backlogged, is not failing), the pull request will be merged.
  - If the pull request is not mergeable (merge conflict, failing commit status, etc) it will be rejected.
  - Pull requests can be removed from the queue.
  - API endpoints to list / add / remove pull requests from the queue.

Future features:
  - UI to add a PR to the queue
  - UI to list PRs in the queue