### PR TITLE
Don't automatically deploy a commit without it's revert

### DIFF
--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -36,6 +36,11 @@ module Shipit
 
     delegate :broadcast_update, :filter_deploy_envs, to: :stack
 
+    def reload(*args)
+      @commits = @commits_since = @default_since_commit_id = nil
+      super
+    end
+
     def build_rollback(user = nil, env: nil)
       Rollback.new(
         user_id: user.try!(:id),
@@ -134,6 +139,27 @@ module Shipit
 
     def confirmed?
       confirmations.abs >= CONFIRMATIONS_REQUIRED
+    end
+
+    def too_dangerous?
+      revert_being_left_behind?
+    end
+
+    def revert_being_left_behind?
+      return if commits_since.empty?
+
+      commits_since.each do |commit|
+        matches = commit.message.match(/^\s*Revert "(.*)"\s*$/)
+        next unless matches
+        parent_message = matches[1]
+
+        commits.each do |other_commit|
+          next if commit == other_commit
+          return true if parent_message == other_commit.message
+        end
+      end
+
+      false
     end
 
     private

--- a/test/helpers/commits_helper.rb
+++ b/test/helpers/commits_helper.rb
@@ -1,0 +1,21 @@
+module CommitsHelper
+  def create_revert(parent_commit, pr: false)
+    message = []
+
+    if pr
+      message << "Merge pull request #12345 from Shopify/revert-that-other-thing"
+      message << ""
+    end
+
+    message << "Revert \"#{parent_commit.message}\""
+
+    parent_commit.stack.commits.create!(
+      author: parent_commit.author,
+      committer: parent_commit.committer,
+      sha: SecureRandom.hex,
+      authored_at: parent_commit.authored_at + 1.minute,
+      committed_at: parent_commit.committed_at + 1.minute,
+      message: message.join("\n"),
+    )
+  end
+end

--- a/test/models/deploys_test.rb
+++ b/test/models/deploys_test.rb
@@ -444,6 +444,18 @@ module Shipit
       assert_predicate @deploy, :alive?
     end
 
+    test "#too_dangerous? returns true if list of undeployed commits contains a commit and it's revert" do
+      refute @deploy.too_dangerous?
+      create_revert(@deploy.commits.last)
+      assert @deploy.reload.too_dangerous?
+    end
+
+    test "#too_dangerous? returns true if list of undeployed commits contains a commit of a PR that reverts it" do
+      refute @deploy.too_dangerous?
+      create_revert(@deploy.commits.last, pr: true)
+      assert @deploy.reload.too_dangerous?
+    end
+
     private
 
     def expect_event(deploy)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -39,6 +39,7 @@ class ActiveSupport::TestCase
   include ApiHelper
   include HooksHelper
   include ActiveJob::TestHelper
+  include CommitsHelper
 
   setup do
     @routes = Shipit::Engine.routes


### PR DESCRIPTION
This PR tries to ensure that a commit that has been reverted can only be automatically deployed if the deploy contains the revert as well.

@tjoyal @byroot @daniellaniyo