### PR TITLE
Link merge commits and pull requests together

### DIFF
--- a/app/helpers/shipit/stacks_helper.rb
+++ b/app/helpers/shipit/stacks_helper.rb
@@ -33,7 +33,11 @@ module Shipit
     end
 
     def github_change_url(commit)
-      commit.pull_request_url || github_commit_url(commit)
+      if commit.pull_request?
+        github_pull_request_url(commit)
+      else
+        github_commit_url(commit)
+      end
     end
 
     def render_commit_message(commit)
@@ -54,7 +58,7 @@ module Shipit
     end
 
     def pull_request_link(commit)
-      link_to("##{commit.pull_request_number}", commit.pull_request_url, target: '_blank', class: 'number')
+      link_to("##{commit.pull_request_number}", github_pull_request_url(commit), target: '_blank', class: 'number')
     end
 
     def render_raw_commit_id_link(commit)

--- a/app/models/shipit/commit_message.rb
+++ b/app/models/shipit/commit_message.rb
@@ -1,0 +1,32 @@
+module Shipit
+  class CommitMessage
+    GITHUB_MERGE_COMMIT_PATTERN = %r{\AMerge pull request #(?<pr_id>\d+) from [\w\-./]+\n\n(?<pr_title>.*)}
+
+    def initialize(text)
+      @text = text
+    end
+
+    def pull_request?
+      !!parsed
+    end
+
+    def pull_request_number
+      parsed && parsed['pr_id'].to_i
+    end
+
+    def pull_request_title
+      parsed && parsed['pr_title']
+    end
+
+    def to_s
+      @text
+    end
+
+    private
+
+    def parsed
+      return @parsed if defined?(@parsed)
+      @parsed = to_s.match(GITHUB_MERGE_COMMIT_PATTERN)
+    end
+  end
+end

--- a/db/migrate/20170208143657_add_pull_request_number_and_title_to_commits.rb
+++ b/db/migrate/20170208143657_add_pull_request_number_and_title_to_commits.rb
@@ -1,0 +1,7 @@
+class AddPullRequestNumberAndTitleToCommits < ActiveRecord::Migration[5.0]
+  def change
+    add_column :commits, :pull_request_number, :integer, null: true
+    add_column :commits, :pull_request_title, :string, limit: 1024, null: true
+    add_column :commits, :pull_request_id, :integer, null: true, index: true
+  end
+end

--- a/db/migrate/20170208154609_backfill_merge_commits.rb
+++ b/db/migrate/20170208154609_backfill_merge_commits.rb
@@ -1,0 +1,11 @@
+class BackfillMergeCommits < ActiveRecord::Migration[5.0]
+  def change
+    Shipit::Commit.find_in_batches do |commits|
+      commits.each do |commit|
+        commit.identify_pull_request
+        commit.save!
+      end
+      print '.'
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170130113633) do
+ActiveRecord::Schema.define(version: 20170208154609) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text     "permissions", limit: 65535
@@ -44,18 +44,21 @@ ActiveRecord::Schema.define(version: 20170130113633) do
   end
 
   create_table "commits", force: :cascade do |t|
-    t.integer  "stack_id",     limit: 4,                     null: false
-    t.integer  "author_id",    limit: 4,                     null: false
-    t.integer  "committer_id", limit: 4,                     null: false
-    t.string   "sha",          limit: 40,                    null: false
-    t.text     "message",      limit: 65535,                 null: false
+    t.integer  "stack_id",            limit: 4,                     null: false
+    t.integer  "author_id",           limit: 4,                     null: false
+    t.integer  "committer_id",        limit: 4,                     null: false
+    t.string   "sha",                 limit: 40,                    null: false
+    t.text     "message",             limit: 65535,                 null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.boolean  "detached",                   default: false, null: false
-    t.datetime "authored_at",                                null: false
-    t.datetime "committed_at",                               null: false
-    t.integer  "additions",    limit: 4
-    t.integer  "deletions",    limit: 4
+    t.boolean  "detached",                          default: false, null: false
+    t.datetime "authored_at",                                       null: false
+    t.datetime "committed_at",                                      null: false
+    t.integer  "additions",           limit: 4
+    t.integer  "deletions",           limit: 4
+    t.integer  "pull_request_number"
+    t.string   "pull_request_title",  limit: 1024
+    t.integer  "pull_request_id"
     t.index ["author_id"], name: "index_commits_on_author_id"
     t.index ["committer_id"], name: "index_commits_on_committer_id"
     t.index ["created_at"], name: "index_commits_on_created_at"

--- a/test/fixtures/shipit/pull_requests.yml
+++ b/test/fixtures/shipit/pull_requests.yml
@@ -8,8 +8,10 @@ shipit_fetching:
 shipit_pending:
   stack: shipit
   number: 62
+  title: Super duper nice feature
   merge_status: pending
   merge_requested_at: <%= 5.minute.ago.to_s(:db) %>
+  merge_requested_by: walrus
   github_id: 42424424242424
   api_url: https://api.github.com/repos/shopify/shipit-engine/pulls/62
   state: open
@@ -23,6 +25,7 @@ shipit_pending_unmergeable:
   number: 61
   merge_status: pending
   merge_requested_at: <%= 4.minute.ago.to_s(:db) %>
+  merge_requested_by: walrus
   github_id: 43434434343434
   api_url: https://api.github.com/repos/shopify/shipit-engine/pulls/61
   state: open
@@ -35,6 +38,7 @@ shipit_pending_not_mergeable_yet:
   stack: shipit
   number: 64
   merge_status: pending
+  merge_requested_by: walrus
   merge_requested_at: <%= 3.minute.ago.to_s(:db) %>
   github_id: 45454454545454
   api_url: https://api.github.com/repos/shopify/shipit-engine/pulls/64


### PR DESCRIPTION
Followup to: https://github.com/Shopify/shipit-engine/pull/643

One of the main drawback of the merge queue is that now the merge commits are authored by the Shipit user. In itself it's not a big deal, as it's the reality, but it's quite a breaking change for the Shipit API and the Shipit Hooks.

So this makes a few changes for usability:
  - The merge commit will contain a `Merge-Requested-By: @login` field for traceability
  - If the merge commit is identified and match a known pull request, the merge commit will be recorded in Shipit as if it was authored by the merge requester.

Another thing we could eventually do is that Shipit could do the merge on the behalf of the requester. This isn't guaranteed to work as the requester might not have sufficient permissions.

@Shopify/pipeline @etiennebarrie thoughts ?