### PR TITLE
Reduce test warnings

### DIFF
--- a/app/models/shipit/user.rb
+++ b/app/models/shipit/user.rb
@@ -9,6 +9,7 @@ module Shipit
     has_many :tasks
 
     attr_encrypted :github_access_token, key: Shipit.user_access_tokens_key
+    attribute :github_access_token
 
     def self.find_or_create_by_login!(login)
       find_or_create_by!(login: login) do |user|


### PR DESCRIPTION
While running the tests, I've seen a couple of instances of 
```
DEPRECATION WARNING: github_access_token is not an attribute known to Active Record. This behavior is deprecated and will be removed in the next version of Rails. If you'd like github_access_token to be managed by Active Record, add `attribute :github_access_token to your class. (called from sign_in_github at /Users/javierhonduco/src/github.com/Shopify/shipit-engine/app/controllers/shipit/github_authentication_controller.rb:25)
```

This PR attempts fixing this 😄 