### PR TITLE
Make sure kubernetes discovery does not override existing task

### DIFF
--- a/test/models/deploy_spec_test.rb
+++ b/test/models/deploy_spec_test.rb
@@ -346,6 +346,21 @@ module Shipit
       assert_equal ['bundle exec foo'], definition.steps
     end
 
+    test "#task_definitions does not add kubernetes-restart if restart task is already defined" do
+      @spec.stubs(:load_config).returns(
+        'tasks' => {'restart' => {'steps' => %w(foo)}},
+        'kubernetes' => {
+          'namespace' => 'foo',
+          'context' => 'bar',
+        },
+      )
+      tasks = @spec.task_definitions
+      assert_equal 1, tasks.size
+
+      restart_task = tasks.first
+      assert_equal ["foo"], restart_task.steps
+    end
+
     test "#task_definitions returns kubernetes commands as well as comands from the config" do
       @spec.stubs(:load_config).returns(
         'tasks' => {'another_task' => {'steps' => %w(foo)}},


### PR DESCRIPTION
Related to https://github.com/Shopify/shipit/issues/214

When I added the kubernetes-restart task, I made sure that it wouldn't override existing `restart` task. After looking into https://github.com/Shopify/shipit/issues/214, I double-checked that and added a test case.