### PR TITLE
Fix heroku version detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,7 +649,7 @@ These variables are accessible only during deploys and rollback:
 
 ### Heroku
 
-To use Heroku integration (`lib/snippets/push-to-heroku`), make sure that the environment has [Heroku toolbelt](https://devcenter.heroku.com/articles/heroku-cli) available.
+To use Heroku integration (`lib/snippets/push-to-heroku`), make sure that the environment has [Heroku CLI](https://devcenter.heroku.com/articles/heroku-cli) available.
 
 ### Kubernetes
 

--- a/lib/snippets/push-to-heroku
+++ b/lib/snippets/push-to-heroku
@@ -23,7 +23,7 @@ if [[ -z "${HEROKU_APP}" ]]; then
   exit 1;
 fi
 
-echo "$HEROKU_RELEASES" | head -n2 | tail -n1 | grep '^\(v[0-9]\+\)' >/dev/null
+echo "$HEROKU_RELEASES" | grep 'Current: \(v[0-9]\+\)' >/dev/null
 
 if [[ $? -ne 0 ]]; then
   red "Error detecting current heroku release. Message from 'heroku releases':"
@@ -33,7 +33,7 @@ if [[ $? -ne 0 ]]; then
   exit 1;
 fi
 
-HEROKU_LAST_GOOD_RELEASE=`echo "$HEROKU_RELEASES" | head -n2 | tail -n1 | sed -e 's/^\(v[0-9]\+\).*/\1/'`
+HEROKU_LAST_GOOD_RELEASE=`echo "$HEROKU_RELEASES" | grep 'Current: \(v[0-9]\+\)' | sed -e 's/.*\(v[0-9]\+\).*/\1/'`
 green "Current heroku release: ${HEROKU_LAST_GOOD_RELEASE}"
 
 green "Pushing to heroku."


### PR DESCRIPTION
Fixes #722 

Tested with this `heroku releases` output:

```
 ▸    heroku-cli: update available from 6.13.19 to 6.14.3-115fb1b
=== my-cool-app Releases - Current: v478
v478  Deploy df12dfe1   some@email.com  2017/08/30 22:42:05 +0000 (~ 13h ago)
v477  Deploy 9c853a05   some@email.com  2017/08/30 19:49:18 +0000 (~ 16h ago)
```

I'm unsure how to handle backwards compatibility here - do we require a minimum version of the heroku cli?