### PR TITLE
Refactor and improve live update

### DIFF
--- a/app/assets/javascripts/shipit/page_updater.js.coffee
+++ b/app/assets/javascripts/shipit/page_updater.js.coffee
@@ -1,0 +1,63 @@
+class PageUpdater
+  DEBOUNCE = 100
+  RETRY_DELAY = 5000
+  MAX_RETRIES = 5
+
+  @callbacks: []
+  @afterUpdate: (callback) ->
+    @callbacks.push(callback)
+
+  constructor: (@channel, @selectors) ->
+    @parser = new DOMParser()
+    @source = @listen()
+    @previousLastModified = null
+
+  requestUpdate: =>
+    @updateRequested = true
+    @scheduleUpdate()
+
+  scheduleUpdate: =>
+    return if @updateScheduled
+    return unless @updateRequested
+    setTimeout(@fetchPage, DEBOUNCE)
+    @updateScheduled = true
+
+  fetchPage: (message) =>
+    @updateRequested = false
+    jQuery.get(window.location.toString()).done(@updatePage).fail(=> @updateScheduled = false)
+
+  updatePage: (html, status, response) =>
+    lastModified = response.getResponseHeader('last-modified')
+    if lastModified? and lastModified != @previousLastModified
+      @previousLastModified = lastModified
+
+      newDocument = @parser.parseFromString(html, 'text/html')
+      for selector in @selectors
+        $(selector).html(newDocument.querySelectorAll("#{selector} > *"))
+      for callback in PageUpdater.callbacks
+        callback()
+
+    @updateScheduled = false
+
+  listen: ->
+    @source = new EventSource(@channel)
+    @source.addEventListener('update', @requestUpdate)
+    @retries = MAX_RETRIES
+    @interval = setInterval =>
+      switch @source.readyState
+        when @source.CLOSED
+          clearInterval(@interval)
+          if @retries > 0
+            @retries -= 1
+            @listen()
+        else
+          @retries = MAX_RETRIES
+    , RETRY_DELAY
+
+jQuery ($) ->
+  PageUpdater.afterUpdate -> $('time[data-time-ago]').timeago()
+
+  channel = $('meta[name=subscription-channel]').attr('content')
+  selectors = (e.content for e in $('meta[name=subscription-selector]'))
+  if channel and selectors
+    new PageUpdater(channel, selectors)

--- a/app/assets/javascripts/shipit/stacks.js.coffee
+++ b/app/assets/javascripts/shipit/stacks.js.coffee
@@ -20,28 +20,6 @@ jQuery ($) ->
 
   displayIgnoreCiMessage()
 
-  updatePage = (message) ->
-    payload = JSON.parse(message.data)
-    $('[data-layout-content]').load("#{payload.url} [data-layout-content] > *", -> $('time[data-time-ago]').timeago())
-
-  retries = 0
-  listenToEventSource = (url) ->
-    source = new EventSource(url)
-    source.addEventListener 'stack.update', updatePage
-    interval = setInterval ->
-      switch source.readyState
-        when source.CLOSED
-          clearInterval(interval)
-          if retries > 0
-            retries -= 1
-            listenToEventSource(url)
-        else
-          retries = 2
-    , 30000
-
-  $('[data-event-stream]').each ->
-    listenToEventSource($(this).data('event-stream'))
-
   $(document).on 'click', '.setting-ccmenu input[type=submit]', (event) ->
     event.preventDefault()
     $(event.target).prop('disabled', true)

--- a/app/helpers/shipit/shipit_helper.rb
+++ b/app/helpers/shipit/shipit_helper.rb
@@ -1,5 +1,14 @@
 module Shipit
   module ShipitHelper
+    def subscribe(url, *selectors)
+      content_for(:update_subscription) do
+        [
+          tag('meta', name: 'subscription-channel', content: url),
+          *selectors.map { |s| tag('meta', name: 'subscription-selector', content: s) },
+        ].join("\n").html_safe
+      end
+    end
+
     def emojify(content)
       h(content).to_str.gsub(/:([\w+-]+):/) do |match|
         if emoji = Emoji.find_by_alias($1)

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -377,9 +377,11 @@ module Shipit
     end
 
     def broadcast_update
