### PR TITLE
Advise to push both commits and tags simultaneously

### DIFF
--- a/app/models/shipit/deploy_spec/npm_discovery.rb
+++ b/app/models/shipit/deploy_spec/npm_discovery.rb
@@ -21,12 +21,14 @@ module Shipit
 
       def discover_yarn_checklist
         [%(<strong>Don't forget version and tag before publishing!</strong> You can do this with:<br/>
-          yarn version --new-version <strong>&lt;major|minor|patch&gt;</strong> && git push --follow-tags</pre>)] if yarn?
+          yarn version --new-version <strong>&lt;major|minor|patch&gt;</strong>
+          && git push --follow-tags</pre>)] if yarn?
       end
 
       def discover_npm_checklist
         [%(<strong>Don't forget version and tag before publishing!</strong> You can do this with:<br/>
-          npm version <strong>&lt;major|minor|patch&gt;</strong> && git push --follow-tags</pre>)] if npm?
+          npm version <strong>&lt;major|minor|patch&gt;</strong>
+          && git push --follow-tags</pre>)] if npm?
       end
 
       def npm?

--- a/app/models/shipit/deploy_spec/npm_discovery.rb
+++ b/app/models/shipit/deploy_spec/npm_discovery.rb
@@ -21,12 +21,12 @@ module Shipit
 
       def discover_yarn_checklist
         [%(<strong>Don't forget version and tag before publishing!</strong> You can do this with:<br/>
-          yarn version --new-version <strong>&lt;major|minor|patch&gt;</strong> && git push --tags</pre>)] if yarn?
+          yarn version --new-version <strong>&lt;major|minor|patch&gt;</strong> && git push --follow-tags</pre>)] if yarn?
       end
 
       def discover_npm_checklist
         [%(<strong>Don't forget version and tag before publishing!</strong> You can do this with:<br/>
-          npm version <strong>&lt;major|minor|patch&gt;</strong> && git push --tags</pre>)] if npm?
+          npm version <strong>&lt;major|minor|patch&gt;</strong> && git push --follow-tags</pre>)] if npm?
       end
 
       def npm?


### PR DESCRIPTION
`git push --tags` will only push tags, whereas `git push --follow-tags` will push both commits and tags to the origin