### PR TITLE
Deprecate automatically prepending `bundle exec` to tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@
 * Fix caching of discovered tasks.
 * Reconsider all undeployed commits for locking after a rollback has completed (https://github.com/Shopify/shipit-engine/issues/707).
 * Marks deploys that are triggered while ignoring safety features (https://github.com/Shopify/shipit-engine/issues/699).
-* Automatically prepending `bundle exec` to tasks is deprecated, set `SHIPIT_PREPEND_BUNDLE_EXEC=0` to test the future behaviour before it is enforced.
+* Automatically prepending `bundle exec` to tasks is deprecated, set `Shipit.automatically_prepend_bundle_exec = false` to test the future behaviour before it is enforced.
 
 # 0.19.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 * Fix caching of discovered tasks.
 * Reconsider all undeployed commits for locking after a rollback has completed (https://github.com/Shopify/shipit-engine/issues/707).
 * Marks deploys that are triggered while ignoring safety features (https://github.com/Shopify/shipit-engine/issues/699).
+* Automatically prepending `bundle exec` to tasks is deprecated, set `SHIPIT_PREPEND_BUNDLE_EXEC=0` to test the future behaviour before it is enforced.
 
 # 0.19.0
 

--- a/app/models/shipit/deploy_spec/bundler_discovery.rb
+++ b/app/models/shipit/deploy_spec/bundler_discovery.rb
@@ -54,7 +54,16 @@ module Shipit
       end
 
       def coerce_task_definition(config)
-        config.merge('steps' => Array(config['steps']).map(&method(:bundle_exec)))
+        coerced_steps = Array(config['steps']).map do |command|
+          should_prepend_bundle_exec?(command) ? bundle_exec(command) : command
+        end
+        config.merge('steps' => coerced_steps)
+      end
+
+      private
+
+      def should_prepend_bundle_exec?(command)
+        Shipit.automatically_prepend_bundle_exec && !command.start_with?('bundle exec')
       end
     end
   end

--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -57,6 +57,7 @@ module Shipit
   delegate :table_name_prefix, to: :secrets
 
   attr_accessor :disable_api_authentication
+  attr_writer :automatically_prepend_bundle_exec
 
   def app_name
     @app_name ||= secrets.app_name || Rails.application.class.name.split(':').first || 'Shipit'
@@ -207,8 +208,14 @@ module Shipit
   end
 
   def automatically_prepend_bundle_exec
-    # Prepending `bundle exec` automatically is deprecated
-    Rails.env.production? && ENV.fetch('SHIPIT_PREPEND_BUNDLE_EXEC', '1') != '0'
+    unless defined?(@automatically_prepend_bundle_exec)
+      ActiveSupport::Deprecation.warn(
+        'Automatically prepending `bundle exec` will be removed in a future version of Shipit, '\
+        'set `Shipit.automatically_prepend_bundle_exec = false` to test the new behaviour.',
+      )
+      @automatically_prepend_bundle_exec = true
+    end
+    @automatically_prepend_bundle_exec
   end
 
   protected

--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -206,6 +206,11 @@ module Shipit
     secrets.commands_inactivity_timeout || 5.minutes.to_i
   end
 
+  def automatically_prepend_bundle_exec
+    # Prepending `bundle exec` automatically is deprecated
+    Rails.env.production? && ENV.fetch('SHIPIT_PREPEND_BUNDLE_EXEC', '1') != '0'
+  end
+
   protected
 
   def revision_file

--- a/template.rb
+++ b/template.rb
@@ -126,6 +126,8 @@ Sidekiq.configure_client do |config|
 end
 CODE
 
+environment 'Shipit.automatically_prepend_bundle_exec = false'
+
 if yes?("Are you hosting Shipit on Heroku? (y/n)")
   inject_into_file "Gemfile", "ruby '#{RUBY_VERSION}'", after: "source 'https://rubygems.org'\n"
 

--- a/test/models/deploy_spec_test.rb
+++ b/test/models/deploy_spec_test.rb
@@ -6,7 +6,6 @@ module Shipit
       @app_dir = '/tmp/'
       @spec = DeploySpec::FileSystem.new(@app_dir, 'env')
       @spec.stubs(:load_config).returns({})
-      Shipit.stubs(:automatically_prepend_bundle_exec).returns(true)
     end
 
     test '#supports_fetch_deployed_revision? returns false by default' do

--- a/test/models/deploy_spec_test.rb
+++ b/test/models/deploy_spec_test.rb
@@ -318,6 +318,15 @@ module Shipit
       assert_equal 'SAFETY_DISABLED', variable_definition.name
     end
 
+    test "task definitions prepend bundle exec by default" do
+      @spec.expects(:load_config).returns('tasks' => {'restart' => {'steps' => %w(foo)}})
+      @spec.expects(:bundler?).returns(true).at_least_once
+      assert_deprecated(/Automatically prepending `bundle exec`/) do
+        definition = @spec.find_task_definition('restart')
+        assert_equal ['bundle exec foo'], definition.steps
+      end
+    end
+
     test "task definitions prepend bundle exec if enabled" do
       Shipit.expects(:automatically_prepend_bundle_exec).returns(true).at_least_once
       @spec.expects(:load_config).returns('tasks' => {'restart' => {'steps' => %w(foo)}})


### PR DESCRIPTION
Supersedes #714, this deprecates automatically prepending `bundle exec` to tasks, though we maintain the default behaviour for Capistrano, and prepend `bundle exec` if we detect bundler. We wont duplicate `bundle exec` if it's already present, allowing projects to add it themselves before setting `SHIPIT_PREPEND_BUNDLE_EXEC=0`.