### PR TITLE
Add `Commit.deploy_requested_at`

### DIFF
--- a/app/jobs/shipit/merge_pull_requests_job.rb
+++ b/app/jobs/shipit/merge_pull_requests_job.rb
@@ -8,9 +8,7 @@ module Shipit
       pull_requests.each do |pull_request|
         pull_request.refresh!
         pull_request.reject_unless_mergeable!
-        if pull_request.closed?
-          pull_request.merged_upstream? ? pull_request.complete! : pull_request.cancel!
-        end
+        pull_request.cancel! if pull_request.closed?
       end
 
       return false unless stack.allows_merges?

--- a/app/models/shipit/commit.rb
+++ b/app/models/shipit/commit.rb
@@ -194,6 +194,14 @@ module Shipit
       self.pull_request_title = message_parser.pull_request_title unless self[:pull_request_title]
     end
 
+    def deploy_requested_at
+      if pull_request.try!(:merged?)
+        pull_request.merge_requested_at
+      else
+        created_at
+      end
+    end
+
     private
 
     def message_parser

--- a/test/fixtures/shipit/commits.yml
+++ b/test/fixtures/shipit/commits.yml
@@ -102,3 +102,17 @@ shipit_pending_pr_head:
   deletions: 24
   updated_at: <%= 8.days.ago.to_s(:db) %>
   detached: true
+
+cyclimse_merged:
+  id: 9
+  sha: 772b4795871e4a45aa17d53f02aa45d0
+  message: "Merge pull request #66 from cyclimse/yoloshipit\n\nyoloshipit!"
+  stack: cyclimse
+  author: walrus
+  committer: walrus
+  authored_at: <%= 4.days.ago.to_s(:db) %>
+  committed_at: <%= 3.days.ago.to_s(:db) %>
+  additions: 420
+  deletions: 342
+  updated_at: <%= 8.days.ago.to_s(:db) %>
+  pull_request_id: 99

--- a/test/fixtures/shipit/pull_requests.yml
+++ b/test/fixtures/shipit/pull_requests.yml
@@ -104,3 +104,21 @@ shipit_mergeable_pending_ci:
   mergeable: true
   additions: 23
   deletions: 43
+
+cyclimse_pending_merged:
+  id: 99
+  stack: cyclimse
+  number: 66
+  merge_status: merged
+  merge_requested_by: walrus
+  merge_requested_at: <%= 3.minute.ago.to_s(:db) %>
+  merged_at: <%= 2.minute.ago.to_s(:db) %>
+  revalidated_at: <%= 3.minute.ago.to_s(:db) %>
+  github_id: 43243243243232
+  api_url: https://api.github.com/repos/shopify/cyclimse/pulls/66
+  state: closed
+  branch: feature-64
+  head_id: 8
+  mergeable: null
+  additions: 23
+  deletions: 43

--- a/test/jobs/merge_pull_requests_job_test.rb
+++ b/test/jobs/merge_pull_requests_job_test.rb
@@ -68,16 +68,16 @@ module Shipit
       assert_predicate @closed_pr.reload, :canceled?
     end
 
-    test "#perform completes merge requests for already merged PRs" do
+    test "#perform cancels merge requests for manually merged PRs" do
       @pending_pr.cancel!
       PullRequest.any_instance.stubs(:refresh!)
       @job.perform(@stack)
-      assert_predicate @merged_pr.reload, :merged?
+      assert_predicate @merged_pr.reload, :canceled?
     end
 
     test "#perform does not reject pull requests with pending statuses" do
-      PullRequest.any_instance.stubs(:refresh!)
       @pending_pr.cancel!
+      PullRequest.any_instance.stubs(:refresh!)
       @job.perform(@stack)
       refute_predicate @mergable_pending_ci.reload, :rejected?
       refute_predicate @mergable_pending_ci.reload, :merged?

--- a/test/models/commits_test.rb
+++ b/test/models/commits_test.rb
@@ -551,6 +551,24 @@ module Shipit
       assert revert.revert_of?(commit)
     end
 
+    test "deploy_requested_at defaults to commit created_at" do
+      assert_equal @commit.deploy_requested_at, @commit.created_at
+    end
+
+    test "when merged via the queue, deploy_requested_at is merge_requested_at" do
+      commit = shipit_commits(:cyclimse_merged)
+      assert_predicate commit, :pull_request?
+      assert_equal commit.pull_request, shipit_pull_requests(:cyclimse_pending_merged)
+      assert_equal commit.deploy_requested_at, commit.pull_request.merge_requested_at
+    end
+
+    test "when merged manually after being queued, deploy_requested_at is created_at" do
+      pr = shipit_pull_requests(:cyclimse_pending_merged)
+      pr.cancel!
+      commit = shipit_commits(:cyclimse_merged)
+      assert_equal commit.deploy_requested_at, commit.created_at
+    end
+
     private
 
     def expect_event(stack)


### PR DESCRIPTION
This is attempt to identify when a commit entered the deploy pipeline:

* If the commit is a direct merge to master, use the local `created_at` timestamp - this is to more reliably identify when a commit was pushed to Github. `committed_at` is vulnerable to skew because commits could exist local to a developer long before they are actually pushed for  deployment
* If the commit was merged via the merge queue, use `merge_requested_at` - although not the time the commit was merged, this was the moment this commit entered the deploy pipeline
* Handle the case where the commit was added and then removed from the merge queue, and merged manually