### PR TITLE
Update Rails version recommendation on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,8 +46,8 @@ This guide aims to help you [set up](#installation-and-setup), [use](#using-ship
 
 Shipit provides you with a Rails template. To bootstrap your Shipit installation:
 
-1. If you don't have Rails installed, run this command: `gem install rails -v 5.0.0.1`
-2. Run this command:  `rails _5.0.0.1_ new shipit --skip-action-cable --skip-turbolinks --skip-action-mailer -m https://raw.githubusercontent.com/Shopify/shipit-engine/master/template.rb`
+1. If you don't have Rails installed, run this command: `gem install rails -v 5.1`
+2. Run this command:  `rails _5.1_ new shipit --skip-action-cable --skip-turbolinks --skip-action-mailer -m https://raw.githubusercontent.com/Shopify/shipit-engine/master/template.rb`
 3. Enter your **Client ID**, **Client Secret**, and **GitHub API access token** when prompted. These can be found on your application's GitHub page.
 4. To setup the database, run this command: `rake db:setup`
 


### PR DESCRIPTION
As the latest gem version now requires Rails `~> 5.1.0`, we should update README as well.