-      payload = {url: Shipit::Engine.routes.url_helpers.stack_path(self)}.to_json
-      event = Pubsubstub::Event.new(payload, name: "stack.update")
-      Pubsubstub::RedisPubSub.publish("stack.#{id}", event)
+      Pubsubstub.publish(
+        "stack.#{id}",
+        {id: id, updated_at: updated_at}.to_json,
+        name: 'update',
+      )
     end
 
     def setup_hooks

--- a/app/views/layouts/shipit.html.erb
+++ b/app/views/layouts/shipit.html.erb
@@ -5,7 +5,7 @@
   <%= favicon_link_tag %>
   <%= stylesheet_link_tag :shipit, media: 'all' %>
   <%= javascript_include_tag :shipit %>
-
+  <%= yield :update_subscription %>
   <%= csrf_meta_tags %>
 </head>
 <body>
@@ -26,51 +26,53 @@
     </div>
   </div>
 
-  <% github_status = Shipit::GithubStatus.status
-     unless github_status.nil? || github_status[:status] == 'good' %>
-    <div class="banner github-status banner--orange hidden">
-      <div class="banner__inner wrapper">
-        <div class="banner__content">
-          <h2 class="banner__title">GitHub is having issues</h2>
-            <% if github_status[:body].present? %>
-              "<i><%= github_status[:body] %></i>"
-            <% end %>
-            <% if github_status[:last_updated].present? %>
-              <%= time_ago_in_words(github_status[:last_updated]) %> ago
-            <% end %>
-        </div>
-
-        <a class="banner__dismiss">&times;</a>
-      </div>
-    </div>
-  <% end %>
-
-  <header class="header">
-    <%= link_to "Shipit v#{Shipit::VERSION}", "https://github.com/Shopify/shipit-engine/tree/v#{Shipit::VERSION}", class: 'powered-by' %>
-    <div class="wrapper">
-      <div class="header__inner">
-        <a href="/" class="logo">
-          <span class="visually-hidden">Shipit</span>
-        </a>
-        <div class="header__page-title">
-          <%= yield :page_title %>
-        </div>
-        <% if content_for? :primary_navigation %>
-          <div class="header__page-actions">
-            <%= yield :primary_navigation %>
+  <div id="layout-content">
+    <% github_status = Shipit::GithubStatus.status
+       unless github_status.nil? || github_status[:status] == 'good' %>
+      <div class="banner github-status banner--orange hidden">
+        <div class="banner__inner wrapper">
+          <div class="banner__content">
+            <h2 class="banner__title">GitHub is having issues</h2>
+              <% if github_status[:body].present? %>
+                "<i><%= github_status[:body] %></i>"
+              <% end %>
+              <% if github_status[:last_updated].present? %>
+                <%= time_ago_in_words(github_status[:last_updated]) %> ago
+              <% end %>
           </div>
+
+          <a class="banner__dismiss">&times;</a>
+        </div>
+      </div>
+    <% end %>
+
+    <header class="header">
+      <%= link_to "Shipit v#{Shipit::VERSION}", "https://github.com/Shopify/shipit-engine/tree/v#{Shipit::VERSION}", class: 'powered-by' %>
+      <div class="wrapper">
+        <div class="header__inner">
+          <a href="/" class="logo">
+            <span class="visually-hidden">Shipit</span>
+          </a>
+          <div class="header__page-title">
+            <%= yield :page_title %>
+          </div>
+          <% if content_for? :primary_navigation %>
+            <div class="header__page-actions">
+              <%= yield :primary_navigation %>
+            </div>
+          <% end %>
+        </div>
+        <% if content_for? :secondary_navigation %>
+          <nav class="nav">
+            <%= yield :secondary_navigation %>
+          </nav>
         <% end %>
       </div>
-      <% if content_for? :secondary_navigation %>
-        <nav class="nav">
-          <%= yield :secondary_navigation %>
-        </nav>
-      <% end %>
-    </div>
-  </header>
+    </header>
 
-  <div class="main <%= content_for(:main_classes) %>" data-layout-content>
-    <%= yield %>
+    <div class="main <%= content_for(:main_classes) %>">
+      <%= yield %>
+    </div>
   </div>
 </body>
 </html>

