### PR TITLE
add TASK_ID as an evnironment variable available to the script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 * Pull requests in the merge queue which are closed on Github will be marked as merged/cancelled as appropriate.
 
+* TASK_ID environment variable is now available to tasks and deploy scripts.
+
 # 0.16.0
 
 * Move uncommon tasks to drop down menu.

--- a/README.md
+++ b/README.md
@@ -634,6 +634,7 @@ Your deploy scripts have access to the following environment variables:
 * `BRANCH`: The stack branch (e.g `master`)
 * `LAST_DEPLOYED_SHA`: The git SHA of the last deployed commit
 * `DIFF_LINK`: URL to the diff on GitHub.
+* `TASK_ID`: ID of the task that is running
 * All the content of the `secrets.yml` `env` key
 * All the content of the `shipit.yml` `machine.environment` key
 

--- a/lib/shipit/task_commands.rb
+++ b/lib/shipit/task_commands.rb
@@ -37,6 +37,7 @@ module Shipit
         'BUNDLE_PATH' => Rails.root.join('data', 'bundler').to_s,
         'SHIPIT_LINK' => permalink,
         'LAST_DEPLOYED_SHA' => @stack.last_deployed_commit.sha,
+        'TASK_ID' => @task.id.to_s,
       ).merge(deploy_spec.machine_env).merge(@task.env)
     end
 

--- a/test/unit/deploy_commands_test.rb
+++ b/test/unit/deploy_commands_test.rb
@@ -134,6 +134,13 @@ module Shipit
       assert_equal @deploy.stack.last_deployed_commit.sha, command.env['LAST_DEPLOYED_SHA']
     end
 
+    test "#perform calls cap $environment deploy with the TASK_ID in the environment" do
+      commands = @commands.perform
+      assert_equal 1, commands.length
+      command = commands.first
+      assert_equal @deploy.id.to_s, command.env['TASK_ID']
+    end
+
     test "#perform transliterates the user name" do
       @deploy.user = User.new(login: 'Sirupsen', name: "Simon Hørup Eskildsen")
       commands = @commands.perform


### PR DESCRIPTION
Sometimes its useful to know what the task id is in the script. This makes it possible without having to parse `SHIPIT_LINK`