### PR TITLE
Add CCMenu/CCTray endpoint

### DIFF
--- a/app/assets/javascripts/shipit/stacks.js.coffee
+++ b/app/assets/javascripts/shipit/stacks.js.coffee
@@ -41,3 +41,13 @@ jQuery ($) ->
 
   $('[data-event-stream]').each ->
     listenToEventSource($(this).data('event-stream'))
+
+  $(document).on 'click', '.setting-ccmenu input[type=submit]', (event) ->
+    event.preventDefault()
+    $(event.target).prop('disabled', true)
+    $.get(event.target.dataset.remote).done((data) ->
+      $('#ccmenu-url').val(data.ccmenu_url).removeClass('hidden')
+      $(event.target).addClass('hidden')
+    ).fail(->
+      $(event.target).prop('disabled', false)
+    )

--- a/app/assets/stylesheets/_pages/_settings.scss
+++ b/app/assets/stylesheets/_pages/_settings.scss
@@ -13,4 +13,12 @@
     font-size: smaller;
     font-style: italic;
   }
+
+  .ccmenu-url {
+    width: 85%;
+  }
+
+  .hidden {
+    display: none;
+  }
 }

--- a/app/controllers/shipit/api/ccmenu_controller.rb
+++ b/app/controllers/shipit/api/ccmenu_controller.rb
@@ -11,19 +11,10 @@ module Shipit
         def ended_at
           Time.now.utc
         end
-
-        def status
-          false
-        end
-
-        alias_method :running?, :status
-        alias_method :failed?, :status
-        alias_method :error?, :status
-        alias_method :success?, :status
       end
 
       def show
-        latest_deploy = stack.deploys.first || NoDeploy.new
+        latest_deploy = stack.deploys_and_rollbacks.last || NoDeploy.new
         render 'shipit/ccmenu/project.xml.builder', formats: [:xml], locals: {stack: stack, deploy: latest_deploy}
       end
 

--- a/app/controllers/shipit/api/ccmenu_controller.rb
+++ b/app/controllers/shipit/api/ccmenu_controller.rb
@@ -32,6 +32,11 @@ module Shipit
       def stack
         @stack ||= Stack.from_param!(params[:stack_id])
       end
+
+      def authenticate_api_client
+        @current_api_client = ApiClient.authenticate(params[:token])
+        super unless @current_api_client
+      end
     end
   end
 end

--- a/app/controllers/shipit/api/ccmenu_controller.rb
+++ b/app/controllers/shipit/api/ccmenu_controller.rb
@@ -1,0 +1,37 @@
+module Shipit
+  module Api
+    class CcmenuController < BaseController
+      require_permission :read, :stack
+
+      class NoDeploy
+        def id
+          0
+        end
+
+        def ended_at
+          Time.now.utc
+        end
+
+        def status
+          false
+        end
+
+        alias_method :running?, :status
+        alias_method :failed?, :status
+        alias_method :error?, :status
+        alias_method :success?, :status
+      end
+
+      def show
+        latest_deploy = stack.deploys.first || NoDeploy.new
+        render 'shipit/ccmenu/project.xml.builder', formats: [:xml], locals: {stack: stack, deploy: latest_deploy}
+      end
+
+      private
+
+      def stack
+        @stack ||= Stack.from_param!(params[:stack_id])
+      end
+    end
+  end
+end

--- a/app/controllers/shipit/api/ccmenu_controller.rb
+++ b/app/controllers/shipit/api/ccmenu_controller.rb
@@ -1,6 +1,6 @@
 module Shipit
   module Api
-    class CcmenuController < BaseController
+    class CCMenuController < BaseController
       require_permission :read, :stack
 
       class NoDeploy

--- a/app/controllers/shipit/ccmenu_url_controller.rb
+++ b/app/controllers/shipit/ccmenu_url_controller.rb
@@ -1,7 +1,7 @@
 require 'uri'
 
 module Shipit
-  class CcmenuUrlController < ShipitController
+  class CCMenuUrlController < ShipitController
     def fetch
       uri = URI(api_stack_ccmenu_url(stack_id: stack.to_param))
       uri.query = {'token' => client.authentication_token}.to_query

