### PR TITLE
Rework the pull request timeout feature

### DIFF
--- a/app/models/shipit/deploy_spec.rb
+++ b/app/models/shipit/deploy_spec.rb
@@ -159,10 +159,13 @@ module Shipit
       end
     end
 
-    def pull_request_timeout
-      Duration.parse(config('merge', 'timeout') { '1h' })
-    rescue Duration::ParseError
-      Duration.parse('1h')
+    def revalidate_pull_requests_after
+      if timeout = config('merge', 'revalidate_after')
+        begin
+          Duration.parse(timeout)
+        rescue Duration::ParseError
+        end
+      end
     end
 
     def review_checks

--- a/app/models/shipit/deploy_spec/file_system.rb
+++ b/app/models/shipit/deploy_spec/file_system.rb
@@ -32,7 +32,7 @@ module Shipit
           'merge' => {
             'require' => pull_request_required_statuses,
             'ignore' => pull_request_ignored_statuses,
-            'timeout' => pull_request_timeout.to_i,
+            'revalidate_after' => revalidate_pull_requests_after.try!(:to_i),
           },
           'ci' => {
             'hide' => hidden_statuses,

--- a/test/fixtures/shipit/stacks.yml
+++ b/test/fixtures/shipit/stacks.yml
@@ -40,6 +40,9 @@ shipit:
           "allow_concurrency": true
         }
       },
+      "merge": {
+        "revalidate_after": 900
+      },
       "ci": {
         "hide": ["ci/hidden"],
         "allow_failures": ["ci/ok_to_fail"]

--- a/test/models/deploy_spec_test.rb
+++ b/test/models/deploy_spec_test.rb
@@ -283,7 +283,7 @@ module Shipit
         'merge' => {
           'require' => [],
           'ignore' => [],
-          'timeout' => 3600,
+          'revalidate_after' => nil,
         },
         'ci' => {
           'hide' => [],
@@ -483,27 +483,27 @@ module Shipit
       assert_equal ['bar'], @spec.pull_request_required_statuses
     end
 
-    test "pull_request_timeout defaults to 1 hour" do
+    test "revalidate_pull_requests_after defaults to `nil" do
       @spec.expects(:load_config).returns({})
-      assert_equal 3600, @spec.pull_request_timeout.to_i
+      assert_nil @spec.revalidate_pull_requests_after
     end
 
-    test "pull_request_timeout defaults to 1 hour if `merge.timeout` cannot be parsed" do
+    test "revalidate_pull_requests_after defaults to `nil` if `merge.timeout` cannot be parsed" do
       @spec.expects(:load_config).returns(
         'merge' => {
-          'timeout' => 'ALSKhfjsdkf',
+          'revalidate_after' => 'ALSKhfjsdkf',
         },
       )
-      assert_equal 3600, @spec.pull_request_timeout.to_i
+      assert_nil @spec.revalidate_pull_requests_after
     end
 
-    test "pull_request_timeout returns `merge.timeout` if present" do
+    test "revalidate_after returns `merge.revalidate_after` if present" do
       @spec.expects(:load_config).returns(
         'merge' => {
-          'timeout' => '5m30s',
+          'revalidate_after' => '5m30s',
         },
       )
-      assert_equal 330, @spec.pull_request_timeout.to_i
+      assert_equal 330, @spec.revalidate_pull_requests_after.to_i
     end
 
     test "#file is impacted by `machine.directory`" do

--- a/test/models/pull_request_test.rb
+++ b/test/models/pull_request_test.rb
@@ -122,13 +122,13 @@ module Shipit
       assert_equal 'ci_failing', @pr.rejection_reason
     end
 
-    test "#reject_unless_mergeable! rejects the PR if it has been enqueued for too ling" do
+    test "#merge! rejects the PR if it has been enqueued for too long" do
       @pr.update!(merge_requested_at: 5.hours.ago)
 
-      assert_predicate @pr, :timedout?
-      assert_equal true, @pr.reject_unless_mergeable!
+      assert_predicate @pr, :need_revalidation?
+      assert_equal true, @pr.merge!
       assert_predicate @pr, :rejected?
-      assert_equal 'timedout', @pr.rejection_reason
+      assert_equal 'expired', @pr.rejection_reason
     end
 
     test "status transitions emit hooks" do


### PR DESCRIPTION
Following up on: https://github.com/Shopify/shipit-engine/pull/646

After thoughts, rejecting a pull request off the queue if it couldn't be merged after a certain amount of time is elapsed doesn't make much sense.

The whole idea behind the merge queue is to free people from overwatching the stack to know when they can merge, and this doesn't help achieve that goal in any way.

This change makes it so that now the PR is only rejected if it could have actually been merged. Which means that it's very likely that it's enqueued back in soon, it's will be merged very shortly.

This allow to leverage the webhooks that is fired when the PR is rejected, to notify the requester, and offer an easy way to enqueue it back.

Summary of the changes:
  - To reflect the new meaning the directive is now: `merge.revalidate_after`
  - It now defaults to no limit.
  - The `rejection_reason` is now `expired`

@Shopify/pipeline for review please.