### PR TITLE
Implement locking of commits

### DIFF
--- a/app/assets/javascripts/shipit/stacks.js.coffee
+++ b/app/assets/javascripts/shipit/stacks.js.coffee
@@ -1,3 +1,13 @@
+$(document).on 'click', '.commit-lock a', (event) ->
+  event.preventDefault()
+  $commit = $(event.target).closest('.commit')
+  $link = $(event.target).closest('a')
+
+  locked = $commit.hasClass('locked')
+  $commit.toggleClass('locked')
+
+  $.ajax($link.attr('href'), method: 'PATCH', data: {commit: {locked: !locked}})
+
 jQuery ($) ->
   displayIgnoreCiMessage = ->
     ignoreCiMessage = $(".ignoring-ci")

--- a/app/assets/stylesheets/_base/_base.scss
+++ b/app/assets/stylesheets/_base/_base.scss
@@ -106,7 +106,7 @@ a {
   text-decoration: none;
   cursor: pointer;
   color: $blue;
-    &.subdued { color: #999; }
+    &.subdued { color: $grey; }
     &.subdued:hover { color: $blue; }
 }
 

--- a/app/assets/stylesheets/_base/_buttons.scss
+++ b/app/assets/stylesheets/_base/_buttons.scss
@@ -28,7 +28,7 @@
 }
 
 .btn--disabled {
-  color: #999;
+  color: $grey;
   background-color: #fafafa;
   cursor: default;
 }
@@ -38,7 +38,7 @@
   border: none;
   background-color: $bright-red;
   &.btn-disabled {
-    color: #999;
+    color: $grey;
     background-color: $light-red;
   }
 }
@@ -47,7 +47,7 @@
   color: #fff;
   background-color: $orange;
   &.btn-disabled {
-    color: #999;
+    color: $grey;
     background-color: $light-orange;
   }
 }

--- a/app/assets/stylesheets/_base/_colors.scss
+++ b/app/assets/stylesheets/_base/_colors.scss
@@ -15,3 +15,4 @@ $orange: #FFAD4C;
 $light-orange: #ffebcc;
 $slate: #2E343A;
 $terminal-black: #272C30;
+$grey: #999;

--- a/app/assets/stylesheets/_pages/_commits.scss
+++ b/app/assets/stylesheets/_pages/_commits.scss
@@ -63,7 +63,7 @@
 }
 
 .commit-author__name__username {
-  color: #999;
+  color: $grey;
 }
 
 
@@ -98,9 +98,30 @@
   color: $blue;
 }
 
