### PR TITLE
Add form to request a PR merge

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -139,3 +139,6 @@ Style/ParallelAssignment:
 
 Style/IfUnlessModifier:
   Enabled: false
+
+Performance/Casecmp:
+  Enabled: false # ugly

--- a/app/assets/stylesheets/_base/_forms.scss
+++ b/app/assets/stylesheets/_base/_forms.scss
@@ -26,6 +26,20 @@ textarea {
 
 .field-wrapper {
   margin-bottom: 1.5rem;
+  input:focus {
+    border-color: $blue;
+  }
+  &.inline {
+    input {
+      &.btn {
+        height: 2.5rem;
+      }
+      display: inline;
+      &:focus {
+        padding-right: 30px;
+      }
+    }
+  }
 }
 
 .field_with_errors {

--- a/app/controllers/shipit/pull_requests_controller.rb
+++ b/app/controllers/shipit/pull_requests_controller.rb
@@ -4,6 +4,16 @@ module Shipit
       @pull_requests = stack.pull_requests.to_be_merged
     end
 
+    def create
+      if pr_number = PullRequest.extract_number(stack, params[:number_or_url])
+        pull_request = PullRequest.request_merge!(stack, pr_number, current_user)
+        flash[:success] = "Pull request ##{pull_request.number} added to the queue."
+      else
+        flash[:warning] = "Invalid or missing pull request number."
+      end
+      redirect_to stack_pull_requests_path
+    end
+
     def destroy
       pull_request = stack.pull_requests.find(params[:id])
       pull_request.cancel!

--- a/app/models/shipit/pull_request.rb
+++ b/app/models/shipit/pull_request.rb
@@ -86,6 +86,17 @@ module Shipit
       Shipit::Stack.where(id: pending.uniq.pluck(:stack_id)).find_each(&:schedule_merges)
     end
 
+    def self.extract_number(stack, number_or_url)
+      case number_or_url
+      when /\A#?(\d+)\z/
+        $1.to_i
+      when %r{\Ahttps://#{Regexp.escape(Shipit.github_domain)}/([^/]+)/([^/]+)/pull/(\d+)}
+        return unless $1.downcase == stack.repo_owner.downcase
+        return unless $2.downcase == stack.repo_name.downcase
+        return $3.to_i
+      end
+    end
+
     def self.request_merge!(stack, number, user)
       now = Time.now.utc
       pull_request = begin

--- a/app/views/shipit/pull_requests/index.html.erb
+++ b/app/views/shipit/pull_requests/index.html.erb
@@ -2,6 +2,15 @@
 
 <div class="wrapper">
   <section>
+    <header class="section-header">
+      <%= form_tag stack_pull_requests_path(@stack) do %>
+        <div class="field-wrapper inline">
+          <%= text_field_tag :number_or_url, '', placeholder: 'PR number or URL' %>
+          <%= submit_tag 'Request merge', class: 'btn' %>
+        </div>
+      <% end %>
+    </header>
+
     <ul class="pr-list">
       <%= render @pull_requests %>
     </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -89,7 +89,7 @@ Shipit::Engine.routes.draw do
       end
     end
 
-    resources :pull_requests, only: %i(index destroy)
+    resources :pull_requests, only: %i(index destroy create)
   end
   get '/stacks/:id' => 'stacks#lookup'
 end

--- a/test/controllers/pull_requests_controller_test.rb
+++ b/test/controllers/pull_requests_controller_test.rb
@@ -14,6 +14,13 @@ module Shipit
       assert_select '.pr-list .pr', @stack.pull_requests.pending.count
     end
 
+    test "#add can enqueue a pull request" do
+      assert_difference -> { PullRequest.count }, +1 do
+        post :create, params: {stack_id: @stack.to_param, number_or_url: '#5'}
+      end
+      assert_redirected_to stack_pull_requests_path(@stack)
+    end
+
     test "#destroy can cancel a pending pull request" do
       assert_predicate @pr, :pending?
       delete :destroy, params: {stack_id: @stack.to_param, id: @pr.id}

--- a/test/models/pull_request_test.rb
+++ b/test/models/pull_request_test.rb
@@ -22,6 +22,18 @@ module Shipit
       end
     end
 
+    test ".extract_number can get a pull request number from different formats" do
+      assert_equal 42, PullRequest.extract_number(@stack, '42')
+      assert_equal 42, PullRequest.extract_number(@stack, '#42')
+      assert_equal 42, PullRequest.extract_number(@stack, 'https://github.com/Shopify/shipit-engine/pull/42')
+
+      assert_nil PullRequest.extract_number(@stack, 'https://github.com/ACME/shipit-engine/pull/42')
+
+      Shipit.expects(:github_domain).returns('github.acme.com').at_least_once
+      assert_equal 42, PullRequest.extract_number(@stack, 'https://github.acme.com/Shopify/shipit-engine/pull/42')
+      assert_nil PullRequest.extract_number(@stack, 'https://github.com/Shopify/shipit-engine/pull/42')
+    end
+
     test "refresh! pulls state from GitHub" do
       pull_request = shipit_pull_requests(:shipit_fetching)
 


### PR DESCRIPTION
Follow up to: https://github.com/Shopify/shipit-engine/pull/655

![pr-add](https://cloud.githubusercontent.com/assets/19192189/23017236/c5466000-f439-11e6-8214-d4c04a956381.gif)

It's not super great as the PullRequest normally starts it's lifecycle in the `fetching` state, and we don't display those. Then a job immediately kicks in, and move it to either `pending`, or `rejected` (e.g. failing or pending CI).

So you might have to refresh to see your PR or worse it could be rejected almost immediately and you won't see it.

I think what we could do it to listen to SSE to make that page automatically refresh. That would improve UX. But that's for a followup IMO.

@Shopify/pipeline for review please.