### PR TITLE
Handle a PR being closed/merged upstream

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Pull requests in the merge queue which are closed on Github will be marked as merged/cancelled as appropriate.
+
 # 0.16.0
 
 * Add a CCMenu compatible API.

--- a/app/jobs/shipit/merge_pull_requests_job.rb
+++ b/app/jobs/shipit/merge_pull_requests_job.rb
@@ -8,6 +8,9 @@ module Shipit
       pull_requests.each do |pull_request|
         pull_request.refresh!
         pull_request.reject_unless_mergeable!
+        if pull_request.closed?
+          pull_request.merged_upstream? ? pull_request.complete! : pull_request.cancel!
+        end
       end
 
       return false unless stack.allows_merges?

--- a/app/models/shipit/pull_request.rb
+++ b/app/models/shipit/pull_request.rb
@@ -209,6 +209,14 @@ module Shipit
       RefreshPullRequestJob.perform_later(self)
     end
 
+    def closed?
+      state == "closed"
+    end
+
+    def merged_upstream?
+      closed? && merged_at
+    end
+
     def refresh!
       update!(github_pull_request: Shipit.github_api.pull_request(stack.github_repo_name, number))
       head.refresh_statuses!
@@ -225,6 +233,7 @@ module Shipit
       self.deletions = github_pull_request.deletions
       self.branch = github_pull_request.head.ref
       self.head = find_or_create_commit_from_github_by_sha!(github_pull_request.head.sha, detached: true)
+      self.merged_at = github_pull_request.merged_at
     end
 
     def merge_message

--- a/db/migrate/20170310164315_add_merged_at_on_pull_requests.rb
+++ b/db/migrate/20170310164315_add_merged_at_on_pull_requests.rb
@@ -1,0 +1,9 @@
+class AddMergedAtOnPullRequests < ActiveRecord::Migration[5.0]
+  def up
+    add_column :pull_requests, :merged_at, :datetime
+  end
+
+  def down
+    remove_column :pull_requests, :merged_at
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170221130336) do
+ActiveRecord::Schema.define(version: 20170310164315) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text     "permissions", limit: 65535
@@ -145,6 +145,7 @@ ActiveRecord::Schema.define(version: 20170221130336) do
     t.datetime "updated_at",                                     null: false
     t.string   "branch"
     t.datetime "revalidated_at"
+    t.datetime "merged_at"
     t.index ["head_id"], name: "index_pull_requests_on_head_id"
     t.index ["merge_requested_by_id"], name: "index_pull_requests_on_merge_requested_by_id"
     t.index ["stack_id", "github_id"], name: "index_pull_requests_on_stack_id_and_github_id", unique: true

--- a/test/fixtures/shipit/pull_requests.yml
+++ b/test/fixtures/shipit/pull_requests.yml
@@ -54,3 +54,36 @@ shipit_pending_not_mergeable_yet:
   mergeable: null
   additions: 23
   deletions: 43
+
+shipit_pending_closed:
+  stack: shipit
+  number: 65
+  merge_status: pending
+  merge_requested_by: walrus
+  merge_requested_at: <%= 3.minute.ago.to_s(:db) %>
+  revalidated_at: <%= 3.minute.ago.to_s(:db) %>
+  github_id: 43243243243243
+  api_url: https://api.github.com/repos/shopify/shipit-engine/pulls/65
+  state: closed
+  branch: feature-64
+  head_id: 8
+  mergeable: null
+  additions: 23
+  deletions: 43
+
+shipit_pending_merged:
+  stack: shipit
+  number: 66
+  merge_status: pending
+  merge_requested_by: walrus
+  merge_requested_at: <%= 3.minute.ago.to_s(:db) %>
+  merged_at: <%= 2.minute.ago.to_s(:db) %>
+  revalidated_at: <%= 3.minute.ago.to_s(:db) %>
+  github_id: 43243243243232
+  api_url: https://api.github.com/repos/shopify/shipit-engine/pulls/66
+  state: closed
+  branch: feature-64
+  head_id: 8
+  mergeable: null
+  additions: 23
+  deletions: 43

--- a/test/models/pull_request_test.rb
+++ b/test/models/pull_request_test.rb
@@ -18,7 +18,7 @@ module Shipit
 
     test ".request_merge! only track pull requests once" do
       assert_difference -> { PullRequest.count }, +1 do
-        5.times { PullRequest.request_merge!(@stack, 65, @user) }
+        5.times { PullRequest.request_merge!(@stack, 999, @user) }
       end
     end
 
@@ -77,6 +77,7 @@ module Shipit
           mergeable: true,
           additions: 24,
           deletions: 5,
+          merged_at: nil,
           head: stub(
             ref: 'super-branch',
             sha: head_sha,


### PR DESCRIPTION
If a PR gets closed manually on Github, the merge request queue would get stuck in a loop when it reached that PR. This fixes that by marking the PR as merged or cancelled as appropriate, to determine that we need to store the 'merged_at' field from the Github api, so there's a migration required.

Closes #665 and Shopify/shipit#162

/r:  @Shopify/pipeline 