### PR TITLE
Automatically lock commits on revert

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Automatically lock impacted commits when a revert is merged. This include the reverted commit as well as all it's childs up to the revert. 
+
 * Allow to lock undeployed commits, to prevent them from being deployed.
 
 * Pull requests in the merge queue which are closed on Github will be marked as merged/cancelled as appropriate.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Unreleased
 
-* Automatically lock impacted commits when a revert is merged. This include the reverted commit as well as all it's childs up to the revert. 
+* Automatically lock impacted commits when a revert is merged. This include the reverted commit as well as all its children up to the revert. 
 
 * Allow to lock undeployed commits, to prevent them from being deployed.
 

--- a/app/jobs/shipit/github_sync_job.rb
+++ b/app/jobs/shipit/github_sync_job.rb
@@ -17,11 +17,22 @@ module Shipit
         @stack.transaction do
           shared_parent.try!(:detach_children!)
           new_commits.each do |gh_commit|
-            @stack.commits.create_from_github!(gh_commit)
+            append_commit(gh_commit)
           end
         end
       end
       CacheDeploySpecJob.perform_later(@stack)
+    end
+
+    def append_commit(gh_commit)
+      appended_commit = @stack.commits.create_from_github!(gh_commit)
+      if appended_commit.revert?
+        impacted_commits = @stack.undeployed_commits.reverse.drop_while { |c| !appended_commit.revert_of?(c) }
+        impacted_commits.pop # appended_commit
+        impacted_commits.each do |impacted_commit|
+          impacted_commit.update!(locked: true)
+        end
+      end
     end
 
     def fetch_missing_commits(&block)

--- a/app/models/shipit/commit.rb
+++ b/app/models/shipit/commit.rb
@@ -126,11 +126,23 @@ module Shipit
     end
 
     def title
-      pull_request_title || message
+      pull_request_title || message_header
+    end
+
+    def message_header
+      message.lines.first.strip
     end
 
     def pull_request_title # TODO: remove in a few versions when it is assumed the commits table was backfilled
       super || message_parser.pull_request_title
+    end
+
+    def revert?
+      title.start_with?('Revert "') && title.end_with?('"')
+    end
+
+    def revert_of?(commit)
+      title == %(Revert "#{commit.title}") || title == %(Revert "#{commit.message_header}")
     end
 
     def short_sha

--- a/test/fixtures/shipit/commits.yml
+++ b/test/fixtures/shipit/commits.yml
@@ -53,7 +53,7 @@ fourth:
 fifth:
   id: 5
   sha: 567578b362bf2b4df5903e1c7960929361c3abcd
-  message: "fix all teh things"
+  message: "fix all the things"
   stack: shipit
   author: walrus
   committer: walrus

--- a/test/jobs/github_sync_job_test.rb
+++ b/test/jobs/github_sync_job_test.rb
@@ -36,6 +36,55 @@ module Shipit
       assert shipit_commits(:fifth).reload.detached?
     end
 
+    test "#perform locks all commits leading to a revert" do
+      @stack.deploys_and_rollbacks.destroy_all
+
+      initial_queue = [
+        ["fix all teh things", false],
+        ["yoloshipit!", false],
+        ["fix it!", false],
+        ["sheep it!", false],
+        ["lets go", false],
+      ]
+      assert_equal initial_queue, @stack.undeployed_commits.map { |c| [c.title, c.locked?] }
+
+      author = stub(
+        id: 1234,
+        login: 'bob',
+        name: 'Bob the Builder',
+        email: 'bob@bob.com',
+        date: '2011-04-14T16:00:49Z',
+      )
+      @job.expects(:fetch_missing_commits).returns([
+        [
+          stub(
+            sha: '36514755579bfb5bc313f403b216f4347a027990',
+            author: author,
+            committer: author,
+            stats: nil,
+            commit: stub(
+              sha: '36514755579bfb5bc313f403b216f4347a027990',
+              message: 'Revert "fix it!"',
+              author: author,
+              committer: author,
+            ),
+          ),
+        ],
+        shipit_commits(:fifth),
+      ])
+      @job.perform(stack_id: @stack.id)
+
+      final_queue = [
+        ['Revert "fix it!"', false],
+        ["fix all teh things", true],
+        ["yoloshipit!", true],
+        ["fix it!", true],
+        ["sheep it!", false],
+        ["lets go", false],
+      ]
+      assert_equal final_queue, @stack.reload.undeployed_commits.map { |c| [c.title, c.locked?] }
+    end
+
     test "#fetch_missing_commits returns the commits in the reverse order if it doesn't know the parent" do
       last = stub(sha: 123)
       first = stub(sha: 345)

