### PR TITLE
Add `force` to stack cache key

### DIFF
--- a/app/views/shipit/stacks/show.html.erb
+++ b/app/views/shipit/stacks/show.html.erb
@@ -21,7 +21,7 @@
     </ul>
   </section>
 
-  <% cache @stack do %>
+  <% cache [@stack, params[:force]] do %>
     <section>
       <header class="section-header">
         <h2>Previous Deploys</h2>


### PR DESCRIPTION
On our installation we've encountered situations when the 'Redeploy' button is disabled when it shouldn't be, fragment cache is the likely suspect. This is a best guess fix, I unfortunately have not been able to replicate this locally - in development mode, I'm not entirely sure I ever got the fragment cache actually enabled+working - I added this to `test/dummy/config/environments/development.rb`

```
  config.cache_store = :memory_store, { size: 64.megabytes }
  config.log_level = :debug
  config.action_controller.perform_caching = true
```

.. an ran `bin/rails app:dev:cache` to enable the cache. I saw some blogs suggesting I should see cache activity in the logs, but I never saw any :(

I also tried to write a unit test for this but struggled with the same issues :(