### PR TITLE
Ability to explicitly disable `bundle exec` for tasks

### DIFF
--- a/app/models/shipit/deploy_spec/bundler_discovery.rb
+++ b/app/models/shipit/deploy_spec/bundler_discovery.rb
@@ -54,6 +54,7 @@ module Shipit
       end
 
       def coerce_task_definition(config)
+        return config if config.fetch('bundler', nil) == false
         config.merge('steps' => Array(config['steps']).map(&method(:bundle_exec)))
       end
     end

--- a/app/models/shipit/deploy_spec/kubernetes_discovery.rb
+++ b/app/models/shipit/deploy_spec/kubernetes_discovery.rb
@@ -16,6 +16,7 @@ module Shipit
               'action' => "Restart application",
               'description' => "Simulates a rollout of Kubernetes deployments by using kubernetes-restart utility",
               'steps' => [kubernetes_restart_cmd],
+              'bundler' => false,
             },
           }
         else


### PR DESCRIPTION
Ref Shopify/shipit#214, this allows you to explicitly disable `bundle exec` for a task, and disables it for the default `kubernetes-restart` tasks.