### PR TITLE
Reconsider commits for locking after a rollback happened

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
-* Marks deploys that are triggered while ignoring safety features.
+* Reconsider all undeployed commits for locking after a rollback has completed (https://github.com/Shopify/shipit-engine/issues/707).
+* Marks deploys that are triggered while ignoring safety features (https://github.com/Shopify/shipit-engine/issues/699).
 
 # 0.19.0
 

--- a/app/jobs/shipit/github_sync_job.rb
+++ b/app/jobs/shipit/github_sync_job.rb
@@ -16,23 +16,17 @@ module Shipit
 
         @stack.transaction do
           shared_parent.try!(:detach_children!)
-          new_commits.each do |gh_commit|
+          appended_commits = new_commits.map do |gh_commit|
             append_commit(gh_commit)
           end
+          @stack.lock_reverted_commits! if appended_commits.any?(&:revert?)
         end
       end
       CacheDeploySpecJob.perform_later(@stack)
     end
 
     def append_commit(gh_commit)
-      appended_commit = @stack.commits.create_from_github!(gh_commit)
-      if appended_commit.revert?
-        impacted_commits = @stack.undeployed_commits.reverse.drop_while { |c| !appended_commit.revert_of?(c) }
-        impacted_commits.pop # appended_commit
-        impacted_commits.each do |impacted_commit|
-          impacted_commit.update!(locked: true)
-        end
-      end
+      @stack.commits.create_from_github!(gh_commit)
     end
 
     def fetch_missing_commits(&block)

--- a/app/models/shipit/rollback.rb
+++ b/app/models/shipit/rollback.rb
@@ -2,6 +2,10 @@ module Shipit
   class Rollback < Deploy
     belongs_to :deploy, foreign_key: :parent_id
 
+    state_machine :status do
+      after_transition to: :success, do: :lock_reverted_commits
+    end
+
     def rollback?
       true
     end
@@ -29,6 +33,10 @@ module Shipit
     end
 
     private
+
+    def lock_reverted_commits
+      stack.lock_reverted_commits!
+    end
 
     def create_commit_deployments
       # Rollback events are confusing in GitHub

--- a/test/models/rollbacks_test.rb
+++ b/test/models/rollbacks_test.rb
@@ -3,6 +3,7 @@ require 'test_helper'
 module Shipit
   class RollbackTest < ActiveSupport::TestCase
     setup do
+      @stack = shipit_stacks(:shipit)
       @rollback = Rollback.new
     end
 
@@ -16,6 +17,39 @@ module Shipit
 
     test "#supports_rollback? returns false" do
       refute @rollback.supports_rollback?
+    end
+
+    test "when a rollback succeed reverted commits are locked" do
+      @stack.tasks.where.not(id: shipit_tasks(:shipit_complete).id).delete_all
+
+      deploy = @stack.deploys.success.last
+      reverted_commit = deploy.until_commit
+
+      @stack.commits.create!(
+        sha: '50ce7d4440fcd8c734f8b7b76c86f8db46706e4f',
+        message: %(Revert "#{reverted_commit.message_header}"),
+        author: reverted_commit.author,
+        committer: reverted_commit.committer,
+        authored_at: Time.zone.now,
+        committed_at: Time.zone.now,
+      )
+
+      expected = [
+        ['Revert "Merge pull request #7 from shipit-engine/yoloshipit"', false],
+        ['fix all the things', false],
+      ]
+      assert_equal expected, @stack.undeployed_commits.map { |c| [c.title, c.locked?] }
+
+      rollback = deploy.trigger_revert
+      rollback.run!
+      rollback.complete!
+
+      expected = [
+        ['Revert "Merge pull request #7 from shipit-engine/yoloshipit"', false],
+        ['fix all the things', true],
+        ['yoloshipit!', true],
+      ]
+      assert_equal expected, @stack.undeployed_commits.map { |c| [c.title, c.locked?] }
     end
   end
 end


### PR DESCRIPTION
Fix: https://github.com/Shopify/shipit-engine/issues/707

Now, after a rollback is completed, the heuristic to identify reverts and lock reverted ranges is ran again.