--- a/app/controllers/shipit/ccmenu_url_controller.rb
+++ b/app/controllers/shipit/ccmenu_url_controller.rb
@@ -4,7 +4,7 @@ module Shipit
   class CcmenuUrlController < ShipitController
     def fetch
       uri = URI(api_stack_ccmenu_url(stack_id: stack.to_param))
-      uri.user = client.authentication_token
+      uri.query = {'token' => client.authentication_token}.to_query
       render json: {ccmenu_url: uri.to_s}
     end
 

--- a/app/controllers/shipit/ccmenu_url_controller.rb
+++ b/app/controllers/shipit/ccmenu_url_controller.rb
@@ -1,0 +1,22 @@
+require 'uri'
+
+module Shipit
+  class CcmenuUrlController < ShipitController
+    def fetch
+      uri = URI(api_stack_ccmenu_url(stack_id: stack.to_param))
+      uri.user = client.authentication_token
+      render json: {ccmenu_url: uri.to_s}
+    end
+
+    private
+
+    def client
+      @client ||= Shipit::ApiClient.create_with(permissions: %w(read:stack))
+                                   .find_or_create_by!(creator: current_user, name: 'CCMenu Client')
+    end
+
+    def stack
+      @stack ||= Stack.from_param!(params[:stack_id])
+    end
+  end
+end

--- a/app/controllers/shipit/ccmenu_url_controller.rb
+++ b/app/controllers/shipit/ccmenu_url_controller.rb
@@ -11,8 +11,8 @@ module Shipit
     private
 
     def client
-      @client ||= Shipit::ApiClient.create_with(permissions: %w(read:stack))
-                                   .find_or_create_by!(creator: current_user, name: 'CCMenu Client')
+      @client ||= ApiClient.create_with(permissions: %w(read:stack))
+                           .find_or_create_by!(creator: current_user, name: 'CCMenu Client')
     end
 
     def stack

--- a/app/views/shipit/ccmenu/project.xml.builder
+++ b/app/views/shipit/ccmenu/project.xml.builder
@@ -1,0 +1,13 @@
+# Derived from http://timnew.me/blog/2013/04/07/multiple-project-summary-reporting-standard-cctray-xml-feed/
+status_map = {'backlogged' => 'failure', 'locked' => 'failure'}
+xml.instruct!
+xml.Projects do
+  xml.Project '', {
+    :name => stack.to_param,
+    :lastBuildStatus => status_map.fetch(stack.merge_status, stack.merge_status).capitalize,
+    :activity => deploy.running? ? 'Building' : 'Sleeping',
+    :lastBuildTime => deploy.ended_at || deploy.started_at || deploy.created_at,
+    :lastBuildLabel => deploy.id,
+    :webUrl => stack_url(stack),
+  }
+end

--- a/app/views/shipit/stacks/settings.html.erb
+++ b/app/views/shipit/stacks/settings.html.erb
@@ -71,15 +71,13 @@
       </table>
     </div>
 
-    <div class="setting-section">
+    <div class="setting-section setting-ccmenu">
       <h5>Miscellaneous</h5>
-      <table>
-        <tr>
-          <td>CCTray/CCMenu URL</td>
-          <td id="ccmenu-url" style="width: 100%"><%= button_to "Fetch URL", "javascript:fetchCCMenuURL()", class: 'btn' %></td>
-        </tr>
-      </table>
-        <%#input type="text" disabled value="<%= ccmenu_url(stack_id: @stack.to_param, token: @cc_token) >"%>
+      <div class="field-wrapper">
+        <label>CCMenu URL</label>
+        <input id="ccmenu-url" class="hidden" type="text" disabled />
+      </div>
+      <%= button_to "Fetch URL", "", class: 'btn', data: {remote: ccmenu_url_url(stack_id: @stack.to_param)} %>
     </div>
 
     <div class="setting-section">
@@ -90,11 +88,3 @@
 
   </section>
 </div>
-<script type="text/javascript">
-function fetchCCMenuURL() {
-  $.ajax({url: "<%= ccmenu_url_url(stack_id: @stack.to_param) %>", success: function(result){
-    console.log(result);
-    $("#ccmenu-url").html("<input type='text' disabled value='" + result.ccmenu_url + "'/>");
-  }});
-}
-</script>

