### PR TITLE
Queue timeout

### DIFF
--- a/app/models/shipit/deploy_spec.rb
+++ b/app/models/shipit/deploy_spec.rb
@@ -159,6 +159,12 @@ module Shipit
       end
     end
 
+    def pull_request_timeout
+      Duration.parse(config('merge', 'timeout') { '1h' })
+    rescue Duration::ParseError
+      Duration.parse('1h')
+    end
+
     def review_checks
       config('review', 'checks') || []
     end

--- a/app/models/shipit/deploy_spec.rb
+++ b/app/models/shipit/deploy_spec.rb
@@ -144,16 +144,16 @@ module Shipit
     end
 
     def pull_request_required_statuses
-      if config('ci', 'pr')
-        Array.wrap(config('ci', 'pr', 'require'))
+      if config('merge', 'require') || config('merge', 'ignore')
+        Array.wrap(config('merge', 'require'))
       else
         required_statuses
       end
     end
 
     def pull_request_ignored_statuses
-      if config('ci', 'pr')
-        Array.wrap(config('ci', 'pr', 'ignore'))
+      if config('merge', 'require') || config('merge', 'ignore')
+        Array.wrap(config('merge', 'ignore'))
       else
         soft_failing_statuses | hidden_statuses
       end

--- a/app/models/shipit/deploy_spec/file_system.rb
+++ b/app/models/shipit/deploy_spec/file_system.rb
@@ -32,6 +32,7 @@ module Shipit
           'merge' => {
             'require' => pull_request_required_statuses,
             'ignore' => pull_request_ignored_statuses,
+            'timeout' => pull_request_timeout.to_i,
           },
           'ci' => {
             'hide' => hidden_statuses,

--- a/app/models/shipit/deploy_spec/file_system.rb
+++ b/app/models/shipit/deploy_spec/file_system.rb
@@ -29,11 +29,11 @@ module Shipit
 
       def cacheable_config
         (config || {}).deep_merge(
+          'merge' => {
+            'require' => pull_request_required_statuses,
+            'ignore' => pull_request_ignored_statuses,
+          },
           'ci' => {
-            'pr' => {
-              'require' => pull_request_required_statuses,
-              'ignore' => pull_request_ignored_statuses,
-            },
             'hide' => hidden_statuses,
             'allow_failures' => soft_failing_statuses,
             'require' => required_statuses,

--- a/app/models/shipit/duration.rb
+++ b/app/models/shipit/duration.rb
@@ -1,5 +1,7 @@
 module Shipit
   class Duration < ActiveSupport::Duration
+    ParseError = Class.new(ArgumentError)
+
     FORMAT = /
       \A
       (?<days>\d+d)?
@@ -18,7 +20,7 @@ module Shipit
     class << self
       def parse(value)
         unless match = FORMAT.match(value.to_s)
-          raise ArgumentError, "not a duration: #{value.inspect}"
+          raise ParseError, "not a duration: #{value.inspect}"
         end
         parts = []
         UNITS.values.each do |unit|

--- a/test/models/deploy_spec_test.rb
+++ b/test/models/deploy_spec_test.rb
@@ -259,6 +259,7 @@ module Shipit
         'merge' => {
           'require' => [],
           'ignore' => [],
+          'timeout' => 3600,
         },
         'ci' => {
           'hide' => [],
@@ -398,7 +399,7 @@ module Shipit
       assert_equal %w(ci/circleci ci/jenkins ci/travis).sort, @spec.pull_request_ignored_statuses.sort
     end
 
-    test "pull_request_ignored_statuses defaults to empty if `ci.pr.require` is present" do
+    test "pull_request_ignored_statuses defaults to empty if `merge.require` is present" do
       @spec.expects(:load_config).returns(
         'merge' => {
           'require' => 'bar',
@@ -411,7 +412,7 @@ module Shipit
       assert_equal [], @spec.pull_request_ignored_statuses
     end
 
-    test "pull_request_ignored_statuses returns `ci.pr.ignore` if present" do
+    test "pull_request_ignored_statuses returns `merge.ignore` if present" do
       @spec.expects(:load_config).returns(
         'merge' => {
           'ignore' => 'bar',
@@ -456,6 +457,29 @@ module Shipit
         },
       )
       assert_equal ['bar'], @spec.pull_request_required_statuses
+    end
+
+    test "pull_request_timeout defaults to 1 hour" do
+      @spec.expects(:load_config).returns({})
+      assert_equal 3600, @spec.pull_request_timeout.to_i
+    end
+
+    test "pull_request_timeout defaults to 1 hour if `merge.timeout` cannot be parsed" do
+      @spec.expects(:load_config).returns(
+        'merge' => {
+          'timeout' => 'ALSKhfjsdkf',
+        },
+      )
+      assert_equal 3600, @spec.pull_request_timeout.to_i
+    end
+
+    test "pull_request_timeout returns `merge.timeout` if present" do
+      @spec.expects(:load_config).returns(
+        'merge' => {
+          'timeout' => '5m30s',
+        },
+      )
+      assert_equal 330, @spec.pull_request_timeout.to_i
     end
 
     test "#file is impacted by `machine.directory`" do

--- a/test/models/deploy_spec_test.rb
+++ b/test/models/deploy_spec_test.rb
@@ -256,11 +256,11 @@ module Shipit
       assert_instance_of DeploySpec::FileSystem, @spec
       assert_instance_of DeploySpec, @spec.cacheable
       config = {
+        'merge' => {
+          'require' => [],
+          'ignore' => [],
+        },
         'ci' => {
-          'pr' => {
-            'require' => [],
-            'ignore' => [],
-          },
           'hide' => [],
           'allow_failures' => [],
           'require' => [],
@@ -398,10 +398,12 @@ module Shipit
       assert_equal %w(ci/circleci ci/jenkins ci/travis).sort, @spec.pull_request_ignored_statuses.sort
     end
 
-    test "pull_request_ignored_statuses defaults to empty if `ci.pr` is present" do
+    test "pull_request_ignored_statuses defaults to empty if `ci.pr.require` is present" do
       @spec.expects(:load_config).returns(
+        'merge' => {
+          'require' => 'bar',
+        },
         'ci' => {
-          'pr' => {'foo' => 'bar'},
           'hide' => %w(ci/circleci ci/jenkins),
           'allow_failures' => %w(ci/circleci ci/travis),
         },
@@ -411,8 +413,10 @@ module Shipit
 
     test "pull_request_ignored_statuses returns `ci.pr.ignore` if present" do
       @spec.expects(:load_config).returns(
+        'merge' => {
+          'ignore' => 'bar',
+        },
         'ci' => {
-          'pr' => {'ignore' => 'bar'},
           'hide' => %w(ci/circleci ci/jenkins),
           'allow_failures' => %w(ci/circleci ci/travis),
         },
@@ -429,20 +433,24 @@ module Shipit
       assert_equal %w(ci/circleci ci/jenkins), @spec.pull_request_required_statuses
     end
 
-    test "pull_request_required_statuses defaults to empty if `ci.pr` is present" do
+    test "pull_request_required_statuses defaults to empty if `merge.ignore` is present" do
       @spec.expects(:load_config).returns(
+        'merge' => {
+          'ignore' => 'bar',
+        },
         'ci' => {
-          'pr' => {'foo' => 'bar'},
           'require' => %w(ci/circleci ci/jenkins),
         },
       )
       assert_equal [], @spec.pull_request_required_statuses
     end
 
-    test "pull_request_required_statuses returns `ci.pr.require` if present" do
+    test "pull_request_required_statuses returns `merge.require` if present" do
       @spec.expects(:load_config).returns(
+        'merge' => {
+          'require' => 'bar',
+        },
         'ci' => {
-          'pr' => {'require' => 'bar'},
           'hide' => %w(ci/circleci ci/jenkins),
           'allow_failures' => %w(ci/circleci ci/travis),
         },


### PR DESCRIPTION
Add `merge.timeout` to the `shipit.yml`. Defaults to `1h`.

If a pull request can't be merged in that timeframe, it will be rejected.

Additionally, now that there is a `merge` namespace in `shipit.yml`, `ci.pr.require` and `ci.pr.ignore` have been renamed to `merge.require` and `merge.ignore` respectively.

@wvanbergen for review please.