### PR TITLE
Always schedule a MergePullRequestsJob for merge-queue-enabled stacks

### DIFF
--- a/app/models/shipit/pull_request.rb
+++ b/app/models/shipit/pull_request.rb
@@ -102,7 +102,7 @@ module Shipit
     end
 
     def self.schedule_merges
-      Shipit::Stack.where(id: pending.uniq.pluck(:stack_id)).find_each(&:schedule_merges)
+      Shipit::Stack.where(merge_queue_enabled: true).find_each(&:schedule_merges)
     end
 
     def self.extract_number(stack, number_or_url)


### PR DESCRIPTION
Schedule the job as part of the minutely cron, no matter if they have pending PRs or not. This is slightly less efficient, but will make it a lot easier to instrument.

