### PR TITLE
Trigger merge job as a reaction of several events

### DIFF
--- a/app/models/shipit/commit.rb
+++ b/app/models/shipit/commit.rb
@@ -192,8 +192,13 @@ module Shipit
 
       payload = {commit: self, stack: stack, status: new_status.state}
       Hook.emit(:commit_status, stack, payload.merge(commit_status: new_status)) if previous_status != new_status
-      if previous_status.simple_state != new_status.simple_state && (!new_status.pending? || previous_status.unknown?)
-        Hook.emit(:deployable_status, stack, payload.merge(deployable_status: new_status))
+      if previous_status.simple_state != new_status.simple_state
+        if !new_status.pending? || previous_status.unknown?
+          Hook.emit(:deployable_status, stack, payload.merge(deployable_status: new_status))
+        end
+        if new_status.pending? || new_status.success?
+          stack.schedule_merges
+        end
       end
       new_status
     end

--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -6,6 +6,7 @@ module Shipit
 
     state_machine :status do
       after_transition to: :success, do: :schedule_continuous_delivery
+      after_transition to: :success, do: :schedule_merges
       after_transition to: :success, do: :update_undeployed_commits_count
       after_transition to: :aborted, do: :trigger_revert_if_required
       after_transition any => any, do: :update_commit_deployments
@@ -161,6 +162,10 @@ module Shipit
     def denormalize_commit_stats
       self.additions = commits.map(&:additions).compact.sum
       self.deletions = commits.map(&:deletions).compact.sum
+    end
+
+    def schedule_merges
+      stack.schedule_merges
     end
 
     def schedule_continuous_delivery

--- a/test/models/deploys_test.rb
+++ b/test/models/deploys_test.rb
@@ -225,6 +225,13 @@ module Shipit
       end
     end
 
+    test "transitioning to success schedule a MergePullRequests job" do
+      @deploy = shipit_deploys(:shipit_running)
+      assert_enqueued_with(job: MergePullRequestsJob, args: [@deploy.stack]) do
+        @deploy.complete!
+      end
+    end
+
     test "transitioning to success schedule a fetch of the deployed revision" do
       @deploy = shipit_deploys(:shipit_running)
       assert_enqueued_with(job: FetchDeployedRevisionJob, args: [@deploy.stack]) do

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -327,6 +327,16 @@ module Shipit
       end
     end
 
+    test "unlocking the stack triggers a MergePullRequests job" do
+      assert_no_enqueued_jobs(only: MergePullRequestsJob) do
+        @stack.update(lock_reason: "Just for fun", lock_author: shipit_users(:walrus))
+      end
+
+      assert_enqueued_with(job: MergePullRequestsJob, args: [@stack]) do
+        @stack.update(lock_reason: nil)
+      end
+    end
+
     test "the git cache lock prevent concurrent access to the git cache" do
       @stack.acquire_git_cache_lock do
         assert_raises Redis::Lock::LockTimeout do


### PR DESCRIPTION
Ref: https://github.com/Shopify/shipit-engine/pull/643

- When a stack is unlocked
- When a deploy or rollback complete successfully
- When a commit becomes successful or pending

All these events are associated with a merge window opening up.

Also note that `MergePullRequestsjob` uses the `Unique` module, and as such only a single one per stack can be active at a time, so I'm not too worried about wasting capacity.

@Shopify/pipeline for review please.