### PR TITLE
Change the default leniency factor for undeployed commit backlog to 2.0

### DIFF
--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -198,14 +198,14 @@ module Shipit
       commits.reachable.first.try!(:sha)
     end
 
-    def merge_status(backlog_leniency_factor: 1.5)
+    def merge_status(backlog_leniency_factor: 2.0)
       return 'locked' if locked?
       return 'failure' if %w(failure error).freeze.include?(branch_status)
       return 'backlogged' if backlogged?(backlog_leniency_factor: backlog_leniency_factor)
       'success'
     end
 
-    def backlogged?(backlog_leniency_factor: 1.5)
+    def backlogged?(backlog_leniency_factor: 2.0)
       maximum_commits_per_deploy && (undeployed_commits_count > maximum_commits_per_deploy * backlog_leniency_factor)
     end
 

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -441,14 +441,14 @@ module Shipit
       @stack.deploys_and_rollbacks.destroy_all
       @stack.update_undeployed_commits_count
       @stack.reload
-      assert_equal 'backlogged', @stack.merge_status
+      assert_equal 'backlogged', @stack.merge_status(backlog_leniency_factor: 1.5)
     end
 
     test "#merge_status returns success with a higher leniency factor" do
       @stack.deploys_and_rollbacks.destroy_all
       @stack.update_undeployed_commits_count
       @stack.reload
-      assert_equal 'success', @stack.merge_status(backlog_leniency_factor: 2.0)
+      assert_equal 'success', @stack.merge_status(backlog_leniency_factor: 3.0)
     end
 
     test "#handle_github_redirections update the stack if the repository was renamed" do


### PR DESCRIPTION
This changes the default leniency factor of being backlogged from 1.5 to 2.0.

In practice, this means we allow two times the number of commits that the maximum amount of commits in a single deploy batch to be merged to master. This means we can start running tests on a full deploy batch while a previous deploy is ongoing, which increases deploy velocity in backlogged situations.

The drawback to this is that if something goes wrong in the deploy pipeline, we will end up with more undeployed commits that potentially have to be reverted.