### PR TITLE
Expose last deployed time via stack endpoint

### DIFF
--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -183,7 +183,7 @@ module Shipit
     end
 
     def update_last_deploy_time
-      stack.update(deployed_at: updated_at)
+      stack.update(last_deployed_at: ended_at)
     end
   end
 end

--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -10,6 +10,7 @@ module Shipit
       after_transition to: :success, do: :update_undeployed_commits_count
       after_transition to: :aborted, do: :trigger_revert_if_required
       after_transition any => any, do: :update_commit_deployments
+      after_transition any => any, do: :update_last_deploy_time
     end
 
     has_many :commit_deployments, dependent: :destroy, inverse_of: :task, foreign_key: :task_id do
@@ -179,6 +180,10 @@ module Shipit
 
     def update_undeployed_commits_count
       stack.update_undeployed_commits_count(until_commit)
+    end
+
+    def update_last_deploy_time
+      stack.update(deployed_at: updated_at)
     end
   end
 end

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -379,8 +379,8 @@ module Shipit
 
     def update_undeployed_commits_count(after_commit = nil)
       after_commit ||= last_deployed_commit
-      undeployed_commits = commits.reachable.newer_than(after_commit).select('count(*) as count')
-      self.class.where(id: id).update_all("undeployed_commits_count = (#{undeployed_commits.to_sql})")
+      undeployed_commits = commits.reachable.newer_than(after_commit).count
+      update(undeployed_commits_count: undeployed_commits)
     end
 
     def broadcast_update

--- a/app/serializers/shipit/stack_serializer.rb
+++ b/app/serializers/shipit/stack_serializer.rb
@@ -5,7 +5,7 @@ module Shipit
     has_one :lock_author
     attributes :id, :repo_owner, :repo_name, :environment, :html_url, :url, :tasks_url, :deploy_url, :pull_requests_url,
                :deploy_spec, :undeployed_commits_count, :is_locked, :lock_reason, :continuous_deployment, :created_at,
-               :updated_at, :locked_since
+               :updated_at, :locked_since, :last_deployed_at
 
     def url
       api_stack_url(object)

--- a/db/migrate/20170314145604_add_deployed_at_to_stack.rb
+++ b/db/migrate/20170314145604_add_deployed_at_to_stack.rb
@@ -1,9 +1,0 @@
-class AddDeployedAtToStack < ActiveRecord::Migration[5.0]
-  def up
-    add_column :stacks, :deployed_at, :datetime
-  end
-
-  def down
-    remove_column :stacks, :deployed_at
-  end
-end

--- a/db/migrate/20170314145604_add_deployed_at_to_stack.rb
+++ b/db/migrate/20170314145604_add_deployed_at_to_stack.rb
@@ -1,0 +1,9 @@
+class AddDeployedAtToStack < ActiveRecord::Migration[5.0]
+  def up
+    add_column :stacks, :deployed_at, :datetime
+  end
+
+  def down
+    remove_column :stacks, :deployed_at
+  end
+end

--- a/db/migrate/20170314145604_add_last_deployed_at_to_stack.rb
+++ b/db/migrate/20170314145604_add_last_deployed_at_to_stack.rb
@@ -1,0 +1,9 @@
+class AddLastDeployedAtToStack < ActiveRecord::Migration[5.0]
+  def up
+    add_column :stacks, :last_deployed_at, :datetime
+  end
+
+  def down
+    remove_column :stacks, :last_deployed_at
+  end
+end

--- a/test/controllers/api/stacks_controller_test.rb
+++ b/test/controllers/api/stacks_controller_test.rb
@@ -101,6 +101,12 @@ module Shipit
         assert_response :ok
         assert_json 'id', @stack.id
       end
+
+      test "#show returns last_deployed_at column for stack" do
+        get :show, params: {id: @stack.to_param}
+        assert_response :ok
+        assert_json 'last_deployed_at', @stack.last_deployed_at
+      end
     end
   end
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170310164315) do
+ActiveRecord::Schema.define(version: 20170314145604) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text     "permissions", limit: 65535
@@ -174,6 +174,7 @@ ActiveRecord::Schema.define(version: 20170310164315) do
     t.datetime "continuous_delivery_delayed_since"
     t.datetime "locked_since"
     t.boolean  "merge_queue_enabled",                             default: false,        null: false
+    t.datetime "deployed_at"
     t.index ["repo_owner", "repo_name", "environment"], name: "stack_unicity", unique: true
   end
 

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -174,7 +174,7 @@ ActiveRecord::Schema.define(version: 20170314145604) do
     t.datetime "continuous_delivery_delayed_since"
     t.datetime "locked_since"
     t.boolean  "merge_queue_enabled",                             default: false,        null: false
-    t.datetime "deployed_at"
+    t.datetime "last_deployed_at"
     t.index ["repo_owner", "repo_name", "environment"], name: "stack_unicity", unique: true
   end
 

--- a/test/fixtures/shipit/stacks.yml
+++ b/test/fixtures/shipit/stacks.yml
@@ -50,6 +50,7 @@ shipit:
         "allow_failures": ["ci/ok_to_fail"]
       }
     }
+  deployed_at: <%= 8.days.ago.to_s(:db) %>
   updated_at: <%= 8.days.ago.to_s(:db) %>
 
 cyclimse:
@@ -83,6 +84,7 @@ cyclimse:
         }
       }
     }
