### PR TITLE
Fully prevent race condition while triggering deploys

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Fix a race condition allowing for duplicate deploys
+
 # 0.18.0
 
 * Upgrade to Rails 5.1

--- a/app/controllers/shipit/api/deploys_controller.rb
+++ b/app/controllers/shipit/api/deploys_controller.rb
@@ -11,7 +11,8 @@ module Shipit
       def create
         commit = stack.commits.by_sha(params.sha) || param_error!(:sha, 'Unknown revision')
         param_error!(:force, "Can't deploy a locked stack") if !params.force && stack.locked?
-        render_resource stack.trigger_deploy(commit, current_user, env: params.env), status: :accepted
+        deploy = stack.trigger_deploy(commit, current_user, env: params.env, force: params.force)
+        render_resource deploy, status: :accepted
       end
     end
   end

--- a/app/controllers/shipit/deploys_controller.rb
+++ b/app/controllers/shipit/deploys_controller.rb
@@ -20,10 +20,15 @@ module Shipit
     end
 
     def create
-      return redirect_to new_stack_deploy_path(@stack, sha: @until_commit.sha) if !params[:force] && @stack.active_task?
-
-      @deploy = @stack.trigger_deploy(@until_commit, current_user, env: deploy_params[:env])
+      @deploy = @stack.trigger_deploy(
+        @until_commit,
+        current_user,
+        env: deploy_params[:env],
+        force: params[:force].present?,
+      )
       respond_with(@deploy.stack, @deploy)
+    rescue Task::ConcurrentTaskRunning
+      redirect_to new_stack_deploy_path(@stack, sha: @until_commit.sha)
     end
 
     def rollback

--- a/app/controllers/shipit/rollbacks_controller.rb
+++ b/app/controllers/shipit/rollbacks_controller.rb
@@ -4,9 +4,10 @@ module Shipit
     before_action :load_deploy
 
     def create
-      return redirect_to rollback_stack_deploy_path(@stack, @deploy) if !params[:force] && @stack.active_task?
-      @rollback = @deploy.trigger_rollback(current_user, env: rollback_params[:env])
+      @rollback = @deploy.trigger_rollback(current_user, env: rollback_params[:env], force: params[:force].present?)
       redirect_to stack_deploy_path(@stack, @rollback)
+    rescue Task::ConcurrentTaskRunning
+      redirect_to rollback_stack_deploy_path(@stack, @deploy)
     end
 
     private

--- a/app/controllers/shipit/tasks_controller.rb
+++ b/app/controllers/shipit/tasks_controller.rb
@@ -28,10 +28,15 @@ module Shipit
     def create
       @definition = stack.find_task_definition(params[:definition_id])
 
-      if @definition.allow_concurrency? || params[:force] || !@stack.active_task?
-        @task = stack.trigger_task(params[:definition_id], current_user, env: task_params[:env])
+      begin
+        @task = stack.trigger_task(
+          params[:definition_id],
+          current_user,
+          env: task_params[:env],
+          force: params[:force].present?,
+        )
         redirect_to [stack, @task]
-      else
+      rescue Task::ConcurrentTaskRunning
         redirect_to new_stack_tasks_path(stack, @definition)
       end
     end

--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -37,7 +37,7 @@ module Shipit
 
     delegate :broadcast_update, :filter_deploy_envs, to: :stack
 
-    def build_rollback(user = nil, env: nil)
+    def build_rollback(user = nil, env: nil, force: false)
       Rollback.new(
         user_id: user.try!(:id),
         stack_id: stack_id,
@@ -45,12 +45,13 @@ module Shipit
         since_commit: stack.last_deployed_commit,
         until_commit: until_commit,
         env: env.try!(:to_h) || {},
+        allow_concurrency: force,
       )
     end
 
     # Rolls the stack back to this deploy
