### PR TITLE
Make the backlog leniency factor configurable when determining the merge status

### DIFF
--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -191,14 +191,15 @@ module Shipit
       commits.reachable.first.try!(:sha)
     end
 
-    def merge_status
+    def merge_status(backlog_leniency_factor: 1.5)
       return 'locked' if locked?
       return 'failure' if %w(failure error).freeze.include?(branch_status)
-      if maximum_commits_per_deploy && (undeployed_commits_count > maximum_commits_per_deploy * 1.5)
-        'backlogged'
-      else
-        'success'
-      end
+      return 'backlogged' if backlogged?(backlog_leniency_factor: backlog_leniency_factor)
+      'success'
+    end
+
+    def backlogged?(backlog_leniency_factor: 1.5)
+      maximum_commits_per_deploy && (undeployed_commits_count > maximum_commits_per_deploy * backlog_leniency_factor)
     end
 
     def branch_status

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -428,6 +428,13 @@ module Shipit
       assert_equal 'backlogged', @stack.merge_status
     end
 
+    test "#merge_status returns success with a higher leniency factor" do
+      @stack.deploys_and_rollbacks.destroy_all
+      @stack.update_undeployed_commits_count
+      @stack.reload
+      assert_equal 'success', @stack.merge_status(backlog_leniency_factor: 2.0)
+    end
+
     test "#handle_github_redirections update the stack if the repository was renamed" do
       repo_permalink = 'https://api.github.com/repositories/42'
 


### PR DESCRIPTION
Right now, the backlog factor is hardcoded to be 1.5 times the maximum number of commits per deploy. This change allows you to override this 1.5 factor.

The reason for this change is to allow using different factors for the merge queue, and manual merges. I'd like to be able to report "backlogged" as status to people that are trying to merge manually, but give the merge queue a bit more leniency to still get commits merged.