### PR TITLE
Synchronously increment `undeployed_commits_count` on merge

### DIFF
--- a/app/models/shipit/pull_request.rb
+++ b/app/models/shipit/pull_request.rb
@@ -95,6 +95,10 @@ module Shipit
       before_transition any => :pending do |pr|
         pr.revalidated_at = Time.now.utc
       end
+
+      before_transition %i(pending) => :merged do |pr|
+        Stack.increment_counter(:undeployed_commits_count, pr.stack_id)
+      end
     end
 
     def self.schedule_merges

--- a/test/models/pull_request_test.rb
+++ b/test/models/pull_request_test.rb
@@ -200,5 +200,15 @@ module Shipit
       Shipit.github_api.expects(:delete_branch).never.returns(false)
       assert_equal true, @pr.merge!
     end
+
+    test "#merge! increments undeployed_commits_count" do
+      Shipit.github_api.expects(:merge_pull_request).once.returns(true)
+      Shipit.github_api.expects(:pull_requests).once.returns([])
+      Shipit.github_api.expects(:delete_branch).once.returns(true)
+      assert_difference '@stack.undeployed_commits_count' do
+        @pr.merge!
+        @stack.reload
+      end
+    end
   end
 end


### PR DESCRIPTION
Prevents `undeployed_commits_count` becoming stale.

/cc @byroot 