### PR TITLE
Add a tooltip to explain commit locks

### DIFF
--- a/app/assets/stylesheets/_pages/_commits.scss
+++ b/app/assets/stylesheets/_pages/_commits.scss
@@ -107,6 +107,10 @@
   &:hover .icon {
     background-color: darken(#ddd, 20%);
   }
+
+  .action-unlock-commit {
+    display: none;
+  }
 }
 
 .commit.locked .commit-lock {
@@ -116,6 +120,14 @@
 
   &:hover .icon {
     background-color: darken($bright-red, 20%);
+  }
+
+  .action-lock-commit {
+    display: none;
+  }
+
+  .action-unlock-commit {
+    display: inline-block;
   }
 }
 

--- a/app/views/shipit/commits/_commit.html.erb
+++ b/app/views/shipit/commits/_commit.html.erb
@@ -15,7 +15,10 @@
     </p>
   </div>
   <div class="commit-lock">
-    <%= link_to stack_commit_path(commit.stack, commit) do %>
+    <%= link_to stack_commit_path(commit.stack, commit), class: 'action-lock-commit', data: {tooltip: t('commit.lock')} do %>
+      <i class="icon icon--lock"></i>
+    <% end %>
+    <%= link_to stack_commit_path(commit.stack, commit), class: 'action-unlock-commit', data: {tooltip: t('commit.unlock')} do %>
       <i class="icon icon--lock"></i>
     <% end %>
   </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -20,6 +20,9 @@
 # available at http://guides.rubyonrails.org/i18n.html.
 
 en:
+  commit:
+    lock: This commit is safe to deploy. Click to mark it as unsafe.
+    unlock: This commit is unsafe to deploy. Click to mark it as safe.
   deploy_button:
     hint:
       max_commits: It is recommended not to deploy more than %{maximum} commits at once.


### PR DESCRIPTION
Alternative to https://github.com/Shopify/shipit-engine/pull/678

Tooltips are the same, just implemented differently. However there is no confirm.

@wvanbergen @kirs @jules2689 