### PR TITLE
Display flash message when enqueueing a Git Cache clearing

### DIFF
--- a/app/controllers/shipit/stacks_controller.rb
+++ b/app/controllers/shipit/stacks_controller.rb
@@ -71,6 +71,7 @@ module Shipit
 
     def clear_git_cache
       ClearGitCacheJob.perform_later(@stack)
+      flash[:success] = 'Git Cache clearing scheduled'
       redirect_to stack_settings_path(@stack)
     end
 

--- a/test/controllers/stacks_controller_test.rb
+++ b/test/controllers/stacks_controller_test.rb
@@ -156,6 +156,11 @@ module Shipit
       assert_redirected_to stack_settings_path(@stack)
     end
 
+    test "#clear_git_cache displays a flash message" do
+      post :clear_git_cache, params: {id: @stack.to_param}
+      assert_equal 'Git Cache clearing scheduled', flash[:success]
+    end
+
     test "#update redirects to return_to parameter" do
       patch :update, params: {id: @stack.to_param, stack: {ignore_ci: false}, return_to: stack_path(@stack)}
       assert_redirected_to stack_path(@stack)


### PR DESCRIPTION
This PR just adds a flash message to acknowledge the user that the background job has been scheduled to run.