-    def trigger_rollback(user = AnonymousUser.new, env: nil)
-      rollback = build_rollback(user, env: env)
+    def trigger_rollback(user = AnonymousUser.new, env: nil, force: false)
+      rollback = build_rollback(user, env: env, force: force)
       rollback.save!
       rollback.enqueue
 

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -32,7 +32,7 @@ module Shipit
     end
 
     test ":new shows a warning if a deploy is already running" do
-      shipit_deploys(:shipit_running).update_column(:status, 'running')
+      shipit_deploys(:shipit_running).update!(allow_concurrency: false, status: 'running')
 
       get :new, params: {stack_id: @stack.to_param, sha: @commit.sha}
       assert_response :success
@@ -70,7 +70,7 @@ module Shipit
     end
 
     test ":create redirect back to :new with a warning if there is an active deploy" do
-      shipit_deploys(:shipit_running).update_column(:status, 'running')
+      shipit_deploys(:shipit_running).update!(allow_concurrency: false, status: 'running')
 
       assert_no_difference '@stack.deploys.count' do
         post :create, params: {stack_id: @stack.to_param, deploy: {until_commit_id: @commit.id}}
@@ -90,7 +90,7 @@ module Shipit
     end
 
     test ":rollback shows a warning if a deploy is already running" do
-      shipit_deploys(:shipit_running).update_column(:status, 'running')
+      shipit_deploys(:shipit_running).update!(allow_concurrency: false, status: 'running')
 
       get :rollback, params: {stack_id: @stack.to_param, id: @deploy.id}
       assert_response :success

--- a/test/controllers/rollbacks_controller_test.rb
+++ b/test/controllers/rollbacks_controller_test.rb
@@ -39,7 +39,7 @@ module Shipit
     end
 
     test ":create redirects back to the :new page if there is an active deploy" do
-      shipit_deploys(:shipit_running).update_column(:status, 'running')
+      shipit_deploys(:shipit_running).update!(allow_concurrency: false, status: 'running')
       assert_no_difference '@stack.deploys.count' do
         post :create, params: {stack_id: @stack.to_param, rollback: {parent_id: @deploy.id}}
       end

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -16,15 +16,19 @@ module Shipit
     end
 
     test "tasks defined in the shipit.yml can't be triggered if the stack is being deployed" do
-      assert @stack.active_task?
+      shipit_deploys(:shipit_running).update!(allow_concurrency: false, status: 'running')
+
+      assert_predicate @stack, :active_task?
       assert_no_difference -> { @stack.tasks.count } do
         post :create, params: {stack_id: @stack, definition_id: @definition.id}
       end
       assert_redirected_to new_stack_tasks_path(@stack, @definition)
     end
 
-    test "tasks defined in the shipit.yml can be triggered anyway if force apram is present" do
-      assert @stack.active_task?
+    test "tasks defined in the shipit.yml can be triggered anyway if force param is present" do
+      shipit_deploys(:shipit_running).update!(allow_concurrency: false, status: 'running')
+
+      assert_predicate @stack, :active_task?
       assert_difference -> { @stack.tasks.count } do
         post :create, params: {stack_id: @stack, definition_id: @definition.id, force: 'true'}
       end

--- a/test/fixtures/shipit/tasks.yml
+++ b/test/fixtures/shipit/tasks.yml
@@ -61,6 +61,7 @@ shipit_pending:
   additions: 432
   deletions: 406
   created_at: <%= (60 - 4).minutes.ago.to_s(:db) %>
+  allow_concurrency: true
 
 shipit_running:
   id: 5
@@ -74,6 +75,7 @@ shipit_running:
   deletions: 342
   created_at: <%= (60 - 5).minutes.ago.to_s(:db) %>
   started_at: <%= (60 - 5).minutes.ago.to_s(:db) %>
+  allow_concurrency: true
 
 shipit_complete:
   id: 6


### PR DESCRIPTION
As described here: https://github.com/Shopify/shipit-engine/issues/685#issuecomment-292353111

Until now we had a protection against concurrent deploys, but it wasn't perfect since a race condition window, albeit relatively small, exists.

This PR move the concurrency protection inside the deploy creation transaction to prevent any such race condition.

@Shopify/pipeline for review please