### PR TITLE
kubernetes keyword in shipit.yml should take precedence over Capfile

### DIFF
--- a/app/models/shipit/deploy_spec/file_system.rb
+++ b/app/models/shipit/deploy_spec/file_system.rb
@@ -2,11 +2,11 @@ module Shipit
   class DeploySpec
     class FileSystem < DeploySpec
       include NpmDiscovery
-      include KubernetesDiscovery
       include PypiDiscovery
       include RubygemsDiscovery
       include CapistranoDiscovery
       include BundlerDiscovery
+      include KubernetesDiscovery
 
       def initialize(app_dir, env)
         @app_dir = Pathname(app_dir)

--- a/test/models/deploy_spec_test.rb
+++ b/test/models/deploy_spec_test.rb
@@ -126,6 +126,18 @@ module Shipit
       assert_equal ["kubernetes-deploy foo bar"], @spec.deploy_steps
     end
 
+    test "#deploy_steps returns kubernetes-deploy command if both capfile and `kubernetes` are present" do
+      @spec.stubs(:bundler?).returns(true)
+      @spec.stubs(:capistrano?).returns(true)
+      @spec.stubs(:load_config).returns(
+        'kubernetes' => {
+          'namespace' => 'foo',
+          'context' => 'bar',
+        },
+      )
+      assert_equal ["kubernetes-deploy foo bar"], @spec.deploy_steps
+    end
+
     test "#deploy_steps returns kubernetes command if `kubernetes` is present and template_dir is set" do
       @spec.stubs(:load_config).returns(
         'kubernetes' => {
@@ -170,6 +182,18 @@ module Shipit
     end
 
     test "#rollback_steps returns `kubernetes-deploy <namespace> <context>` if `kubernetes` is present" do
+      @spec.stubs(:load_config).returns(
+        'kubernetes' => {
+          'namespace' => 'foo',
+          'context' => 'bar',
+        },
+      )
+      assert_equal ["kubernetes-deploy foo bar"], @spec.rollback_steps
+    end
+
+    test "#rollback_steps returns kubernetes-deploy command when both capfile and `kubernetes` are present" do
+      @spec.stubs(:bundler?).returns(true)
+      @spec.stubs(:capistrano?).returns(true)
       @spec.stubs(:load_config).returns(
         'kubernetes' => {
           'namespace' => 'foo',


### PR DESCRIPTION
@byroot @Shopify/cloudplatform 
cc @JamesOwenHall 

This fixes the issue where a shipit env that explicitly uses the `kubernetes` keyword will still try to deploy with Capistrano if there is a Capfile in the repo.