### PR TITLE
Normalise GitHub login for api actions

### DIFF
--- a/app/controllers/shipit/api/base_controller.rb
+++ b/app/controllers/shipit/api/base_controller.rb
@@ -46,7 +46,7 @@ module Shipit
 
       def identify_user
         user_login = request.headers['X-Shipit-User'].presence
-        User.find_by(login: user_login) if user_login
+        User.where('lower(login) = ?', user_login.downcase).first if user_login
       end
 
       def stacks

--- a/dev.yml
+++ b/dev.yml
@@ -7,7 +7,7 @@ up:
     - openssl
     - sqlite
   - ruby:
-      version: 2.2.3
+      version: 2.3.3
   - railgun
   - bundler:
       without: ci

--- a/test/controllers/api/deploys_controller_test.rb
+++ b/test/controllers/api/deploys_controller_test.rb
@@ -40,6 +40,13 @@ module Shipit
         deploy.user == @user
       end
 
+      test "#create normalises the claimed user" do
+        request.headers['X-Shipit-User'] = @user.login.swapcase
+        post :create, params: {stack_id: @stack.to_param, sha: @commit.sha}
+        deploy = Deploy.last
+        assert_equal deploy.user, @user
+      end
+
       test "#create renders a 422 if the sha isn't found" do
         post :create, params: {stack_id: @stack.to_param, sha: '123443543545'}
         assert_response :unprocessable_entity


### PR DESCRIPTION
GitHub usernames are case-insensitive - though the case is preserved - so we should normalise when searching by login. 

Given we have to support 3 database engines, this seems quite complex to achieve at the schema level. I think it's reasonable to assume the users table will always be relatively small, so this simple but slightly inefficient approach is hopefully fine, and works across the databases.