### PR TITLE
Allow pending statues on PRs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,6 @@
 dist: precise # https://github.com/travis-ci/travis-ci/issues/8331
 addons:
   apt:
-    sources:
-      - travis-ci/sqlite3
     packages:
       - sqlite3 # https://github.com/rails/rails/issues/24288#issuecomment-206011385
 language: ruby

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Pull requests with pending CI will no longer be rejected immediately from the merge queue, they will remain on the queue until CI completes, or the PR needs revalidating.
+
 # 0.20.1
 
 * Fix hook deliveries purge mechanism that wasn't deleting the correct records.

--- a/app/jobs/shipit/merge_pull_requests_job.rb
+++ b/app/jobs/shipit/merge_pull_requests_job.rb
@@ -17,6 +17,7 @@ module Shipit
 
       pull_requests.select(&:pending?).each do |pull_request|
         pull_request.refresh!
+        next unless pull_request.all_status_checks_passed?
         begin
           pull_request.merge!
         rescue PullRequest::NotReady

--- a/app/models/shipit/pull_request.rb
+++ b/app/models/shipit/pull_request.rb
@@ -146,7 +146,7 @@ module Shipit
 
     def reject_unless_mergeable!
       return reject!('merge_conflict') if merge_conflict?
-      return reject!('ci_failing') unless all_status_checks_passed?
+      return reject!('ci_failing') if any_status_checks_failed?
       false
     end
 
@@ -185,6 +185,11 @@ module Shipit
 
     def all_status_checks_passed?
       StatusChecker.new(head, head.statuses, stack.cached_deploy_spec).success?
+    end
+
+    def any_status_checks_failed?
+      status = StatusChecker.new(head, head.statuses, stack.cached_deploy_spec)
+      status.failure? || status.error?
     end
 
     def waiting?

--- a/test/fixtures/shipit/pull_requests.yml
+++ b/test/fixtures/shipit/pull_requests.yml
@@ -87,3 +87,20 @@ shipit_pending_merged:
   mergeable: null
   additions: 23
   deletions: 43
+
+shipit_mergeable_pending_ci:
+  stack: shipit
+  number: 67
+  title: Super duper nice feature
+  merge_status: pending
+  merge_requested_at: <%= 5.minute.ago.to_s(:db) %>
+  revalidated_at: <%= 5.minute.ago.to_s(:db) %>
+  merge_requested_by: walrus
+  github_id: 424244242424241
+  api_url: https://api.github.com/repos/shopify/shipit-engine/pulls/67
+  state: open
+  branch: feature-67
+  head_id: 4
+  mergeable: true
+  additions: 23
+  deletions: 43

--- a/test/jobs/merge_pull_requests_job_test.rb
+++ b/test/jobs/merge_pull_requests_job_test.rb
@@ -11,6 +11,7 @@ module Shipit
       @not_ready_pr = shipit_pull_requests(:shipit_pending_not_mergeable_yet)
       @closed_pr = shipit_pull_requests(:shipit_pending_closed)
       @merged_pr = shipit_pull_requests(:shipit_pending_merged)
+      @mergable_pending_ci = shipit_pull_requests(:shipit_mergeable_pending_ci)
     end
 
     test "#perform rejects unmergeable PRs and merge the others" do
@@ -72,6 +73,14 @@ module Shipit
       PullRequest.any_instance.stubs(:refresh!)
       @job.perform(@stack)
       assert_predicate @merged_pr.reload, :merged?
+    end
+
+    test "#perform does not reject pull requests with pending statuses" do
+      PullRequest.any_instance.stubs(:refresh!)
+      @pending_pr.cancel!
+      @job.perform(@stack)
+      refute_predicate @mergable_pending_ci.reload, :rejected?
+      refute_predicate @mergable_pending_ci.reload, :merged?
     end
   end
 end


### PR DESCRIPTION
Fixes #719 

Pull requests with pending statuses will be skipped instead of rejected, allowing them to complete and be merged if the statuses are eventually successful.