+.commit-lock {
+  display: inline-block;
+  .icon {
+    background-color: #ddd;
+  }
+
+  &:hover .icon {
+    background-color: darken(#ddd, 20%);
+  }
+}
+
+.commit.locked .commit-lock {
+  .icon {
+    background-color: $bright-red;
+  }
+
+  &:hover .icon {
+    background-color: darken($bright-red, 20%);
+  }
+}
+
 .commit-meta, .pr-meta {
   font-size: 0.8em;
-  color: #999;
+  color: $grey;
   margin: 0;
 
   @include media(desktop) {
@@ -133,6 +154,11 @@
 
   @include media(desktop) {
     margin-left: 1rem;
+    min-width: 10rem;
+
+    .btn {
+      float: right;
+    }
   }
 }
 
@@ -285,5 +311,5 @@
 
 .commit-summary__sha {
   font-size: 0.875rem;
-  color: #999;
+  color: $grey;
 }

--- a/app/assets/stylesheets/_structure/_layout.scss
+++ b/app/assets/stylesheets/_structure/_layout.scss
@@ -16,7 +16,7 @@
 .header {
   border-bottom: 1px solid #e5e5e5;
   background-color: #fff;
-  color: #999;
+  color: $grey;
 }
 
 .header__inner {
@@ -44,7 +44,7 @@
   top: .5rem;
   right: 1rem;
   font-size: 12px;
-  color: #999;
+  color: $grey;
 }
 
 

--- a/app/assets/stylesheets/_structure/_main.scss
+++ b/app/assets/stylesheets/_structure/_main.scss
@@ -40,7 +40,7 @@
         & > p {
           margin: 0;
           padding: .7rem 0;
-          color: #999;
+          color: $grey;
           font-size: .875rem;
             .repo-name { font-weight: 500; color: #777; }
         }
@@ -140,7 +140,7 @@ pre {
 }
 
 .less-important {
-    color: #999;
+    color: $grey;
     margin-bottom: 0em;
     margin-top: 1em;
     p {

--- a/app/controllers/shipit/commits_controller.rb
+++ b/app/controllers/shipit/commits_controller.rb
@@ -1,0 +1,18 @@
+module Shipit
+  class CommitsController < ShipitController
+    def update
+      commit.update(params.require(:commit).permit(:locked))
+      head :ok
+    end
+
+    private
+
+    def commit
+      @commit ||= stack.commits.find(params[:id])
+    end
+
+    def stack
+      @stack ||= Stack.from_param!(params[:stack_id])
+    end
+  end
+end

--- a/app/models/shipit/commit.rb
+++ b/app/models/shipit/commit.rb
@@ -106,7 +106,7 @@ module Shipit
     delegate :pending?, :success?, :error?, :failure?, :state, to: :status
 
     def deployable?
-      success? || stack.ignore_ci?
+      !locked? && (success? || stack.ignore_ci?)
     end
 
     def children

--- a/app/models/shipit/undeployed_commit.rb
+++ b/app/models/shipit/undeployed_commit.rb
@@ -11,7 +11,7 @@ module Shipit
       state = deployable? ? 'allowed' : status.state
       unless bypass_safeties
         state = 'deploying' if stack.active_task?
-        state = 'locked' if stack.locked?
+        state = 'locked' if locked?
       end
       state
     end
@@ -19,7 +19,6 @@ module Shipit
     def redeploy_state(bypass_safeties = false)
       state = 'allowed'
       unless bypass_safeties
-        state = 'locked' if stack.locked?
         state = 'deploying' if stack.active_task?
       end
       state

--- a/app/views/shipit/commits/_commit.html.erb
+++ b/app/views/shipit/commits/_commit.html.erb
@@ -1,4 +1,4 @@
-<li class="commit" id="commit-<%= commit.id %>">
+<li class="commit <%= 'locked' if commit.locked? %>" id="commit-<%= commit.id %>">
   <%= render 'shipit/shared/author', author: commit.author %>
   <%= render commit.status %>
   <div class="commit-details">
@@ -13,6 +13,11 @@
     <p class="commit-meta">
       <%= timeago_tag(commit.committed_at, force: true) %>
     </p>
+  </div>
+  <div class="commit-lock">
+    <%= link_to stack_commit_path(commit.stack, commit) do %>
+      <i class="icon icon--lock"></i>
+    <% end %>
   </div>
   <div class="commit-actions">
     <%= deploy_button(commit) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -24,17 +24,17 @@ en:
     hint:
       max_commits: It is recommended not to deploy more than %{maximum} commits at once.
     caption:
-      pending: CI Pending...
-      failure: CI Failure
-      error: CI Error
+      pending: Pending CI
+      failure: Failing CI
+      error: Failing CI
       unknown: Not Run
       locked: Locked
-      deploying: A Deploy is in Progress...
+      deploying: A Deploy is in Progress
       allowed: Deploy
       missing: Missing CI
   redeploy_button:
     caption:
-      deploying: A Deploy is in Progress...
+      deploying: A Deploy is in Progress
       allowed: Redeploy
       locked: Locked
   deploy_spec:

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,6 +73,7 @@ Shipit::Engine.routes.draw do
     get '/commit/:sha/checks/tail' => 'commit_checks#tail', as: :tail_commit_checks, defaults: {format: :json}
 
     resources :rollbacks, only: %i(create)
+    resources :commits, only: %i(update)
     resources :tasks, only: %i(show) do
       collection do
         get '' => 'tasks#index', as: :index

--- a/db/migrate/20170320124156_add_locked_to_commits.rb
+++ b/db/migrate/20170320124156_add_locked_to_commits.rb
@@ -1,0 +1,5 @@
+class AddLockedToCommits < ActiveRecord::Migration[5.0]
+  def change
+    add_column :commits, :locked, :boolean, default: false, null: false
+  end
+end

--- a/test/controllers/commits_controller_test.rb
+++ b/test/controllers/commits_controller_test.rb
@@ -1,0 +1,18 @@
+require 'test_helper'
+
+module Shipit
+  class CommitsControllerTest < ActionController::TestCase
+    setup do
+      @stack = shipit_stacks(:shipit)
+      @commit = shipit_commits(:first)
+      session[:user_id] = shipit_users(:walrus).id
+    end
+
+    test "#update allows to lock a commit" do
+      refute_predicate @commit, :locked?
+      patch :update, params: {stack_id: @stack.to_param, id: @commit.id, commit: {locked: true}}
+      assert_response :ok
+      assert_predicate @commit.reload, :locked?
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170314145604) do
+ActiveRecord::Schema.define(version: 20170320124156) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text     "permissions", limit: 65535
@@ -59,6 +59,7 @@ ActiveRecord::Schema.define(version: 20170314145604) do
     t.integer  "pull_request_number"
     t.string   "pull_request_title",  limit: 1024
     t.integer  "pull_request_id"
+    t.boolean  "locked",                            default: false, null: false
     t.index ["author_id"], name: "index_commits_on_author_id"
     t.index ["committer_id"], name: "index_commits_on_committer_id"
     t.index ["created_at"], name: "index_commits_on_created_at"

--- a/test/models/commits_test.rb
+++ b/test/models/commits_test.rb
@@ -294,6 +294,12 @@ module Shipit
       refute_predicate shipit_commits(:fifth), :deployable?
     end
 
+    test "#deployable? is false if commit is locked" do
+      commit = shipit_commits(:cyclimse_first)
+      commit.update!(locked: true)
+      refute_predicate commit, :deployable?
+    end
+
     test "#deployable? is false if a required status is missing" do
       commit = shipit_commits(:cyclimse_first)
       commit.stack.stubs(:required_statuses).returns(%w(ci/very-important))

--- a/test/models/undeployed_commits_test.rb
+++ b/test/models/undeployed_commits_test.rb
@@ -43,8 +43,8 @@ module Shipit
       assert_equal 'allowed', @commit.deploy_state
     end
 
-    test "#deploy_state returns `locked` if the stack is locked" do
-      @stack.update!(lock_reason: "Let's eat some chips!")
+    test "#deploy_state returns `locked` if the commit is locked" do
+      @commit.update!(locked: true)
       assert_equal 'locked', @commit.deploy_state
     end
 
@@ -70,11 +70,6 @@ module Shipit
 
     test "#redeploy_state returns `allowed` by default" do
       assert_equal 'allowed', @commit.redeploy_state
-    end
-
-    test "#redeploy_state returns `locked` if the stack is locked" do
-      @stack.update!(lock_reason: "Let's eat some chips!")
-      assert_equal 'locked', @commit.redeploy_state
     end
 
     test "#redeploy_state returns `allowed` if the stack is locked but the safeties are ignored" do


### PR DESCRIPTION
Fix: https://github.com/Shopify/shipit-engine/issues/270
Closes: https://github.com/Shopify/shipit-engine/pull/669
Closes: https://github.com/Shopify/shipit-engine/pull/675

![capture d ecran 2017-03-20 a 14 37 33](https://cloud.githubusercontent.com/assets/19192189/24102150/4d62d9b4-0d7b-11e7-9eef-c199fbfb7cb0.png)

Every undeployed commit get a little lock icon. It's greyed by default, but you can toggle it to red by clicking on it. A locked commit won't be automatically deployed, and require emergency mode to be deployed manually.

In a followup, I'll look at automatically locking commits when a revert is merged, so that it addresses #669 / #675. 

As usual the UI is quite ugly, so suggestions are welcome.

@Shopify/pipeline @fw42 @tjoyal @daniellaniyo thoughts?