### PR TITLE
Fix CCMenu on stacks with no deploys

### DIFF
--- a/app/controllers/shipit/api/ccmenu_controller.rb
+++ b/app/controllers/shipit/api/ccmenu_controller.rb
@@ -11,6 +11,10 @@ module Shipit
         def ended_at
           Time.now.utc
         end
+
+        def running?
+          false
+        end
       end
 
       def show

--- a/test/controllers/api/ccmenu_controller_test.rb
+++ b/test/controllers/api/ccmenu_controller_test.rb
@@ -42,6 +42,12 @@ module Shipit
         assert_payload 'lastBuildStatus', 'Failure'
       end
 
+      test "stacks with no deploys render correctly" do
+        stack = Stack.create!(repo_owner: 'foo', repo_name: 'bar')
+        get :show, params: {stack_id: stack.to_param}
+        assert_payload 'lastBuildStatus', 'Success'
+      end
+
       private
 
       def get_project_from_xml(xml)


### PR DESCRIPTION
I accidentally deleted the test for this during previous refactors :(

@Shopify/pipeline 