### PR TITLE
Truncate Shipit.user_access_tokens_key to 32 bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 * Index `commits` table by `(sha, stack_id)`.
 * Index `pull_requests` table by `merge_status`.
 * Fix Rails 5.1 compatibility issue when `active_record.belongs_to_required_by_default` is enabled.
+* Truncate `Shipit.user_access_tokens_key` to 32 bytes.
 
 # 0.18.1
 

--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -130,7 +130,7 @@ module Shipit
   end
 
   def user_access_tokens_key
-    (secrets.user_access_tokens_key.presence || secrets.secret_key_base).slice(0, 32)
+    (secrets.user_access_tokens_key.presence || secrets.secret_key_base).byteslice(0, 32)
   end
 
   def host

--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -130,7 +130,7 @@ module Shipit
   end
 
   def user_access_tokens_key
-    secrets.user_access_tokens_key.presence || secrets.secret_key_base
+    (secrets.user_access_tokens_key.presence || secrets.secret_key_base).slice(0, 32)
   end
 
   def host


### PR DESCRIPTION
Addresses: #705 

This was the most apparent solution I thought off which didn't force users to have to provide shorter `secret_key_base`.

There wasn't a `CONTRIBUTING.md`, so I wasn't sure of commit/code styling, I just kept it simple.