### PR TITLE
Rename "Pull Requests" menu item to "Merge Queue"

### DIFF
--- a/app/views/shipit/stacks/_header.html.erb
+++ b/app/views/shipit/stacks/_header.html.erb
@@ -21,7 +21,7 @@
     </li>
     <% if stack.merge_queue_enabled? %>
       <li class="nav__list__item">
-        <%= link_to "Pull Requests (#{stack.pull_requests.queued.count})", stack_pull_requests_path(stack) %>
+        <%= link_to "Merge Queue (#{stack.pull_requests.queued.count})", stack_pull_requests_path(stack) %>
       </li>
     <% end %>
 


### PR DESCRIPTION
"Pull Requests" does not convey a lot of information. The page this takes you to does not just contain any pull requests, it contains a list of pull requests that are queued to be merged.

It is the "Merge Queue", which is why I propose to change the name.