### PR TITLE
Add tooltips and confirmations to lock on commit

### DIFF
--- a/app/assets/javascripts/shipit/stacks.js.coffee
+++ b/app/assets/javascripts/shipit/stacks.js.coffee
@@ -4,19 +4,8 @@ $(document).on 'click', '.commit-lock a', (event) ->
   $link = $(event.target).closest('a')
 
   locked = $commit.hasClass('locked')
-  new_toolip = ''
-
-  if locked
-    confirmation = confirm("Mark this commit as safe to deploy?");
-    unless confirmation
-      return
-    new_toolip = 'This commit is safe to deploy. Click to mark it as unsafe'
-  else
-    new_toolip = 'This commit is unsafe to deploy. Click to mark it as safe'
-
-  $link.attr('data-tooltip', new_toolip) # Change DOM
-  $link.data('tooltip', new_toolip) # Break data cache
   $commit.toggleClass('locked')
+
   $.ajax($link.attr('href'), method: 'PATCH', data: {commit: {locked: !locked}})
 
 jQuery ($) ->

--- a/app/assets/javascripts/shipit/stacks.js.coffee
+++ b/app/assets/javascripts/shipit/stacks.js.coffee
@@ -4,8 +4,19 @@ $(document).on 'click', '.commit-lock a', (event) ->
   $link = $(event.target).closest('a')
 
   locked = $commit.hasClass('locked')
-  $commit.toggleClass('locked')
+  new_toolip = ''
 
+  if locked
+    confirmation = confirm("Mark this commit as safe to deploy?");
+    unless confirmation
+      return
+    new_toolip = 'This commit is safe to deploy. Click to mark it as unsafe'
+  else
+    new_toolip = 'This commit is unsafe to deploy. Click to mark it as safe'
+
+  $link.attr('data-tooltip', new_toolip) # Change DOM
+  $link.data('tooltip', new_toolip) # Break data cache
+  $commit.toggleClass('locked')
   $.ajax($link.attr('href'), method: 'PATCH', data: {commit: {locked: !locked}})
 
 jQuery ($) ->

--- a/app/assets/stylesheets/_pages/_commits.scss
+++ b/app/assets/stylesheets/_pages/_commits.scss
@@ -107,6 +107,10 @@
   &:hover .icon {
     background-color: darken(#ddd, 20%);
   }
+
+  .action-unlock-commit {
+    display: none;
+  }
 }
 
 .commit.locked .commit-lock {
@@ -116,6 +120,14 @@
 
   &:hover .icon {
     background-color: darken($bright-red, 20%);
+  }
+
+  .action-lock-commit {
+    display: none;
+  }
+
+  .action-unlock-commit {
+    display: inline-block;
   }
 }
 

--- a/app/views/shipit/commits/_commit.html.erb
+++ b/app/views/shipit/commits/_commit.html.erb
@@ -14,8 +14,8 @@
       <%= timeago_tag(commit.committed_at, force: true) %>
     </p>
   </div>
-  <div class="commit-lock">
-    <%= link_to stack_commit_path(commit.stack, commit) do %>
+  <div class="commit-lock" >
+    <%= link_to stack_commit_path(commit.stack, commit), 'data-tooltip' => (commit.locked? ? 'This commit is unsafe to deploy. Click to mark it as safe' : 'This commit is safe to deploy. Click to mark it as unsafe') do %>
       <i class="icon icon--lock"></i>
     <% end %>
   </div>

--- a/app/views/shipit/commits/_commit.html.erb
+++ b/app/views/shipit/commits/_commit.html.erb
@@ -15,7 +15,10 @@
     </p>
   </div>
   <div class="commit-lock" >
-    <%= link_to stack_commit_path(commit.stack, commit), 'data-tooltip' => (commit.locked? ? 'This commit is unsafe to deploy. Click to mark it as safe' : 'This commit is safe to deploy. Click to mark it as unsafe') do %>
+    <%= link_to stack_commit_path(commit.stack, commit), class: 'action-lock-commit', data: {tooltip: t('commit.lock')} do %>
+      <i class="icon icon--lock"></i>
+    <% end %>
+    <%= link_to stack_commit_path(commit.stack, commit), class: 'action-unlock-commit', data: {tooltip: t('commit.unlock'), confirm: t('commit.confirm_unlock')} do %>
       <i class="icon icon--lock"></i>
     <% end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,10 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
+  commit:
+    lock: This commit is safe to deploy. Click to mark it as unsafe.
+    unlock: This commit is unsafe to deploy. Click to mark it as safe.
+    confirm_unlock: Mark this commit as safe to deploy?
   deploy_button:
     hint:
       max_commits: It is recommended not to deploy more than %{maximum} commits at once.


### PR DESCRIPTION
Using the new lock feature, I was a bit confused as to what was going on. When I hovered over the link, it appeared as a normal link. Little did I know that JS overrode this and performed a PATCH request, leading me to accidentally unlocking a commit.

To resolve that confusion, I added a tooltip to the lock and a confirmation to unlock..

![shipit](https://cloud.githubusercontent.com/assets/3074765/24165797/c7bfa3fa-0e47-11e7-9060-c3cee648f01e.gif)

cc @byroot @wvanbergen 