--- a/test/jobs/github_sync_job_test.rb
+++ b/test/jobs/github_sync_job_test.rb
@@ -40,7 +40,7 @@ module Shipit
       @stack.deploys_and_rollbacks.destroy_all
 
       initial_queue = [
-        ["fix all teh things", false],
+        ["fix all the things", false],
         ["yoloshipit!", false],
         ["fix it!", false],
         ["sheep it!", false],
@@ -76,7 +76,7 @@ module Shipit
 
       final_queue = [
         ['Revert "fix it!"', false],
-        ["fix all teh things", true],
+        ["fix all the things", true],
         ["yoloshipit!", true],
         ["fix it!", true],
         ["sheep it!", false],

--- a/test/models/commits_test.rb
+++ b/test/models/commits_test.rb
@@ -502,6 +502,55 @@ module Shipit
       assert_nil commit.pull_request
     end
 
+    test "#revert? returns false if the message doesn't follow the revert convention" do
+      commit = Commit.new(message: "Revert stuff")
+      refute_predicate commit, :revert?
+    end
+
+    test "#revert? returns true for commits reverted by GitHub" do
+      commit = Commit.new(
+        message: "Merge pull request #17 from Shopify/revert-16\n\nRevert \"Create README.md\"",
+      )
+      assert_predicate commit, :revert?
+    end
+
+    test "#revert? returns true for commits reverted from CLI" do
+      commit = Commit.new(
+        message: "Revert \"Super Feature\"\n\nThis reverts commit 49430d5091abc34f2c576c23ebf369ec7094d8aa.",
+      )
+      assert_predicate commit, :revert?
+    end
+
+    test "#revert_of? works with pull requests reverted on GitHub" do
+      commit = Commit.new(
+        message: "Merge pull request #16 from byroot/casperisfine-patch-1\n\nCreate README.md",
+      )
+      revert = Commit.new(
+        message: "Merge pull request #17 from Shopify/revert-16\n\nRevert \"Create README.md\"",
+      )
+      assert revert.revert_of?(commit)
+    end
+
+    test "#revert_of? works with commits reverted from CLI" do
+      commit = Commit.new(
+        message: "Create README.md",
+      )
+      revert = Commit.new(
+        message: "Revert \"Create README.md\"\n\nThis reverts commit 49430d5091abc34f2c576c23ebf369ec7094d8aa.",
+      )
+      assert revert.revert_of?(commit)
+    end
+
+    test "#revert_of? works with pull requests reverted from CLI" do
+      commit = Commit.new(
+        message: "Merge pull request #19 from byroot/casperisfine-patch-1\n\nUpdate README.md",
+      )
+      revert = Commit.new(
+        message: "Revert \"Merge pull request #19 from byroot/casperisfine-patch-1\"\n\nThis reverts commit fa3722ef8372b47160f5d96010d3c54743d192f9, reversing\nchanges made to 868b6f65f759d003c04d056f2f928f18d6813c7e.",
+      )
+      assert revert.revert_of?(commit)
+    end
+
     private
 
     def expect_event(stack)


### PR DESCRIPTION
Followup https://github.com/Shopify/shipit-engine/pull/676

- Detect merged reverts, both manual and from GitHub UI, as long as the default commit message is unmodified.
- When a revert is merged (or pushed), scan the undeployed commits to lock all the entire commit range between the revert and the reverted commit (included).

@Shopify/pipeline @fw42 @tjoyal @daniellaniyo for review please.