### PR TITLE
Doc fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,15 @@ deploy:
 ```
 <br>
 
+**<code>deploy.interval</code>** defines the interval between the end of a deploy and the next deploy, when continuous delivery is enabled. You can use s, m, h, d as units for seconds, minutes, hours, and days. Defaults to 0, which means a new deploy will start as soon as the current one finishes.
+
+For example, this will wait 5 minutes after the end of a deploy before starting a new one:
+
+```yaml
+deploy:
+  interval: 5m
+```
+
 **<code>rollback.override</code>** contains an array of the shell commands required to rollback the application to a previous state. Shipit will try to infer it from the repository structure, but you can change the default inference. This key defaults to `disabled` unless Capistrano is detected.
 
 For example:

--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ The settings in the `shipit.yml` file relate to the different things you can do 
 * [Deployment](#deployment) (`deploy`, `rollback`, `fetch`)
 * [Environment](#environment) (`machine.environment`, `machine.directory`, `machine.cleanup`)
 * [CI](#ci) (`ci.require`, `ci.hide`, `ci.allow_failures`)
+* [Merge Queue](#merge-queue) (`merge.revalidate_after`, `merge.require`, `merge.ignore`)
 * [Custom Tasks](#custom-tasks) (`restart`, `unlock`)
 * [Review Process](#review-process) (`monitor`, `checklist`, `checks`)
 

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ The settings in the `shipit.yml` file relate to the different things you can do 
 * [Environment](#environment) (`machine.environment`, `machine.directory`, `machine.cleanup`)
 * [CI](#ci) (`ci.require`, `ci.hide`, `ci.allow_failures`)
 * [Merge Queue](#merge-queue) (`merge.revalidate_after`, `merge.require`, `merge.ignore`)
-* [Custom Tasks](#custom-tasks) (`restart`, `unlock`)
-* [Review Process](#review-process) (`monitor`, `checklist`, `checks`)
+* [Custom Tasks](#custom-tasks) (`tasks`)
+* [Review Process](#review-process) (`review.checklist`, `review.monitoring`, `review.checks`)
 
 All the settings in `shipit.yml` are optional. Most applications can be deployed from Shipit without any configuration.
 
@@ -270,7 +270,7 @@ deploy:
 ```
 <br>
 
-**<code>deploy.max_commits</code>** define the maximum number of commits that should be shipped per deploys. Defaults to `8`.
+**<code>deploy.max_commits</code>** defines the maximum number of commits that should be shipped per deploys. Defaults to `8`.
 
 Human users will be warned that they are not respecting the recommendation, but allowed to continue.
 However continuous delivery will respect this limit. If there is no deployable commits in this range, a human intervention will be required.
@@ -442,7 +442,7 @@ merge:
 
 You can create custom tasks that users execute directly from a stack's overview page in Shipit. To create a new custom task, specify its parameters in the `tasks` section of the `shipit.yml` file. For example:
 
-**<code>tasks</code>** restarts the application.
+**<code>tasks.restart</code>** restarts the application.
 
 ```yml
 tasks:


### PR DESCRIPTION
This adds documentation for `deploy.interval`, adds a link to the documentation for the `merge` section of `shipit.yml`, and fixes small typos/mistakes in the content.