### PR TITLE
Return conflict when task trigger causes `ConcurrentTaskRunning`

### DIFF
--- a/app/controllers/shipit/api/tasks_controller.rb
+++ b/app/controllers/shipit/api/tasks_controller.rb
@@ -17,6 +17,10 @@ module Shipit
       end
       def trigger
         render_resource stack.trigger_task(params[:task_name], current_user, env: params.env), status: :accepted
+      rescue Shipit::Task::ConcurrentTaskRunning
+        render status: :conflict, json: {
+          message: 'A task is already running.',
+        }
       end
     end
   end

--- a/test/controllers/api/tasks_controller_test.rb
+++ b/test/controllers/api/tasks_controller_test.rb
@@ -81,6 +81,14 @@ module Shipit
         post :trigger, params: {stack_id: @stack.to_param, task_name: 'doesnt_exist'}
         assert_response :not_found
       end
+
+      test "#trigger returns 409 when a task is already running" do
+        shipit_deploys(:shipit_running).update!(allow_concurrency: false, status: 'running')
+        assert_predicate @stack, :active_task?
+        post :trigger, params: {stack_id: @stack.to_param, task_name: 'restart'}
+        assert_response :conflict
+        assert_json 'message', 'A task is already running.'
+      end
     end
   end
 end


### PR DESCRIPTION
Fixes 500 error when triggering a task via the API, but one is already running.