### PR TITLE
Fix `PullRequest.all_status_checks_passed?` when head us known

### DIFF
--- a/app/models/shipit/pull_request.rb
+++ b/app/models/shipit/pull_request.rb
@@ -184,6 +184,7 @@ module Shipit
     end
 
     def all_status_checks_passed?
+      return false unless head
       StatusChecker.new(head, head.statuses, stack.cached_deploy_spec).success?
     end
 

--- a/test/models/pull_request_test.rb
+++ b/test/models/pull_request_test.rb
@@ -221,5 +221,10 @@ module Shipit
         @stack.reload
       end
     end
+
+    test "#all_status_checks_passed? returns false when head commit is unknown" do
+      @pr.update(head_id: nil)
+      refute_predicate @pr, :all_status_checks_passed?
+    end
   end
 end


### PR DESCRIPTION
I want to check the status of this in HCTW, but immediately after adding to the merge queue the head commit is unknown, so we get 500s - this fixes that.