--- a/app/views/shipit/stacks/settings.html.erb
+++ b/app/views/shipit/stacks/settings.html.erb
@@ -71,6 +71,16 @@
       </table>
     </div>
 
+    <div class="setting-section">
+      <h5>Miscellaneous</h5>
+      <table>
+        <tr>
+          <td>CCTray/CCMenu URL</td>
+          <td id="ccmenu-url" style="width: 100%"><%= button_to "Fetch URL", "javascript:fetchCCMenuURL()", class: 'btn' %></td>
+        </tr>
+      </table>
+        <%#input type="text" disabled value="<%= ccmenu_url(stack_id: @stack.to_param, token: @cc_token) >"%>
+    </div>
 
     <div class="setting-section">
       <h5>Delete this stack</h5>
@@ -80,3 +90,11 @@
 
   </section>
 </div>
+<script type="text/javascript">
+function fetchCCMenuURL() {
+  $.ajax({url: "<%= ccmenu_url_url(stack_id: @stack.to_param) %>", success: function(result){
+    console.log(result);
+    $("#ccmenu-url").html("<input type='text' disabled value='" + result.ccmenu_url + "'/>");
+  }});
+}
+</script>

--- a/config/initializers/inflections.rb
+++ b/config/initializers/inflections.rb
@@ -1,0 +1,3 @@
+ActiveSupport::Inflector.inflections(:en) do |inflect|
+  inflect.acronym 'CCMenu'
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,6 +30,7 @@ Shipit::Engine.routes.draw do
     end
 
     scope '/stacks/*stack_id', stack_id: stack_id_format, as: :stack do
+      get '/ccmenu' => 'ccmenu#show', as: :ccmenu
       resource :lock, only: %i(create update destroy)
       resources :tasks, only: %i(index show) do
         resource :output, only: :show
@@ -42,6 +43,10 @@ Shipit::Engine.routes.draw do
     end
 
     resources :hooks, only: %i(index create show update destroy)
+  end
+
+  scope '/ccmenu/*stack_id', stack_id: stack_id_format, as: :ccmenu_url do
+    get '/' => 'ccmenu_url#fetch'
   end
 
   # Humans

--- a/test/controllers/api/ccmenu_controller_test.rb
+++ b/test/controllers/api/ccmenu_controller_test.rb
@@ -15,8 +15,15 @@ module Shipit
         assert_json 'message', 'This operation requires the `read:stack` permission'
       end
 
-      test "#show renders the stack" do
+      test "#show renders the xml" do
         get :show, params: {stack_id: @stack.to_param}
+        assert_response :ok
+        assert_payload 'name', @stack.to_param
+      end
+
+      test "can authenticate with query string token" do
+        request.headers['Authorization'] = 'bleh'
+        get :show, params: {stack_id: @stack.to_param, token: @client.authentication_token}
         assert_response :ok
         assert_payload 'name', @stack.to_param
       end

--- a/test/controllers/api/ccmenu_controller_test.rb
+++ b/test/controllers/api/ccmenu_controller_test.rb
@@ -1,0 +1,50 @@
+require 'test_helper'
+
+module Shipit
+  module Api
+    class CcmenuControllerTest < ActionController::TestCase
+      setup do
+        authenticate!
+        @stack = shipit_stacks(:shipit)
+      end
+
+      test "a request with insufficient permissions will render a 403" do
+        @client.update!(permissions: [])
+        get :show, params: {stack_id: @stack.to_param}
+        assert_response :forbidden
+        assert_json 'message', 'This operation requires the `read:stack` permission'
+      end
+
+      test "#show renders the stack" do
+        get :show, params: {stack_id: @stack.to_param}
+        assert_response :ok
+        assert_payload 'name', @stack.to_param
+      end
+
+      test "xml contains required attributes" do
+        get :show, params: {stack_id: @stack.to_param}
+        project = get_project_from_xml(response.body)
+        %w(name activity lastBuildStatus lastBuildLabel lastBuildTime webUrl).each do |attribute|
+          assert_includes project, attribute, "Response missing required attribute: #{attribute}"
+        end
+      end
+
+      test "locked stacks show as failed" do
+        @stack.lock('test', @user)
+        get :show, params: {stack_id: @stack.to_param}
+        assert_payload 'lastBuildStatus', 'Failure'
+      end
+
+      private
+
+      def get_project_from_xml(xml)
+        Hash.from_xml(xml)['Projects']['Project']
+      end
+
+      def assert_payload(k, v)
+        @project ||= get_project_from_xml(response.body)
+        assert_equal v, @project[k]
+      end
+    end
+  end
+end