+  deployed_at: <%= 8.days.ago.to_s(:db) %>
   updated_at: <%= 8.days.ago.to_s(:db) %>
 
 undeployed_stack:

--- a/test/fixtures/shipit/stacks.yml
+++ b/test/fixtures/shipit/stacks.yml
@@ -50,7 +50,7 @@ shipit:
         "allow_failures": ["ci/ok_to_fail"]
       }
     }
-  deployed_at: <%= 8.days.ago.to_s(:db) %>
+  last_deployed_at: <%= 8.days.ago.to_s(:db) %>
   updated_at: <%= 8.days.ago.to_s(:db) %>
 
 cyclimse:
@@ -84,7 +84,7 @@ cyclimse:
         }
       }
     }
-  deployed_at: <%= 8.days.ago.to_s(:db) %>
+  last_deployed_at: <%= 8.days.ago.to_s(:db) %>
   updated_at: <%= 8.days.ago.to_s(:db) %>
 
 undeployed_stack:

--- a/test/models/commits_test.rb
+++ b/test/models/commits_test.rb
@@ -6,6 +6,7 @@ module Shipit
       @stack = shipit_stacks(:shipit)
       @pr = @stack.commits.new
       @pr.message = "Merge pull request #31 from Shopify/improve-polling\n\nSeveral improvements to polling"
+      @stack.reload
       @commit = shipit_commits(:first)
     end
 
@@ -211,7 +212,7 @@ module Shipit
 
     test "#creating a commit for new stack updates deployed_at to nil" do
       walrus = shipit_users(:walrus)
-      stack = stacks(:undeployed_stack)
+      stack = shipit_stacks(:undeployed_stack)
       stack.commits.create!(
         author: walrus,
         committer: walrus,

--- a/test/models/commits_test.rb
+++ b/test/models/commits_test.rb
@@ -210,7 +210,7 @@ module Shipit
       end
     end
 
-    test "#creating a commit for new stack updates deployed_at to nil" do
+    test "#creating a commit for new stack updates last_deployed_at to nil" do
       walrus = shipit_users(:walrus)
       stack = shipit_stacks(:undeployed_stack)
       stack.commits.create!(
@@ -222,7 +222,7 @@ module Shipit
         message: "more fish!",
       )
       stack.reload
-      assert_nil stack.deployed_at
+      assert_nil stack.last_deployed_at
     end
 
     test ".by_sha! raises if the sha prefix matches multiple commits" do

--- a/test/models/commits_test.rb
+++ b/test/models/commits_test.rb
@@ -209,6 +209,21 @@ module Shipit
       end
     end
 
+    test "#creating a commit for new stack updates deployed_at to nil" do
+      walrus = shipit_users(:walrus)
+      stack = stacks(:undeployed_stack)
+      stack.commits.create!(
+        author: walrus,
+        committer: walrus,
+        sha: "ab12",
+        authored_at: DateTime.now,
+        committed_at: DateTime.now,
+        message: "more fish!",
+      )
+      stack.reload
+      assert_nil stack.deployed_at
+    end
+
     test ".by_sha! raises if the sha prefix matches multiple commits" do
       clone = Commit.new(@commit.attributes.except('id'))
       clone.sha[8..-1] = 'abc12'

--- a/test/models/deploys_test.rb
+++ b/test/models/deploys_test.rb
@@ -229,7 +229,7 @@ module Shipit
       @deploy = shipit_deploys(:shipit_running)
       @deploy.complete!
       @stack.reload
-      assert_in_delta @deploy.updated_at, @stack.deployed_at, 1
+      assert_in_delta @deploy.ended_at, @stack.last_deployed_at, 1
     end
 
     test "transitioning to success schedule a MergePullRequests job" do

--- a/test/models/deploys_test.rb
+++ b/test/models/deploys_test.rb
@@ -225,10 +225,11 @@ module Shipit
       end
     end
 
-    test "transitions to any state updates last deploy time to shipit record" do
+    test "transitions to any state updates last deploy time to stack record" do
       @deploy = shipit_deploys(:shipit_running)
       @deploy.complete!
-      assert_equal @deploy.updated_at, @stack.deployed_at
+      @stack.reload
+      assert_in_delta @deploy.updated_at, @stack.deployed_at, 1
     end
 
     test "transitioning to success schedule a MergePullRequests job" do

--- a/test/models/deploys_test.rb
+++ b/test/models/deploys_test.rb
@@ -225,6 +225,12 @@ module Shipit
       end
     end
 
+    test "transitions to any state updates last deploy time to shipit record" do
+      @deploy = shipit_deploys(:shipit_running)
+      @deploy.complete!
+      assert_equal @deploy.updated_at, @stack.deployed_at
+    end
+
     test "transitioning to success schedule a MergePullRequests job" do
       @deploy = shipit_deploys(:shipit_running)
       assert_enqueued_with(job: MergePullRequestsJob, args: [@deploy.stack]) do


### PR DESCRIPTION
Shipit api doesn't provide last deployment time through stack endpoint. This PR exposes last deployed time for each stack. This time would be useful in [services-db](https://github.com/Shopify/services-db/pull/871) to keep track of actively deployed services. Updated minor piece of unrelated code in stack mode and added `@stack.reload` in commit test since `@stack.commits.new` is going to instantiate new commit which doesn't have any foreign key data assigned.

@byroot @wvanbergen 