### PR TITLE
Mark deploys if they ignored safeties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Marks deploys that are triggered while ignoring safety features.
+
 # 0.19.0
 
 * Fix MRI 2.4 support (https://github.com/attr-encrypted/attr_encrypted/issues/258)

--- a/app/assets/stylesheets/_pages/_deploy.scss
+++ b/app/assets/stylesheets/_pages/_deploy.scss
@@ -212,3 +212,7 @@
     border: none;
   }
 }
+
+.ignored-safeties {
+  color: $orange;
+}

--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -46,6 +46,7 @@ module Shipit
         until_commit: until_commit,
         env: env.try!(:to_h) || {},
         allow_concurrency: force,
+        ignored_safeties: force,
       )
     end
 

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -97,6 +97,7 @@ module Shipit
         since_commit_id: commit.id,
         env: definition.filter_envs(env),
         allow_concurrency: definition.allow_concurrency? || force,
+        ignored_safeties: force,
       )
       task.enqueue
       task
@@ -110,6 +111,7 @@ module Shipit
         since_commit: since_commit,
         env: filter_deploy_envs(env.try!(:to_h) || {}),
         allow_concurrency: force,
+        ignored_safeties: force || !until_commit.deployable?,
       )
     end
 

--- a/app/serializers/shipit/task_serializer.rb
+++ b/app/serializers/shipit/task_serializer.rb
@@ -19,6 +19,7 @@ module Shipit
       updated_at
       created_at
       env
+      ignored_safeties
     ))
 
     def revision

--- a/app/views/shipit/deploys/_deploy.html.erb
+++ b/app/views/shipit/deploys/_deploy.html.erb
@@ -20,6 +20,7 @@
         <span class="sha"><%= link_to_github_deploy(deploy) %></span>
         <span class="code-additions">+<%= deploy.additions %></span>
         <span class="code-deletions">-<%= deploy.deletions %></span>
+        <% if deploy.ignored_safeties? %><span class="ignored-safeties">ignoring safeties</span><% end %>
       </p>
       <p class="commit-meta">
         <% if read_only %>

--- a/app/views/shipit/tasks/_task.html.erb
+++ b/app/views/shipit/tasks/_task.html.erb
@@ -18,6 +18,7 @@
       </span>
       <p class="commit-meta">
         ran a command
+        <% if task.ignored_safeties? %><span class="ignored-safeties">ignoring safeties</span><% end %>
       </p>
       <p class="commit-meta">
         <% if read_only %>
@@ -25,6 +26,7 @@
         <% else %>
           <%= timeago_tag(task.created_at, force: true) %>
         <% end %>
+        
       </p>
     </div>
   </li>

--- a/db/migrate/20170629141736_add_ignored_safeties_on_tasks.rb
+++ b/db/migrate/20170629141736_add_ignored_safeties_on_tasks.rb
@@ -1,0 +1,5 @@
+class AddIgnoredSafetiesOnTasks < ActiveRecord::Migration[5.1]
+  def change
+    add_column :tasks, :ignored_safeties, :boolean, default: false, null: false
+  end
+end

--- a/lib/shipit/task_commands.rb
+++ b/lib/shipit/task_commands.rb
@@ -38,6 +38,7 @@ module Shipit
         'SHIPIT_LINK' => permalink,
         'LAST_DEPLOYED_SHA' => @stack.last_deployed_commit.sha,
         'TASK_ID' => @task.id.to_s,
+        'IGNORED_SAFETIES' => @task.ignored_safeties? ? '1' : '0',
       ).merge(deploy_spec.machine_env).merge(@task.env)
     end
 

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170524125249) do
+ActiveRecord::Schema.define(version: 20170629141736) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text "permissions", limit: 65535
@@ -214,6 +214,7 @@ ActiveRecord::Schema.define(version: 20170524125249) do
     t.boolean "allow_concurrency", default: false, null: false
     t.datetime "started_at"
     t.datetime "ended_at"
+    t.boolean "ignored_safeties", default: false, null: false
     t.index ["rolled_up", "created_at", "status"], name: "index_tasks_on_rolled_up_and_created_at_and_status"
     t.index ["since_commit_id"], name: "index_tasks_on_since_commit_id"
     t.index ["stack_id", "allow_concurrency", "status"], name: "index_active_tasks"

--- a/test/models/deploys_test.rb
+++ b/test/models/deploys_test.rb
@@ -339,6 +339,11 @@ module Shipit
       assert_equal @user, @stack.lock_author
     end
 
+    test "#trigger_rollback marks the rollback as `ignored_safeties` if the force option was used" do
+      rollback = @deploy.trigger_rollback(@user, force: true)
+      assert_predicate rollback, :ignored_safeties?
+    end
+
     test "abort! transition to `aborting`" do
       @deploy.ping
       @deploy.abort!

--- a/test/unit/deploy_commands_test.rb
+++ b/test/unit/deploy_commands_test.rb
@@ -188,6 +188,12 @@ module Shipit
       assert_equal 'BAR', command.env['FOO']
     end
 
+    test "IGNORED_SAFETIES is exposed" do
+      assert_equal '0', @commands.env['IGNORED_SAFETIES']
+      @deploy.ignored_safeties = true
+      assert_equal '1', @commands.env['IGNORED_SAFETIES']
+    end
+
     test "#clear_working_directory rm -rf the working directory" do
       FileUtils.expects(:rm_rf).with(@deploy.working_directory)
       @commands.clear_working_directory


### PR DESCRIPTION
Fix: https://github.com/Shopify/shipit-engine/issues/699

Ignoring safeties can mean two things:

  - Deploying while commit statuses wouldn't allow it using the emergency mode
  - Deploying or running a task concurrently

As usual, some awesome frontend work (:trollface:).

![capture d ecran 2017-06-29 a 17 29 06](https://user-images.githubusercontent.com/19192189/27695993-be7397dc-5cf0-11e7-8c8a-d30892480710.png)

I guess an icon instead would have been nice, but it's out of my reach.

As for recording the reason, I just can't figure out a proper UX / UI for it, so I prefer not to do some subpar flow.

cc @pallan @orenmazor @perobertson


