### PR TITLE
Use default ENV variables when a task is triggered from API

### DIFF
--- a/app/models/shipit/deploy_spec.rb
+++ b/app/models/shipit/deploy_spec.rb
@@ -119,10 +119,6 @@ module Shipit
       EnvironmentVariables.with(env).permit(deploy_variables)
     end
 
-    def filter_task_envs(id, env)
-      find_task_definition(id).filter_envs(env)
-    end
-
     def review_checklist
       (config('review', 'checklist') || discover_review_checklist || []).map(&:strip).select(&:present?)
     end

--- a/app/models/shipit/task_definition.rb
+++ b/app/models/shipit/task_definition.rb
@@ -49,7 +49,7 @@ module Shipit
     end
 
     def variables_with_defaults
-      @variables_with_defaults ||= variables.select { |v| v.default.present? }
+      @variables_with_defaults ||= variables.select(&:default_provided?)
     end
 
     private

--- a/app/models/shipit/task_definition.rb
+++ b/app/models/shipit/task_definition.rb
@@ -48,6 +48,10 @@ module Shipit
       EnvironmentVariables.with(env).permit(variables)
     end
 
+    def variables_with_defaults
+      @variables_with_defaults ||= variables.select { |v| v.default.present? }
+    end
+
     private
 
     def task_variables(config_variables)

--- a/app/models/shipit/variable_definition.rb
+++ b/app/models/shipit/variable_definition.rb
@@ -6,7 +6,12 @@ module Shipit
       @name = attributes.fetch('name')
       @title = attributes['title']
       @default = attributes['default'].to_s
+      @default_provided = attributes.key?('default')
       @select = attributes['select'].presence
+    end
+
+    def default_provided?
+      @default_provided
     end
 
     def to_h

--- a/test/controllers/api/tasks_controller_test.rb
+++ b/test/controllers/api/tasks_controller_test.rb
@@ -24,11 +24,22 @@ module Shipit
         assert_json 'id', task.id
       end
 
+      test "#trigger returns 404 with unknown task" do
+        post :trigger, params: {stack_id: @stack.to_param, task_name: 'shave_the_yak'}
+        assert_response :not_found
+      end
+
       test "#trigger triggers a custom task" do
         post :trigger, params: {stack_id: @stack.to_param, task_name: 'restart'}
         assert_response :accepted
         assert_json 'type', 'task'
         assert_json 'status', 'pending'
+
+        expected_env = {
+          "FOO" => "1",
+          "BAR" => "0",
+        }
+        assert_equal expected_env, Shipit::Task.last.env
       end
 
       test "#trigger refuses to trigger a task with tasks not whitelisted" do
@@ -44,6 +55,26 @@ module Shipit
         assert_response :accepted
         assert_json 'type', 'task'
         assert_json 'status', 'pending'
+
+        expected_env = {
+          "FOO" => "bar",
+          "BAR" => "0",
+        }
+        assert_equal expected_env, Shipit::Task.last.env
+      end
+
+      test "#trigger triggers a task with explicitly passed and default variables" do
+        env = {'WALRUS' => 'overridden value'}
+        post :trigger, params: {stack_id: @stack.to_param, task_name: 'restart', env: env}
+        assert_response :accepted
+
+        # FOO and BAR are variables with a default value
+        expected_env = {
+          "FOO" => "1",
+          "BAR" => "0",
+          "WALRUS" => "overridden value",
+        }
+        assert_equal expected_env, Shipit::Task.last.env
       end
 
       test "#trigger returns a 404 when the task doesn't exist" do

--- a/test/fixtures/shipit/stacks.yml
+++ b/test/fixtures/shipit/stacks.yml
@@ -26,7 +26,8 @@ shipit:
           "description": "Restart app and job servers",
           "variables": [
             {"name": "FOO", "title": "Set to 0 to foo", "default": 1},
-            {"name": "BAR", "title": "Set to 1 to bar", "default": 0}
+            {"name": "BAR", "title": "Set to 1 to bar", "default": 0},
+            {"name": "WALRUS", "title": "Walrus without a default value"}
           ],
           "steps": [
             "cap $ENVIRONMENT deploy:restart"

--- a/test/models/task_definitions_test.rb
+++ b/test/models/task_definitions_test.rb
@@ -12,6 +12,8 @@ module Shipit
         'variables' => [
           {'name' => 'FOO', 'title' => 'Set to 0 to foo', 'default' => '1'},
           {'name' => 'BAR', 'title' => 'Set to 1 to bar', 'default' => '0'},
+          {'name' => 'WALRUS', 'title' => 'Use with caution', 'default' => ' '},
+          {'name' => 'NODEFAULT', 'title' => 'Variable without default'},
         ],
       )
     end
@@ -25,6 +27,11 @@ module Shipit
       assert_nil TaskDefinition.dump(nil)
     end
 
+    test "#variables" do
+      assert_equal 4, @definition.variables.size
+      assert_equal 3, @definition.variables_with_defaults.size
+    end
+
     test "serialization works" do
       as_json = {
         id: 'restart',
@@ -36,6 +43,8 @@ module Shipit
         variables: [
           {'name' => 'FOO', 'title' => 'Set to 0 to foo', 'default' => '1', 'select' => nil},
           {'name' => 'BAR', 'title' => 'Set to 1 to bar', 'default' => '0', 'select' => nil},
+          {'name' => 'WALRUS', 'title' => 'Use with caution', 'default' => ' ', 'select' => nil},
+          {'name' => 'NODEFAULT', 'title' => 'Variable without default', 'default' => '', 'select' => nil},
         ],
       }
       assert_equal as_json, TaskDefinition.load(TaskDefinition.dump(@definition)).as_json

--- a/test/unit/variable_definition_test.rb
+++ b/test/unit/variable_definition_test.rb
@@ -18,6 +18,7 @@ module Shipit
       assert_equal "Variable title", subject.title
       assert_equal "Variable default", subject.default
       assert_nil subject.select
+      assert subject.default_provided?
     end
 
     test "#initialize name is required" do
@@ -46,6 +47,15 @@ module Shipit
       subject = Shipit::VariableDefinition.new(@attributes)
 
       assert_nil subject.select
+    end
+
+    test "#default_provided?" do
+      attributes = {
+        "name" => "Variable name",
+        "title" => "Variable title",
+      }
+      subject = Shipit::VariableDefinition.new(attributes)
+      refute subject.default_provided?
     end
 
     test "#to_h returns hash version" do


### PR DESCRIPTION
I've noticed that when the restart task is triggered by API with a `spy` command, the deploy script doesn't get the default ENV variables, unlike when the task is triggered from the browser.

IMO, when you declare something like:

```
tasks:
  restart:
    action: "Restart Application"
    steps:
      - bin/cap $ENVIRONMENT deploy:restart --trace
    variables:
      -
        name: MYVARIABLE
        title: blahblah
        default: "1"
```

You rely on the fact that `MYVARIABLE` is always present, not only when the task is triggered from the web.

This PR fixes the edge case and extends the test coverage.

review @DazWorrall @casperisfine