### PR TITLE
Specify rails version in migration

### DIFF
--- a/db/migrate/20140226233935_create_baseline.rb
+++ b/db/migrate/20140226233935_create_baseline.rb
@@ -1,4 +1,4 @@
-class CreateBaseline < ActiveRecord::Migration
+class CreateBaseline < ActiveRecord::Migration[4.2]
   def change
     create_table "api_clients", force: :cascade do |t|
       t.text     "permissions", limit: 65535

--- a/db/migrate/20150515190352_add_output_column_to_tasks.rb
+++ b/db/migrate/20150515190352_add_output_column_to_tasks.rb
@@ -1,4 +1,4 @@
-class AddOutputColumnToTasks < ActiveRecord::Migration
+class AddOutputColumnToTasks < ActiveRecord::Migration[4.2]
   def change
     add_column :tasks, :gzip_output, :binary, limit: 16777215
   end

--- a/db/migrate/20150518214944_add_ignore_ci_to_stack.rb
+++ b/db/migrate/20150518214944_add_ignore_ci_to_stack.rb
@@ -1,4 +1,4 @@
-class AddIgnoreCiToStack < ActiveRecord::Migration
+class AddIgnoreCiToStack < ActiveRecord::Migration[4.2]
   def change
     add_column :stacks, :ignore_ci, :boolean
   end

--- a/db/migrate/20150630154640_add_inaccessible_since_to_stacks.rb
+++ b/db/migrate/20150630154640_add_inaccessible_since_to_stacks.rb
@@ -1,4 +1,4 @@
-class AddInaccessibleSinceToStacks < ActiveRecord::Migration
+class AddInaccessibleSinceToStacks < ActiveRecord::Migration[4.2]
   def change
     add_column :stacks, :inaccessible_since, :datetime, default: nil
   end

--- a/db/migrate/20150708143032_add_rollback_when_complete_on_task.rb
+++ b/db/migrate/20150708143032_add_rollback_when_complete_on_task.rb
@@ -1,4 +1,4 @@
-class AddRollbackWhenCompleteOnTask < ActiveRecord::Migration
+class AddRollbackWhenCompleteOnTask < ActiveRecord::Migration[4.2]
   def change
     add_column :tasks, :rollback_once_aborted, :boolean, default: false, null: false
   end

--- a/db/migrate/20150814182557_add_env_to_tasks.rb
+++ b/db/migrate/20150814182557_add_env_to_tasks.rb
@@ -1,4 +1,4 @@
-class AddEnvToTasks < ActiveRecord::Migration
+class AddEnvToTasks < ActiveRecord::Migration[4.2]
   def change
     add_column :tasks, :env, :text
   end

--- a/db/migrate/20150918190012_add_confirmations_to_tasks.rb
+++ b/db/migrate/20150918190012_add_confirmations_to_tasks.rb
@@ -1,4 +1,4 @@
-class AddConfirmationsToTasks < ActiveRecord::Migration
+class AddConfirmationsToTasks < ActiveRecord::Migration[4.2]
   def change
     add_column :tasks, :confirmations, :integer, default: 0, null: false
   end

--- a/db/migrate/20151102201634_schema_constraints_cleanup.rb
+++ b/db/migrate/20151102201634_schema_constraints_cleanup.rb
@@ -1,4 +1,4 @@
-class SchemaConstraintsCleanup < ActiveRecord::Migration
+class SchemaConstraintsCleanup < ActiveRecord::Migration[4.2]
   # Set reasonable size limit to a bunch of indexed string columns. They were defaulted to 255
   def change
     change_column :github_hooks, :event, :string, limit: 50, null: false # The biggest existing event is 27

--- a/db/migrate/20151103144716_convert_stacks_lock_reason_to_text.rb
+++ b/db/migrate/20151103144716_convert_stacks_lock_reason_to_text.rb
@@ -1,4 +1,4 @@
-class ConvertStacksLockReasonToText < ActiveRecord::Migration
+class ConvertStacksLockReasonToText < ActiveRecord::Migration[4.2]
   def change
     change_column :stacks, :lock_reason, :string, limit: 4096
   end

