### PR TITLE
Add branch name to settings screen.

### DIFF
--- a/app/views/shipit/stacks/settings.html.erb
+++ b/app/views/shipit/stacks/settings.html.erb
@@ -14,6 +14,10 @@
         </div>
 
         <div class="field-wrapper">
+          <span>Branch: <%= @stack.branch %></span>
+        </div>
+
+        <div class="field-wrapper">
           <%= f.label :deploy_url, 'Deploy URL (Where is this stack deployed to?)' %>
           <%= f.text_field :deploy_url, placeholder: 'https://' %>
         </div>


### PR DESCRIPTION
Makes it clear what branch you're deploying from, as this is only available in the stack list right now:

![image](https://user-images.githubusercontent.com/249488/29943729-95288820-8e68-11e7-88a6-a6d003aa6fa9.png)