--- a/app/views/shipit/pull_requests/index.html.erb
+++ b/app/views/shipit/pull_requests/index.html.erb
@@ -1,3 +1,5 @@
+<% subscribe events_path(channels: ["stack.#{@stack.id}"]), '.pr-list', '.header' %>
+
 <%= render partial: 'shipit/stacks/header', locals: { stack: @stack } %>
 
 <div class="wrapper">

--- a/app/views/shipit/stacks/show.html.erb
+++ b/app/views/shipit/stacks/show.html.erb
@@ -1,3 +1,5 @@
+<% subscribe events_path(channels: ["stack.#{@stack.id}"]), '#layout-content' %>
+
 <%= render partial: 'shipit/stacks/header', locals: { stack: @stack } %>
 
 <% if !@stack.ignore_ci && !@stack.ci_enabled? %>
@@ -63,8 +65,7 @@
   </div>
 <% end %>
 
-<div class="wrapper" data-event-stream="<%= events_path(channels: ["stack.#{@stack.id}"]) %>">
-
+<div class="wrapper">
   <section>
     <header class="section-header">
       <h2>Undeployed Commits</h2>

--- a/test/models/commits_test.rb
+++ b/test/models/commits_test.rb
@@ -483,10 +483,9 @@ module Shipit
     private
 
     def expect_event(stack)
-      Pubsubstub::RedisPubSub.expects(:publish).at_least_once
-      Pubsubstub::RedisPubSub.expects(:publish).with do |channel, event|
-        data = JSON.load(event.data)
-        channel == "stack.#{stack.id}" && data['url'] == "/#{stack.to_param}"
+      Pubsubstub.expects(:publish).at_least_once
+      Pubsubstub.expects(:publish).with do |channel, _payload, _options = {}|
+        channel == "stack.#{stack.id}"
       end
     end
 

--- a/test/models/deploys_test.rb
+++ b/test/models/deploys_test.rb
@@ -447,10 +447,9 @@ module Shipit
     private
 
     def expect_event(deploy)
-      Pubsubstub::RedisPubSub.expects(:publish).at_least_once
-      Pubsubstub::RedisPubSub.expects(:publish).with do |channel, event|
-        data = JSON.load(event.data)
-        channel == "stack.#{deploy.stack.id}" && data['url'] == "/#{deploy.stack.to_param}"
+      Pubsubstub.expects(:publish).at_least_once
+      Pubsubstub.expects(:publish).with do |channel, _payload, _options|
+        channel == "stack.#{deploy.stack.id}"
       end
     end
   end

--- a/test/models/status_test.rb
+++ b/test/models/status_test.rb
@@ -54,12 +54,9 @@ module Shipit
     end
 
     def expect_event(stack)
-      Pubsubstub::RedisPubSub.expects(:publish).at_least_once
-      Pubsubstub::RedisPubSub.expects(:publish).with do |channel, event|
-        data = JSON.load(event.data)
-        event.name == 'stack.update' &&
-          channel == "stack.#{stack.id}" &&
-          data['url'] == "/#{stack.to_param}"
+      Pubsubstub.expects(:publish).at_least_once
+      Pubsubstub.expects(:publish).with do |channel, _payload, options = {}|
+        options[:name] == 'update' && channel == "stack.#{stack.id}"
       end
     end
   end


### PR DESCRIPTION
Followup to: https://github.com/Shopify/shipit-engine/pull/656

There is several changes that the merge queue feature introduced, that made the current live update code insufficient:

  - The PR count in the header wasn't part of the live updated area.
  - Since the merge queue page contains a form, and that updating it would lead to a poor UX (your input could be wiped while you type), we need to be able to update several distinct areas.

And also some long standing annoying bugs:
  - The update code was using the URL present in the SSE stream, so it could mess with the emergency mode among other things.
  - Since many changes on the stack trigger asynchronous jobs, which might update the stack again, it can easily result in an thundering herd effect.

This PR solves all this:
  - It now fetch the new document by using `window.location`
  - It supports updating multiple fragments of the page
  - The update is debounced, if many updates are triggered in under 100ms (arbitrary choice), they are collapsed
  - The JS code now check the `Last-Modified` header, so it doesn't update the DOM if it's not required (This doesn't change much now, but it allows to introduce a more fine grained `last-modified` computation in the future).

@Shopify/pipeline for review please. 