### PR TITLE
Add a UI for visualizing the merge queue

### DIFF
--- a/app/assets/stylesheets/_base/_base.scss
+++ b/app/assets/stylesheets/_base/_base.scss
@@ -105,9 +105,9 @@ p {
 a {
   text-decoration: none;
   cursor: pointer;
-  color: #248af2;
+  color: $blue;
     &.subdued { color: #999; }
-    &.subdued:hover { color: #248af2; }
+    &.subdued:hover { color: $blue; }
 }
 
 .more {

--- a/app/assets/stylesheets/_pages/_commits.scss
+++ b/app/assets/stylesheets/_pages/_commits.scss
@@ -2,7 +2,7 @@
 // COMMIT LIST
 // =============================================================================
 
-.commit-list, .task-list {
+.commit-list, .task-list, .pr-list {
   list-style-type: none;
   margin: 0; padding: 0;
 }
@@ -11,7 +11,7 @@
   float: right;
 }
 
-.commit, .task {
+.commit, .task, .pr {
   padding: .75rem 0;
   display: flex;
   flex-direction: column;
@@ -70,7 +70,7 @@
 // COMMIT DETAILS
 // -----------------------------------------------------------------------------
 
-.commit-details {
+.commit-details, .pr-details {
   flex-grow: 1;
 
   @include media(tablet-down) {
@@ -88,11 +88,17 @@
   }
 }
 
-.commit-title a {
-  color: #333;
+.commit-title, .pr-title {
+  a {
+    color: #333;
+  }
 }
 
-.commit-meta {
+.pr-details .pr-number .number {
+  color: $blue;
+}
+
+.commit-meta, .pr-meta {
   font-size: 0.8em;
   color: #999;
   margin: 0;

--- a/app/assets/stylesheets/_pages/_stacks.scss
+++ b/app/assets/stylesheets/_pages/_stacks.scss
@@ -154,7 +154,7 @@
     }
   }
   input:focus {
-    border-color: #248af2;
+    border-color: $blue;
   }
 }
 

--- a/app/controllers/shipit/pull_requests_controller.rb
+++ b/app/controllers/shipit/pull_requests_controller.rb
@@ -1,0 +1,13 @@
+module Shipit
+  class PullRequestsController < ShipitController
+    def index
+      @pull_requests = stack.pull_requests.to_be_merged
+    end
+
+    private
+
+    def stack
+      @stack ||= Stack.from_param!(params[:stack_id])
+    end
+  end
+end

--- a/app/helpers/shipit/stacks_helper.rb
+++ b/app/helpers/shipit/stacks_helper.rb
@@ -40,13 +40,18 @@ module Shipit
       end
     end
 
-    def render_commit_message(commit)
-      message = commit.pull_request_title || commit.message
-      content_tag(:span, emojify(message.truncate(COMMIT_TITLE_LENGTH)), class: 'event-message')
+    def render_commit_message(message)
+      content_tag(:span, emojify(message.to_s.truncate(COMMIT_TITLE_LENGTH)), class: 'event-message')
+    end
+
+    def render_pull_request_title_with_link(pull_request)
+      message = render_commit_message(pull_request.title)
+      link_to(message, github_pull_request_url(pull_request), target: '_blank')
     end
 
     def render_commit_message_with_link(commit)
-      link_to(render_commit_message(commit), github_change_url(commit), target: '_blank')
+      message = render_commit_message(commit.pull_request_title || commit.message)
+      link_to(message, github_change_url(commit), target: '_blank')
     end
 
     def render_commit_id_link(commit)
@@ -57,8 +62,13 @@ module Shipit
       end
     end
 
-    def pull_request_link(commit)
-      link_to("##{commit.pull_request_number}", github_pull_request_url(commit), target: '_blank', class: 'number')
+    def pull_request_link(pull_request_or_commit)
+      number = if pull_request_or_commit.respond_to?(:pull_request_number)
+        pull_request_or_commit.pull_request_number
+      else
+        pull_request_or_commit.number
+      end
+      link_to("##{number}", github_pull_request_url(pull_request_or_commit), target: '_blank', class: 'number')
     end
 
     def render_raw_commit_id_link(commit)

--- a/app/models/shipit/pull_request.rb
+++ b/app/models/shipit/pull_request.rb
@@ -1,5 +1,7 @@
 module Shipit
   class PullRequest < ApplicationRecord
+    include DeferredTouch
+
     WAITING_STATUSES = %w(fetching pending).freeze
     REJECTION_REASONS = %w(ci_failing merge_conflict expired).freeze
     InvalidTransition = Class.new(StandardError)
@@ -35,6 +37,8 @@ module Shipit
     belongs_to :head, class_name: 'Shipit::Commit'
     belongs_to :merge_requested_by, class_name: 'Shipit::User'
     has_one :merge_commit, class_name: 'Shipit::Commit'
+
+    deferred_touch stack: :updated_at
 
     validates :number, presence: true, uniqueness: {scope: :stack_id}
 

--- a/app/views/shipit/commits/_commit.html.erb
+++ b/app/views/shipit/commits/_commit.html.erb
@@ -1,5 +1,5 @@
 <li class="commit" id="commit-<%= commit.id %>">
-  <%= render 'shipit/commits/commit_author', commit: commit %>
+  <%= render 'shipit/shared/author', author: commit.author %>
   <%= render commit.status %>
   <div class="commit-details">
     <span class="commit-title"><%= render_commit_message_with_link commit %></span>

--- a/app/views/shipit/commits/_commit_author.html.erb
+++ b/app/views/shipit/commits/_commit_author.html.erb
@@ -1,7 +1,0 @@
-<a href="<%= github_user_url(commit.author.login) %>" class="commit-author">
-  <%= github_avatar(commit.author, size: 80, class: 'commit-author__avatar') %>
-  <div class="commit-author__name">
-    <span class="commit-author__name__real-name"><%= commit.author.name %></span>
-    <span class="commit-author__name__username"><%= commit.author.login %></span>
-  </div>
-</a>

--- a/app/views/shipit/deploys/_deploy.html.erb
+++ b/app/views/shipit/deploys/_deploy.html.erb
@@ -1,7 +1,7 @@
 <%- read_only ||= false -%>
 
 <li class="task deploy" id="task-<%= deploy.id %>" data-status="<%= deploy.status %>">
-  <%= render 'shipit/commits/commit_author', commit: deploy %>
+  <%= render 'shipit/shared/author', author: deploy.author %>
   <a href="<%= stack_deploy_path(@stack, deploy) %>" class="status status--<%= deploy.status %>" data-tooltip="<%= deploy.status.capitalize %>">
     <i class="status__icon"></i>
     <span class="visually-hidden"><%= deploy.status %></span>

--- a/app/views/shipit/pull_requests/_pull_request.html.erb
+++ b/app/views/shipit/pull_requests/_pull_request.html.erb
@@ -1,0 +1,18 @@
+<li class="pr" id="pr-<%= pull_request.id %>">
+  <%= render 'shipit/shared/author', author: pull_request.merge_requested_by %>
+  <div class="pr-details">
+    <span class="pr-number">
+      <%= pull_request_link(pull_request) %>
+    </span>
+    <span class="pr-title">
+      <%= render_pull_request_title_with_link pull_request %>
+    </span>
+    <p class="pr-meta">
+      <span class="code-additions">+<%= pull_request.additions %></span>
+      <span class="code-deletions">-<%= pull_request.deletions %></span>
+    </p>
+    <p class="pr-meta">
+      Enqueued <%= timeago_tag(pull_request.merge_requested_at, force: true) %>
+    </p>
+  </div>
+</li>

--- a/app/views/shipit/pull_requests/index.html.erb
+++ b/app/views/shipit/pull_requests/index.html.erb
@@ -1,0 +1,9 @@
+<%= render partial: 'shipit/stacks/header', locals: { stack: @stack } %>
+
+<div class="wrapper">
+  <section>
+    <ul class="pr-list">
+      <%= render @pull_requests %>
+    </ul>
+  </section>
+</div>

--- a/app/views/shipit/shared/_author.html.erb
+++ b/app/views/shipit/shared/_author.html.erb
@@ -1,0 +1,7 @@
+<a href="<%= github_user_url(author.login) %>" class="commit-author">
+  <%= github_avatar(author, size: 80, class: 'commit-author__avatar') %>
+  <div class="commit-author__name">
+    <span class="commit-author__name__real-name"><%= author.name %></span>
+    <span class="commit-author__name__username"><%= author.login %></span>
+  </div>
+</a>

--- a/app/views/shipit/stacks/_header.html.erb
+++ b/app/views/shipit/stacks/_header.html.erb
@@ -22,6 +22,11 @@
     <li class="nav__list__item">
       <%= link_to 'Timeline', index_stack_tasks_path(stack) %>
     </li>
+    <% if stack.merge_queue_enabled? %>
+      <li class="nav__list__item">
+        <%= link_to "Pull Requests (#{stack.pull_requests.pending.count})", stack_pull_requests_path(stack) %>
+      </li>
+    <% end %>
   </ul>
   <ul class="nav__list nav__list--secondary">
     <% if stack.links.present? %>

--- a/app/views/shipit/tasks/_task.html.erb
+++ b/app/views/shipit/tasks/_task.html.erb
@@ -1,7 +1,7 @@
 <%- read_only ||= false -%>
 
 <li class="task" id="task-<%= task.id %>" data-status="<%= task.status %>">
-  <%= render 'shipit/commits/commit_author', commit: task %>
+  <%= render 'shipit/shared/author', author: task.author %>
   <a href="<%= stack_task_path(@stack, task) %>" class="status status--<%= task.status %>" data-tooltip="<%= task.status.capitalize %>">
     <i class="status__icon"></i>
     <span class="visually-hidden"><%= task.status %></span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -88,6 +88,8 @@ Shipit::Engine.routes.draw do
         get :revert
       end
     end
+
+    resources :pull_requests, only: %i(index)
   end
   get '/stacks/:id' => 'stacks#lookup'
 end

--- a/test/controllers/pull_requests_controller_test.rb
+++ b/test/controllers/pull_requests_controller_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+module Shipit
+  class PullRequestsControllerTest < ActionController::TestCase
+    setup do
+      @stack = shipit_stacks(:shipit)
+      session[:user_id] = shipit_users(:walrus).id
+    end
+
+    test "#index shows pending pull requests" do
+      get :index, params: {stack_id: @stack.to_param}
+      assert_response :success
+      assert_select '.pr-list .pr', @stack.pull_requests.pending.count
+    end
+  end
+end

--- a/test/dummy/db/seeds.rb
+++ b/test/dummy/db/seeds.rb
@@ -134,6 +134,22 @@ module Shipit
         )
       end
     end
+
+    stack.pull_requests.create!(
+      number: Faker::Number.number(3),
+      title: Faker::Company.catch_phrase,
+      merge_status: 'pending',
+      merge_requested_at: 5.minute.ago,
+      merge_requested_by: users.sample,
+      github_id: Faker::Number.number(8),
+      api_url: 'https://api.github.com/repos/shopify/shipit-engine/pulls/62',
+      state: 'open',
+      branch: "feature-#{Faker::Number.number(3)}",
+      head_id: nil,
+      mergeable: true,
+      additions: Faker::Number.number(3),
+      deletions: Faker::Number.number(3),
+    )
   end
 
   def create_chunks

--- a/test/fixtures/shipit/pull_requests.yml
+++ b/test/fixtures/shipit/pull_requests.yml
@@ -24,6 +24,7 @@ shipit_pending:
 shipit_pending_unmergeable:
   stack: shipit
   number: 61
+  title: Other cool feature
   merge_status: pending
   merge_requested_at: <%= 4.minute.ago.to_s(:db) %>
   merge_requested_by: walrus


### PR DESCRIPTION
Followup to: https://github.com/Shopify/shipit-engine/pull/653

<img width="758" alt="capture d ecran 2017-02-15 a 14 46 57" src="https://cloud.githubusercontent.com/assets/19192189/22977641/cb01e28a-f38f-11e6-837c-e5724cf4e6d4.png">

It's read only for now. I'll add controls to request / cancel a merge in a followup.

@Shopify/pipeline for review please.