### PR TITLE
Make lock author optional

### DIFF
--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -32,7 +32,7 @@ module Shipit
     has_many :github_hooks, dependent: :destroy, class_name: 'Shipit::GithubHook::Repo'
     has_many :hooks, dependent: :destroy
     has_many :api_clients, dependent: :destroy
-    belongs_to :lock_author, class_name: :User
+    belongs_to :lock_author, class_name: :User, optional: true
 
     def lock_author(*)
       super || AnonymousUser.new


### PR DESCRIPTION
Just setup our shipit server and couldn't create stack anyway. After digging for a while:

```ruby
irb(main):038:0> begin
irb(main):039:1* Shipit::Stack.create repo_name: "shipit-engine", repo_owner: "Shopify"
irb(main):040:1> rescue => exception
irb(main):041:1>   puts exception.backtrace
irb(main):042:1> end
   (0.8ms)  BEGIN
   (0.5ms)  ROLLBACK
/app/vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.0/lib/active_record/validations/presence.rb:6:in `reject'
/app/vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.0/lib/active_record/validations/presence.rb:6:in `validate_each'
/app/vendor/bundle/ruby/2.3.0/gems/activemodel-5.1.0/lib/active_model/validator.rb:150:in `block in validate'
/app/vendor/bundle/ruby/2.3.0/gems/activemodel-5.1.0/lib/active_model/validator.rb:147:in `each'
/app/vendor/bundle/ruby/2.3.0/gems/activemodel-5.1.0/lib/active_model/validator.rb:147:in `validate'
/app/vendor/bundle/ruby/2.3.0/gems/activesupport-5.1.0/lib/active_support/callbacks.rb:413:in `block in make_lambda'
/app/vendor/bundle/ruby/2.3.0/gems/activesupport-5.1.0/lib/active_support/callbacks.rb:197:in `block (2 levels) in halting'
/app/vendor/bundle/ruby/2.3.0/gems/activesupport-5.1.0/lib/active_support/callbacks.rb:601:in `block (2 levels) in default_terminator'
/app/vendor/bundle/ruby/2.3.0/gems/activesupport-5.1.0/lib/active_support/callbacks.rb:600:in `catch'
/app/vendor/bundle/ruby/2.3.0/gems/activesupport-5.1.0/lib/active_support/callbacks.rb:600:in `block in default_terminator'
/app/vendor/bundle/ruby/2.3.0/gems/activesupport-5.1.0/lib/active_support/callbacks.rb:198:in `block in halting'
/app/vendor/bundle/ruby/2.3.0/gems/activesupport-5.1.0/lib/active_support/callbacks.rb:507:in `block in invoke_before'
/app/vendor/bundle/ruby/2.3.0/gems/activesupport-5.1.0/lib/active_support/callbacks.rb:507:in `each'
/app/vendor/bundle/ruby/2.3.0/gems/activesupport-5.1.0/lib/active_support/callbacks.rb:507:in `invoke_before'
/app/vendor/bundle/ruby/2.3.0/gems/activesupport-5.1.0/lib/active_support/callbacks.rb:130:in `run_callbacks'
/app/vendor/bundle/ruby/2.3.0/gems/activesupport-5.1.0/lib/active_support/callbacks.rb:825:in `_run_validate_callbacks'
/app/vendor/bundle/ruby/2.3.0/gems/activemodel-5.1.0/lib/active_model/validations.rb:405:in `run_validations!'
/app/vendor/bundle/ruby/2.3.0/gems/activemodel-5.1.0/lib/active_model/validations/callbacks.rb:110:in `block in run_validations!'
/app/vendor/bundle/ruby/2.3.0/gems/activesupport-5.1.0/lib/active_support/callbacks.rb:131:in `run_callbacks'
/app/vendor/bundle/ruby/2.3.0/gems/activesupport-5.1.0/lib/active_support/callbacks.rb:825:in `_run_validation_callbacks'
/app/vendor/bundle/ruby/2.3.0/gems/activemodel-5.1.0/lib/active_model/validations/callbacks.rb:110:in `run_validations!'
/app/vendor/bundle/ruby/2.3.0/gems/activemodel-5.1.0/lib/active_model/validations.rb:335:in `valid?'
/app/vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.0/lib/active_record/validations.rb:65:in `valid?'
/app/vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.0/lib/active_record/validations.rb:82:in `perform_validations'
/app/vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.0/lib/active_record/validations.rb:44:in `save'
/app/vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.0/lib/active_record/attribute_methods/dirty.rb:35:in `save'
/app/vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.0/lib/active_record/transactions.rb:308:in `block (2 levels) in save'
/app/vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.0/lib/active_record/transactions.rb:384:in `block in with_transaction_returning_status'
/app/vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.0/lib/active_record/connection_adapters/abstract/database_statements.rb:225:in `block in transaction'
/app/vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.0/lib/active_record/connection_adapters/abstract/transaction.rb:194:in `block in within_new_transaction'
/app/vendor/ruby-2.3.3/lib/ruby/2.3.0/monitor.rb:214:in `mon_synchronize'
/app/vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.0/lib/active_record/connection_adapters/abstract/transaction.rb:191:in `within_new_transaction'
/app/vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.0/lib/active_record/connection_adapters/abstract/database_statements.rb:225:in `transaction'
/app/vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.0/lib/active_record/transactions.rb:210:in `transaction'
/app/vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.0/lib/active_record/transactions.rb:381:in `with_transaction_returning_status'
/app/vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.0/lib/active_record/transactions.rb:308:in `block in save'
/app/vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.0/lib/active_record/transactions.rb:323:in `rollback_active_record_state!'
/app/vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.0/lib/active_record/transactions.rb:307:in `save'
/app/vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.0/lib/active_record/suppressor.rb:42:in `save'
/app/vendor/bundle/ruby/2.3.0/gems/activerecord-5.1.0/lib/active_record/persistence.rb:34:in `create'
(irb):39:in `irb_binding'
```

caused by change introduced in Rails 5 (rails/rails#18937) and override of `lock_author` method.

Not quite sure why this wasn't discovered and fixed previously as Rails 5 should have been released for months. So please correct me if I'm wrong. Thanks!