--- a/db/migrate/20151112152112_reduce_tasks_type_size.rb
+++ b/db/migrate/20151112152112_reduce_tasks_type_size.rb
@@ -1,4 +1,4 @@
-class ReduceTasksTypeSize < ActiveRecord::Migration
+class ReduceTasksTypeSize < ActiveRecord::Migration[4.2]
   def change
     change_column :tasks, :type, :string, limit: 10, null: true
   end

--- a/db/migrate/20151112152113_reduce_tasks_stats_size.rb
+++ b/db/migrate/20151112152113_reduce_tasks_stats_size.rb
@@ -1,4 +1,4 @@
-class ReduceTasksStatsSize < ActiveRecord::Migration
+class ReduceTasksStatsSize < ActiveRecord::Migration[4.2]
   def change
     change_column :tasks, :status, :string, null: false, default: 'pending', limit: 10
   end

--- a/db/migrate/20151113151323_improve_indexes_on_tasks.rb
+++ b/db/migrate/20151113151323_improve_indexes_on_tasks.rb
@@ -1,4 +1,4 @@
-class ImproveIndexesOnTasks < ActiveRecord::Migration
+class ImproveIndexesOnTasks < ActiveRecord::Migration[4.2]
   def change
     add_index :tasks, [:type, :stack_id, :status], name: :index_tasks_by_stack_and_status
     add_index :tasks, [:type, :stack_id, :parent_id], name: :index_tasks_by_stack_and_parent

--- a/db/migrate/20160104151742_increase_tasks_type_size_back.rb
+++ b/db/migrate/20160104151742_increase_tasks_type_size_back.rb
@@ -1,4 +1,4 @@
-class IncreaseTasksTypeSizeBack < ActiveRecord::Migration
+class IncreaseTasksTypeSizeBack < ActiveRecord::Migration[4.2]
   def change
     change_column :tasks, :type, :string, limit: 20, null: true
   end

--- a/db/migrate/20160104151833_convert_sti_columns.rb
+++ b/db/migrate/20160104151833_convert_sti_columns.rb
@@ -1,4 +1,4 @@
-class ConvertStiColumns < ActiveRecord::Migration
+class ConvertStiColumns < ActiveRecord::Migration[4.2]
   def up
     Shipit::Task.where(type: 'Task').update_all(type: 'Shipit::Task')
     Shipit::Task.where(type: 'Deploy').update_all(type: 'Shipit::Deploy')

--- a/db/migrate/20160122165559_rename_hooks_url_in_delivery_url.rb
+++ b/db/migrate/20160122165559_rename_hooks_url_in_delivery_url.rb
@@ -1,4 +1,4 @@
-class RenameHooksUrlInDeliveryUrl < ActiveRecord::Migration
+class RenameHooksUrlInDeliveryUrl < ActiveRecord::Migration[4.2]
   def change
     rename_column :hooks, :url, :delivery_url
   end

--- a/db/migrate/20160210183823_add_allow_concurrency_to_tasks.rb
+++ b/db/migrate/20160210183823_add_allow_concurrency_to_tasks.rb
@@ -1,4 +1,4 @@
-class AddAllowConcurrencyToTasks < ActiveRecord::Migration
+class AddAllowConcurrencyToTasks < ActiveRecord::Migration[4.2]
   def change
     add_column :tasks, :allow_concurrency, :boolean, null: false, default: false
   end

--- a/db/migrate/20160303163611_create_shipit_commit_deployments.rb
+++ b/db/migrate/20160303163611_create_shipit_commit_deployments.rb
@@ -1,4 +1,4 @@
-class CreateShipitCommitDeployments < ActiveRecord::Migration
+class CreateShipitCommitDeployments < ActiveRecord::Migration[4.2]
   def change
     create_table :commit_deployments do |t|
       t.references :commit, foreign_key: true

