### PR TITLE
Update rollback confirmation text

### DIFF
--- a/app/views/shipit/deploys/rollback.html.erb
+++ b/app/views/shipit/deploys/rollback.html.erb
@@ -11,7 +11,7 @@
 
   <section>
     <header class="section-header">
-      <h2>Commits included in this rollback</h2>
+      <h2>Commits that will be rolled back</h2>
     </header>
 
     <p><%= link_to_github_deploy(@rollback) %></p>


### PR DESCRIPTION
Fix #670

Some clarity in a moment of panic: Communicate that the commits will no longer be "included" on the servers after the operation.