### PR TITLE
Disable status target url links when the url is missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Fix status group links not being disabled when the status url is missing (https://github.com/Shopify/shipit-engine/issues/742).
 * Use GitHub ID to refresh users via API to avoid login escaping issues.
 * Improve hook deliveries purge mechanism to reduce database contention.
 * Pull requests with pending CI will no longer be rejected immediately from the merge queue, they will remain on the queue until CI completes, or the PR needs revalidating.

--- a/app/assets/stylesheets/_base/_base.scss
+++ b/app/assets/stylesheets/_base/_base.scss
@@ -106,6 +106,10 @@ a {
   text-decoration: none;
   cursor: pointer;
   color: $blue;
+
+  &.disabled {
+    cursor: default;
+  }
 }
 
 .more {

--- a/app/views/shipit/statuses/_group.html.erb
+++ b/app/views/shipit/statuses/_group.html.erb
@@ -9,7 +9,7 @@
     <% group.statuses.each do |status| %>
       <div class="status-item status-item--<%= status.state %> <%= :ignored if status.allowed_to_fail? %>">
         <i class="status-item__icon"></i>
-        <a href="<%= status.target_url %>" target="_blank">
+        <a href="<%= status.target_url %>" <% unless status.target_url.present? %> disabled class="disabled" <% end %> target="_blank">
           <strong class="status-item__service"><%= status.context %></strong>
         </a>
         <span class="status-item__description">&mdash; <%= status.description %></span>

--- a/app/views/shipit/statuses/_status.html.erb
+++ b/app/views/shipit/statuses/_status.html.erb
@@ -1,4 +1,4 @@
-<a class="status status--<%= status.state %> <%= :disabled unless status.target_url.present? %>" <% unless status.group? %>data-tooltip="<%= status.description.presence || status.state.capitalize %>"<% end %> href="<%= status.target_url%>" target="_blank">
+<a class="status status--<%= status.state %> <%= 'disabled' unless status.target_url.present? %>" <%= 'disabled' unless status.target_url.present? %> <% unless status.group? %>data-tooltip="<%= status.description.presence || status.state.capitalize %>"<% end %> href="<%= status.target_url%>" target="_blank">
   <i class="status__icon"></i>
   <span class="visually-hidden"><%= status.state %></span>
 </a>


### PR DESCRIPTION
Fix: https://github.com/Shopify/shipit-engine/issues/742

It was already handled for commits with a single status, but it look like that corner case was overlooked when we added proper support for multiple statuses.

This properly disable the link, so that clicking it won't have any effect, and also put the mouse cursor back the the default one, so that it doesn't seem clickable.

I would have liked to add another transformation so that it would be more evident that the target_url is missing, but couldn't think of anything beside making the link lighter, but we already use this for another purpose.
