### PR TITLE
[WIP] notify the env on a force ship

### DIFF
--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -104,11 +104,14 @@ module Shipit
 
     def build_deploy(until_commit, user, env: nil, force: false)
       since_commit = last_deployed_commit.presence || commits.first
+      deploy_environment = filter_deploy_envs(env.try!(:to_h) || {})
+      deploy_environment["FORCED_DEPLOY"] = force ? "1" : "0"
+
       deploys.build(
         user_id: user.id,
         until_commit: until_commit,
         since_commit: since_commit,
-        env: filter_deploy_envs(env.try!(:to_h) || {}),
+        env: deploy_environment,
         allow_concurrency: force,
       )
     end


### PR DESCRIPTION
@byroot mostly exploratory at the moment as I'm not particularly familiar with the shipit code.

I also noticed that you guys seem to re-use the 'force deploy' value as the 'allow_concurrency', which feels smelly, which is why I'm not re-using that downstream and instead putting it into the hash in the stack.

thoughts?