--- a/db/migrate/20160303170913_create_shipit_commit_deployment_statuses.rb
+++ b/db/migrate/20160303170913_create_shipit_commit_deployment_statuses.rb
@@ -1,4 +1,4 @@
-class CreateShipitCommitDeploymentStatuses < ActiveRecord::Migration
+class CreateShipitCommitDeploymentStatuses < ActiveRecord::Migration[4.2]
   def change
     create_table :commit_deployment_statuses do |t|
       t.references :commit_deployment, index: true, foreign_key: true

--- a/db/migrate/20160303203940_add_encrypted_token_to_users.rb
+++ b/db/migrate/20160303203940_add_encrypted_token_to_users.rb
@@ -1,4 +1,4 @@
-class AddEncryptedTokenToUsers < ActiveRecord::Migration
+class AddEncryptedTokenToUsers < ActiveRecord::Migration[4.2]
   def change
     add_column :users, :encrypted_github_access_token, :string
     add_column :users, :encrypted_github_access_token_iv, :string

--- a/db/migrate/20160324155046_add_started_at_and_ended_at_on_tasks.rb
+++ b/db/migrate/20160324155046_add_started_at_and_ended_at_on_tasks.rb
@@ -1,4 +1,4 @@
-class AddStartedAtAndEndedAtOnTasks < ActiveRecord::Migration
+class AddStartedAtAndEndedAtOnTasks < ActiveRecord::Migration[4.2]
   def up
     add_column :tasks, :started_at, :datetime, null: true
     add_column :tasks, :ended_at, :datetime, null: true

--- a/db/migrate/20160426155146_add_index_for_stack_active_task.rb
+++ b/db/migrate/20160426155146_add_index_for_stack_active_task.rb
@@ -1,4 +1,4 @@
-class AddIndexForStackActiveTask < ActiveRecord::Migration
+class AddIndexForStackActiveTask < ActiveRecord::Migration[4.2]
   def change
     add_index :tasks, [:status, :stack_id, :allow_concurrency], name: :index_active_tasks
   end

--- a/db/migrate/20160502150713_add_estimated_deploy_duration_to_stacks.rb
+++ b/db/migrate/20160502150713_add_estimated_deploy_duration_to_stacks.rb
@@ -1,4 +1,4 @@
-class AddEstimatedDeployDurationToStacks < ActiveRecord::Migration
+class AddEstimatedDeployDurationToStacks < ActiveRecord::Migration[4.2]
   def change
     add_column :stacks, :estimated_deploy_duration, :integer, null: false, default: 1
   end

--- a/db/migrate/20160526192650_reorder_active_tasks_index.rb
+++ b/db/migrate/20160526192650_reorder_active_tasks_index.rb
@@ -1,4 +1,4 @@
-class ReorderActiveTasksIndex < ActiveRecord::Migration
+class ReorderActiveTasksIndex < ActiveRecord::Migration[4.2]
   def change
     remove_index :tasks, name: :index_active_tasks
     add_index :tasks, %i(stack_id allow_concurrency status), name: :index_active_tasks

--- a/db/migrate/20160802092812_add_continuous_delivery_delayed_since_to_stacks.rb
+++ b/db/migrate/20160802092812_add_continuous_delivery_delayed_since_to_stacks.rb
@@ -1,4 +1,4 @@
-class AddContinuousDeliveryDelayedSinceToStacks < ActiveRecord::Migration
+class AddContinuousDeliveryDelayedSinceToStacks < ActiveRecord::Migration[4.2]
   def change
     add_column :stacks, :continuous_delivery_delayed_since, :datetime, null: true
   end

--- a/db/migrate/20160822131405_add_locked_since_to_stacks.rb
+++ b/db/migrate/20160822131405_add_locked_since_to_stacks.rb
@@ -1,4 +1,4 @@
-class AddLockedSinceToStacks < ActiveRecord::Migration
+class AddLockedSinceToStacks < ActiveRecord::Migration[4.2]
   def change
     add_column :stacks, :locked_since, :datetime, null: true
   end


### PR DESCRIPTION
Error during running migration:
StandardError: An error has occurred, this and all later migrations canceled:

Directly inheriting from ActiveRecord::Migration is not supported. Please specify the Rails release the migration was written for:

  class CreateBaseline < ActiveRecord::Migration[4.2]