--- a/test/controllers/api/ccmenu_controller_test.rb
+++ b/test/controllers/api/ccmenu_controller_test.rb
@@ -2,7 +2,7 @@ require 'test_helper'
 
 module Shipit
   module Api
-    class CcmenuControllerTest < ActionController::TestCase
+    class CCMenuControllerTest < ActionController::TestCase
       setup do
         authenticate!
         @stack = shipit_stacks(:shipit)

--- a/test/controllers/ccmenu_controller_test.rb
+++ b/test/controllers/ccmenu_controller_test.rb
@@ -22,11 +22,12 @@ module Shipit
       end
     end
 
-    test ":fetch url includes api token as username" do
+    test ":fetch url includes api token on query string" do
       get :fetch, params: {stack_id: @stack.to_param}
       data = JSON.parse(response.body)
       client = ApiClient.last
-      assert_equal client.authentication_token, URI(data['ccmenu_url']).user
+      query = Rack::Utils.parse_nested_query(URI(data['ccmenu_url']).query)
+      assert_equal client.authentication_token, query['token']
     end
   end
 end

--- a/test/controllers/ccmenu_controller_test.rb
+++ b/test/controllers/ccmenu_controller_test.rb
@@ -2,7 +2,7 @@ require 'uri'
 require 'test_helper'
 
 module Shipit
-  class CcmenuUrlControllerTest < ActionController::TestCase
+  class CCMenuUrlControllerTest < ActionController::TestCase
     setup do
       @stack = shipit_stacks(:shipit)
       @user = shipit_users(:walrus)

--- a/test/controllers/ccmenu_controller_test.rb
+++ b/test/controllers/ccmenu_controller_test.rb
@@ -1,0 +1,32 @@
+require 'uri'
+require 'test_helper'
+
+module Shipit
+  class CcmenuUrlControllerTest < ActionController::TestCase
+    setup do
+      @stack = shipit_stacks(:shipit)
+      @user = shipit_users(:walrus)
+      session[:user_id] = @user.id
+    end
+
+    test ":fetch returns ok with json" do
+      get :fetch, params: {stack_id: @stack.to_param}
+      assert_response :ok
+      data = JSON.parse(response.body)
+      assert_includes data, 'ccmenu_url'
+    end
+
+    test ":fetch creates a read only api client" do
+      assert_difference 'ApiClient.count' do
+        get :fetch, params: {stack_id: @stack.to_param}
+      end
+    end
+
+    test ":fetch url includes api token as username" do
+      get :fetch, params: {stack_id: @stack.to_param}
+      data = JSON.parse(response.body)
+      client = ApiClient.last
+      assert_equal client.authentication_token, URI(data['ccmenu_url']).user
+    end
+  end
+end


### PR DESCRIPTION
Adds a CCMenu/CCTray endpoint, as described in #347. This is my first contribution to shipit and to a rails project at all I think, so there's likely things wrong here - some things to check:

* Is using a named `APIClient` the correct approach here? It does implement everything needed so it felt like a sin to create something that would be so similar. 
* Lazily creating the client in the stack controller doesn't feel correct but it will prevent creating a bunch of tokens unnecessarily - I imagine most people never look at the settings nor would use the endpoint.
* Should the whole thing be put behind a feature flag, so administrators can disable access?

Something else to note - I tested this with CCMenu myself and noticed that the default poll interval was 5 seconds, which I think is pretty aggressive and it wouldn't take long before a few users checking a few stacks might cause a problem, we should document and discourage that default somewhere.

@Shopify/pipeline for review please.