### PR TITLE
Allow emoji in branch names

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -301,4 +301,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.15.0.pre.2
+   1.15.0

--- a/app/models/shipit/commit_message.rb
+++ b/app/models/shipit/commit_message.rb
@@ -1,6 +1,6 @@
 module Shipit
   class CommitMessage
-    GITHUB_MERGE_COMMIT_PATTERN = %r{\AMerge pull request #(?<pr_id>\d+) from [\w\-./]+\n\n(?<pr_title>.*)}
+    GITHUB_MERGE_COMMIT_PATTERN = /\AMerge pull request #(?<pr_id>\d+) from \S+\n\n(?<pr_title>.*)/
 
     def initialize(text)
       @text = text

--- a/test/models/commits_test.rb
+++ b/test/models/commits_test.rb
@@ -16,9 +16,9 @@ module Shipit
     end
 
     test "#pull_request? detects pull requests with unusual branch names" do
-      @pr.message = "Merge pull request #7 from Shopify/bump-to-v1.0.1\n\nBump to v1.0.1"
+      @pr.message = "Merge pull request #7 from Shopify/bump-👉-v1.0.1\n\nBump 👉 v1.0.1"
       assert @pr.pull_request?
-      assert_equal "Bump to v1.0.1", @pr.pull_request_title
+      assert_equal "Bump 👉 v1.0.1", @pr.pull_request_title
     end
 
     test "#pull_request_number extract the pull request id from the message" do


### PR DESCRIPTION
Shipit failed to recognize this as a merge commit due to the emoji in the branch name.  This makes the regex parsing this information more permissive to catch all valid branch names.

![screen shot 2017-06-08 at 10 04 36 am](https://user-images.githubusercontent.com/6557101/26938940-b8e7e8d0-4c43-11e7-805a-f71103db0a2d.png)
