### PR TITLE
Add a UI to cancel pull request merges

### DIFF
--- a/app/controllers/shipit/pull_requests_controller.rb
+++ b/app/controllers/shipit/pull_requests_controller.rb
@@ -4,6 +4,13 @@ module Shipit
       @pull_requests = stack.pull_requests.to_be_merged
     end
 
+    def destroy
+      pull_request = stack.pull_requests.find(params[:id])
+      pull_request.cancel!
+      flash[:success] = 'Merge canceled'
+      redirect_to stack_pull_requests_path
+    end
+
     private
 
     def stack

--- a/app/models/shipit/pull_request.rb
+++ b/app/models/shipit/pull_request.rb
@@ -65,7 +65,7 @@ module Shipit
       end
 
       event :cancel do
-        transition %i(fetching pending) => :canceled
+        transition any => :canceled
       end
 
       event :complete do

--- a/app/views/shipit/pull_requests/_pull_request.html.erb
+++ b/app/views/shipit/pull_requests/_pull_request.html.erb
@@ -15,4 +15,7 @@
       Enqueued <%= timeago_tag(pull_request.merge_requested_at, force: true) %>
     </p>
   </div>
+  <div class="commit-actions">
+    <%= button_to 'Cancel', stack_pull_request_path(pull_request.stack, pull_request), class: 'btn btn--warning', method: 'delete' %>
+  </div>
 </li>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,7 +89,7 @@ Shipit::Engine.routes.draw do
       end
     end
 
-    resources :pull_requests, only: %i(index)
+    resources :pull_requests, only: %i(index destroy)
   end
   get '/stacks/:id' => 'stacks#lookup'
 end

--- a/test/controllers/pull_requests_controller_test.rb
+++ b/test/controllers/pull_requests_controller_test.rb
@@ -4,6 +4,7 @@ module Shipit
   class PullRequestsControllerTest < ActionController::TestCase
     setup do
       @stack = shipit_stacks(:shipit)
+      @pr = shipit_pull_requests(:shipit_pending)
       session[:user_id] = shipit_users(:walrus).id
     end
 
@@ -11,6 +12,13 @@ module Shipit
       get :index, params: {stack_id: @stack.to_param}
       assert_response :success
       assert_select '.pr-list .pr', @stack.pull_requests.pending.count
+    end
+
+    test "#destroy can cancel a pending pull request" do
+      assert_predicate @pr, :pending?
+      delete :destroy, params: {stack_id: @stack.to_param, id: @pr.id}
+      assert_redirected_to stack_pull_requests_path(@stack)
+      assert_predicate @pr.reload, :canceled?
     end
   end
 end


### PR DESCRIPTION
Followup to: https://github.com/Shopify/shipit-engine/pull/654

![cancel-pr](https://cloud.githubusercontent.com/assets/19192189/22981632/3af603ca-f39d-11e6-9029-1c2451a713e5.gif)

@Shopify/pipeline for review please.