### PR TITLE
More explicit removal of dependent records when destroying a stack

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Unreleased
 
-* Automatically lock impacted commits when a revert is merged. This include the reverted commit as well as all its children up to the revert. 
+* More explicit removal of dependent records when destroying a stack. Reduces total amount of calls to database and speed up removal.
+
+* Automatically lock impacted commits when a revert is merged. This include the reverted commit as well as all its children up to the revert.
 
 * Allow to lock undeployed commits, to prevent them from being deployed.
 

--- a/app/jobs/shipit/destroy_stack_job.rb
+++ b/app/jobs/shipit/destroy_stack_job.rb
@@ -2,7 +2,32 @@ module Shipit
   class DestroyStackJob < BackgroundJob
     queue_as :default
 
+    # stack
+    # +-- api_clients
+    # +-- commits
+    # |   +-- commit_deployments
+    # |   |   +-- statuses
+    # |   +-- statuses
+    # +-- github_hooks
+    # +-- hooks
+    # +-- pull_requests
+    # +-- tasks
+    #     +-- chunks
+
     def perform(stack)
+      Shipit::ApiClient.where(stack_id: stack.id).delete_all
+      commits_ids = Shipit::Commit.where(stack_id: stack.id).pluck(:id)
+      commit_deployments_ids = Shipit::CommitDeployment.where(commit_id: commits_ids).pluck(:id)
+      Shipit::CommitDeploymentStatus.where(commit_deployment_id: commit_deployments_ids).delete_all
+      Shipit::CommitDeployment.where(id: commit_deployments_ids).delete_all
+      Shipit::Status.where(commit_id: commits_ids).delete_all
+      Shipit::Commit.where(id: commits_ids).delete_all
+      Shipit::GithubHook.where(stack_id: stack.id).destroy_all
+      Shipit::Hook.where(stack_id: stack.id).delete_all
+      Shipit::PullRequest.where(stack_id: stack.id).delete_all
+      tasks_ids = Shipit::Task.where(stack_id: stack.id).pluck(:id)
+      Shipit::OutputChunk.where(task_id: tasks_ids).delete_all
+      Shipit::Task.where(id: tasks_ids).delete_all
       stack.destroy!
     end
   end


### PR DESCRIPTION
PR related to issue https://github.com/Shopify/shipit-engine/issues/680

I replaced implicit calls to `#destroy` with explicit `.delete_all` or `.destroy_all` (for `Shipit::GithubHook`).
It should reduce total amount of calls to database and speed up removal.