### PR TITLE
Move dev/railgun to myshopify.io domain

### DIFF
--- a/config/secrets.development.shopify.yml
+++ b/config/secrets.development.shopify.yml
@@ -1,4 +1,4 @@
-host: 'http://shipit-engine.localhost'
+host: 'https://shipit-engine.myshopify.io'
 redis_url: 'redis://shipit-engine.railgun:6379'
 
 github_api:

--- a/dev.yml
+++ b/dev.yml
@@ -19,7 +19,7 @@ commands:
   test: bin/rails test "$@"
 
 open:
-  shipit: http://shipit-engine.localhost
+  shipit: https://shipit-engine.myshopify.io
 
 packages:
   - git@github.com:Shopify/dev-shopify.git

--- a/railgun.yml
+++ b/railgun.yml
@@ -15,4 +15,4 @@ services:
   - nginx
 
 hostnames:
-  - shipit-engine.localhost: { proxy_to_host_port: 55330 }
+  - shipit-engine.myshopify.io: { proxy_to_host_port: 55330 }


### PR DESCRIPTION
My Chrome gives connection refused for `shipit-engine.localhost` - I wonder if it considers itself authoritative for `localhost` and bypasses resolvers/hosts file. This works for me - and switches to SSL as a bonus - but requires Shopify developers to update their OAuth apps with a new callback URL.