### PR TITLE
chore: Rubocop linting

### DIFF
--- a/test/helpers/json_helper.rb
+++ b/test/helpers/json_helper.rb
@@ -4,7 +4,7 @@ module JSONHelper
     if block_given?
       yield value
     elsif args.size == 1
-      if args.first == nil
+      if args.first.nil?
         assert_nil value
       else
         assert_equal args.first, value

--- a/test/unit/csv_serializer_test.rb
+++ b/test/unit/csv_serializer_test.rb
@@ -27,7 +27,7 @@ module Shipit
 
     def assert_dumped(expected, object)
       message = "Expected CSVSerializer.dump(#{object.inspect}) to eq #{expected.inspect}"
-      if expected == nil
+      if expected.nil?
         assert_nil Shipit::CSVSerializer.dump(object), message
       else
         assert_equal(expected, Shipit::CSVSerializer.dump(object), message)
@@ -36,7 +36,7 @@ module Shipit
 
     def assert_loaded(expected, payload)
       message = "Expected CSVSerializer.load(#{payload.inspect}) to eq #{expected.inspect}"
-      if expected == nil
+      if expected.nil?
         assert_nil Shipit::CSVSerializer.load(payload), message
       else
         assert_equal(expected, Shipit::CSVSerializer.load(payload), message)


### PR DESCRIPTION
This PR amends 1e3b4e614f25e3be1134538f6688fef0f845006b (which got rid of minitest warnings!) which left a few open Rubocop warnings behind.

Here what I did to see it work:

- ran the tests
- ran the rake task to auto-correct the things
- re-ran tests – no change