### PR TITLE
Discover restart task from Kubernetes

### DIFF
--- a/app/models/shipit/deploy_spec.rb
+++ b/app/models/shipit/deploy_spec.rb
@@ -108,11 +108,14 @@ module Shipit
     end
 
     def task_definitions
-      (config('tasks') || {}).map { |name, definition| TaskDefinition.new(name, coerce_task_definition(definition)) }
+      discover_task_definitions.merge(config('tasks') || {}).map do |name, definition|
+        TaskDefinition.new(name, coerce_task_definition(definition))
+      end
     end
 
     def find_task_definition(id)
-      TaskDefinition.new(id, coerce_task_definition(config('tasks', id)) || task_not_found!(id))
+      definition = config('tasks', id) || discover_task_definitions[id]
+      TaskDefinition.new(id, coerce_task_definition(definition) || task_not_found!(id))
     end
 
     def filter_deploy_envs(env)
@@ -193,6 +196,10 @@ module Shipit
     end
 
     def discover_review_checklist
+    end
+
+    def discover_task_definitions
+      {}
     end
 
     def discover_dependencies_steps

--- a/test/models/deploy_spec_test.rb
+++ b/test/models/deploy_spec_test.rb
@@ -346,6 +346,21 @@ module Shipit
       assert_equal ['bundle exec foo'], definition.steps
     end
 
+    test "#task_definitions returns kubernetes commands as well as comands from the config" do
+      @spec.stubs(:load_config).returns(
+        'tasks' => {'another_task' => {'steps' => %w(foo)}},
+        'kubernetes' => {
+          'namespace' => 'foo',
+          'context' => 'bar',
+        },
+      )
+      tasks = @spec.task_definitions
+      assert_equal 2, tasks.size
+
+      restart_task = tasks.find { |t| t.id == "restart" }
+      assert_equal ["kubernetes-restart foo bar"], restart_task.steps
+    end
+
     test "task definitions returns an array of VariableDefinition instances" do
       @spec.expects(:load_config).returns('tasks' =>
         {'restart' =>


### PR DESCRIPTION
This adds restart task to all apps that have `kubernetes` support enabled. It works automatically and we won't need to update all repos to add the new task.

Preview:

<img width="639" alt="screen shot 2017-04-24 at 18 11 10" src="https://cloud.githubusercontent.com/assets/522155/25360989/b3263444-2919-11e7-8eff-fba233069138.png">

IMO this is not the best UI because developers would need to enter the name of k8s deployment to restart. Any ideas how we can make it better?

cc @Shopify/cloudplatform @Shopify/undercloud 