### PR TITLE
Optionally reject stale pull requests from the merge queue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@
 * Use GitHub ID to refresh users via API to avoid login escaping issues.
 * Improve hook deliveries purge mechanism to reduce database contention.
 * Pull requests with pending CI will no longer be rejected immediately from the merge queue, they will remain on the queue until CI completes, or the PR needs revalidating.
+* Added optional age limits to pull requests (in commit count and time) after which they will be rejected from the merge queue.
 
 # 0.20.1
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -309,4 +309,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.15.0
+   1.16.0

--- a/README.md
+++ b/README.md
@@ -122,7 +122,7 @@ The settings in the `shipit.yml` file relate to the different things you can do 
 * [Deployment](#deployment) (`deploy`, `rollback`, `fetch`)
 * [Environment](#environment) (`machine.environment`, `machine.directory`, `machine.cleanup`)
 * [CI](#ci) (`ci.require`, `ci.hide`, `ci.allow_failures`)
-* [Merge Queue](#merge-queue) (`merge.revalidate_after`, `merge.require`, `merge.ignore`)
+* [Merge Queue](#merge-queue) (`merge.revalidate_after`, `merge.require`, `merge.ignore`, `merge.max_divergence`)
 * [Custom Tasks](#custom-tasks) (`tasks`)
 * [Review Process](#review-process) (`review.checklist`, `review.monitoring`, `review.checks`)
 
@@ -436,6 +436,24 @@ For example:
 merge:
   ignore:
     - codeclimate
+```
+
+**<code>merge.max_divergence.commits</code>** the maximum number of commits a pull request can be behind its merge base, after which pull requests are rejected from the merge queue.
+
+For example:
+```yml
+merge:
+  max_divergence:
+    commits: 50
+```
+
+**<code>merge.max_divergence.age</code>** a duration after the commit date of the merge base, after which pull requests will be rejected from the merge queue.
+
+For example:
+```yml
+merge:
+  max_divergence:
+    age: 72h
 ```
 
 <h3 id="custom-tasks">Custom tasks</h3>

--- a/app/models/shipit/deploy_spec.rb
+++ b/app/models/shipit/deploy_spec.rb
@@ -167,12 +167,12 @@ module Shipit
       end
     end
 
-    def require_rebase_commits
-      config('merge', 'require_rebase_commits')
+    def max_divergence_commits
+      config('merge', 'max_divergence', 'commits')
     end
 
-    def require_rebase_after
-      if timeout = config('merge', 'require_rebase_after')
+    def max_divergence_age
+      if timeout = config('merge', 'max_divergence', 'age')
         begin
           Duration.parse(timeout)
         rescue Duration::ParseError

--- a/app/models/shipit/deploy_spec.rb
+++ b/app/models/shipit/deploy_spec.rb
@@ -167,6 +167,19 @@ module Shipit
       end
     end
 
+    def require_rebase_commits
+      config('merge', 'require_rebase_commits')
+    end
+
+    def require_rebase_after
+      if timeout = config('merge', 'require_rebase_after')
+        begin
+          Duration.parse(timeout)
+        rescue Duration::ParseError
+        end
+      end
+    end
+
     def review_checks
       config('review', 'checks') || []
     end

--- a/app/models/shipit/deploy_spec/file_system.rb
+++ b/app/models/shipit/deploy_spec/file_system.rb
@@ -33,8 +33,10 @@ module Shipit
             'require' => pull_request_required_statuses,
             'ignore' => pull_request_ignored_statuses,
             'revalidate_after' => revalidate_pull_requests_after.try!(:to_i),
-            'require_rebase_commits' => require_rebase_commits.try!(:to_i),
-            'require_rebase_after' => require_rebase_after.try!(:to_i),
+            'max_divergence' => {
+              'commits' => max_divergence_commits.try!(:to_i),
+              'age' => max_divergence_age.try!(:to_i),
+            },
           },
           'ci' => {
             'hide' => hidden_statuses,

--- a/app/models/shipit/deploy_spec/file_system.rb
+++ b/app/models/shipit/deploy_spec/file_system.rb
@@ -33,6 +33,8 @@ module Shipit
             'require' => pull_request_required_statuses,
             'ignore' => pull_request_ignored_statuses,
             'revalidate_after' => revalidate_pull_requests_after.try!(:to_i),
+            'require_rebase_commits' => require_rebase_commits.try!(:to_i),
+            'require_rebase_after' => require_rebase_after.try!(:to_i),
           },
           'ci' => {
             'hide' => hidden_statuses,

--- a/app/models/shipit/pull_request.rb
+++ b/app/models/shipit/pull_request.rb
@@ -37,6 +37,7 @@ module Shipit
 
     belongs_to :stack
     belongs_to :head, class_name: 'Shipit::Commit', optional: true
+    belongs_to :base_commit, class_name: 'Shipit::Commit', optional: true
     belongs_to :merge_requested_by, class_name: 'Shipit::User', optional: true
     has_one :merge_commit, class_name: 'Shipit::Commit'
 
@@ -240,6 +241,8 @@ module Shipit
       self.branch = github_pull_request.head.ref
       self.head = find_or_create_commit_from_github_by_sha!(github_pull_request.head.sha, detached: true)
       self.merged_at = github_pull_request.merged_at
+      self.base_ref = github_pull_request.base.ref
+      self.base_commit = find_or_create_commit_from_github_by_sha!(github_pull_request.base.sha, detached: true)
     end
 
     def merge_message

--- a/app/models/shipit/pull_request.rb
+++ b/app/models/shipit/pull_request.rb
@@ -258,7 +258,7 @@ module Shipit
       if max_branch_age = spec.max_divergence_age
         return true if Time.now.utc - head.committed_at > max_branch_age
       end
-      if commit_count_limit = spec.require_rebase_commits
+      if commit_count_limit = spec.max_divergence_commits
         return true if comparison.behind_by > commit_count_limit
       end
       false

--- a/app/models/shipit/pull_request.rb
+++ b/app/models/shipit/pull_request.rb
@@ -4,7 +4,7 @@ module Shipit
 
     WAITING_STATUSES = %w(fetching pending).freeze
     QUEUED_STATUSES = %w(pending revalidating).freeze
-    REJECTION_REASONS = %w(ci_failing merge_conflict).freeze
+    REJECTION_REASONS = %w(ci_failing merge_conflict requires_rebase).freeze
     InvalidTransition = Class.new(StandardError)
     NotReady = Class.new(StandardError)
 
@@ -148,6 +148,7 @@ module Shipit
     def reject_unless_mergeable!
       return reject!('merge_conflict') if merge_conflict?
       return reject!('ci_failing') if any_status_checks_failed?
+      return reject!('requires_rebase') if stale?
       false
     end
 

--- a/db/migrate/20171120161420_add_base_info_to_pull_request.rb
+++ b/db/migrate/20171120161420_add_base_info_to_pull_request.rb
@@ -1,0 +1,7 @@
+class AddBaseInfoToPullRequest < ActiveRecord::Migration[5.1]
+  def change
+    add_column :pull_requests, :base_ref, :string, limit: 1024
+    add_column :pull_requests, :base_commit_id, :integer
+    add_foreign_key :pull_requests, :commits, column: :base_commit_id
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170904103242) do
+ActiveRecord::Schema.define(version: 20171120161420) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text "permissions", limit: 65535
@@ -147,6 +147,8 @@ ActiveRecord::Schema.define(version: 20170904103242) do
     t.string "branch"
     t.datetime "revalidated_at"
     t.datetime "merged_at"
+    t.string "base_ref", limit: 1024
+    t.integer "base_commit_id"
     t.index ["head_id"], name: "index_pull_requests_on_head_id"
     t.index ["merge_requested_by_id"], name: "index_pull_requests_on_merge_requested_by_id"
     t.index ["merge_status"], name: "index_pull_requests_on_merge_status"

--- a/test/models/deploy_spec_test.rb
+++ b/test/models/deploy_spec_test.rb
@@ -284,8 +284,10 @@ module Shipit
           'require' => [],
           'ignore' => [],
           'revalidate_after' => nil,
-          'require_rebase_commits' => nil,
-          'require_rebase_after' => nil,
+          'max_divergence' => {
+            'commits' => nil,
+            'age' => nil,
+          },
         },
         'ci' => {
           'hide' => [],
@@ -703,18 +705,20 @@ module Shipit
       assert_match(/yarn version/, @spec.review_checklist[0])
     end
 
-    test "require_rebase_commits defaults to `nil" do
+    test "max_divergence_commits defaults to `nil" do
       @spec.expects(:load_config).returns({})
-      assert_nil @spec.require_rebase_commits
+      assert_nil @spec.max_divergence_commits
     end
 
-    test "require_rebase_after defaults to `nil` if `merge.require_rebase_after` cannot be parsed" do
+    test "max_divergence_age defaults to `nil` if `merge.max_divergence.age` cannot be parsed" do
       @spec.expects(:load_config).returns(
         'merge' => {
-          'require_rebase_after' => 'badbadbad',
+          'max_divergence' => {
+            'age' => 'badbadbad',
+          },
         },
       )
-      assert_nil @spec.require_rebase_after
+      assert_nil @spec.max_divergence_age
     end
   end
 end

--- a/test/models/deploy_spec_test.rb
+++ b/test/models/deploy_spec_test.rb
@@ -284,6 +284,8 @@ module Shipit
           'require' => [],
           'ignore' => [],
           'revalidate_after' => nil,
+          'require_rebase_commits' => nil,
+          'require_rebase_after' => nil,
         },
         'ci' => {
           'hide' => [],
@@ -699,6 +701,20 @@ module Shipit
     test 'yarn checklist takes precedence over npm checklist' do
       @spec.stubs(:yarn?).returns(true).at_least_once
       assert_match(/yarn version/, @spec.review_checklist[0])
+    end
+
+    test "require_rebase_commits defaults to `nil" do
+      @spec.expects(:load_config).returns({})
+      assert_nil @spec.require_rebase_commits
+    end
+
+    test "require_rebase_after defaults to `nil` if `merge.require_rebase_after` cannot be parsed" do
+      @spec.expects(:load_config).returns(
+        'merge' => {
+          'require_rebase_after' => 'badbadbad',
+        },
+      )
+      assert_nil @spec.require_rebase_after
     end
   end
 end

--- a/test/models/pull_request_test.rb
+++ b/test/models/pull_request_test.rb
@@ -68,6 +68,7 @@ module Shipit
       pull_request = shipit_pull_requests(:shipit_fetching)
 
       head_sha = '64b3833d39def7ec65b57b42f496eb27ab4980b6'
+      base_sha = 'ba7ab50e02286f7d6c60c1ef75258133dd9ea763'
       Shipit.github_api.expects(:pull_request).with(@stack.github_repo_name, pull_request.number).returns(
         stub(
           id: 4_857_578,
@@ -82,6 +83,10 @@ module Shipit
             ref: 'super-branch',
             sha: head_sha,
           ),
+          base: stub(
+            ref:  'default-branch',
+            sha: base_sha,
+          )
         ),
       )
 
@@ -91,22 +96,25 @@ module Shipit
         name: 'Bob the Builder',
         email: 'bob@bob.com',
       )
-      Shipit.github_api.expects(:commit).with(@stack.github_repo_name, head_sha).returns(
-        stub(
-          sha: head_sha,
-          author: author,
-          committer: author,
-          commit: stub(
-            message: 'Great feature',
-            author: stub(date: 1.day.ago),
-            committer: stub(date: 1.day.ago),
+
+      [head_sha, base_sha].each do |sha|
+        Shipit.github_api.expects(:commit).with(@stack.github_repo_name, sha).returns(
+          stub(
+            sha: sha,
+            author: author,
+            committer: author,
+            commit: stub(
+              message: 'Great feature',
+              author: stub(date: 1.day.ago),
+              committer: stub(date: 1.day.ago),
+            ),
+            stats: stub(
+              additions: 24,
+              deletions: 5,
+            ),
           ),
-          stats: stub(
-            additions: 24,
-            deletions: 5,
-          ),
-        ),
-      )
+        )
+      end
 
       Shipit.github_api.expects(:statuses).with(@stack.github_repo_name, head_sha).returns([stub(
         state: 'success',

--- a/test/models/pull_request_test.rb
+++ b/test/models/pull_request_test.rb
@@ -254,7 +254,7 @@ module Shipit
           behind_by: 10,
         ),
       )
-      spec = {'merge' => {'require_rebase_commits' => 1}}
+      spec = {'merge' => {'max_divergence' => {'commits' => 1}}}
       @pr.stack.cached_deploy_spec = DeploySpec.new(spec)
       assert_predicate @pr, :stale?
     end


### PR DESCRIPTION
Fixes #720 

This will reject a PR from the merge queue if the head commit is either older than the base commit for a given timespan, or if the branch falls behind the base more than a given number of commits. WIP just after some feedback:

* Have I done the migration + relation correct for `PullRequest.base_commit`?
* Is supporting both a number of commits and time frame a good idea?
* Is `requires_rebase` a good status name? `excess_divergence` seems a bit much :trollface: 
* I'm sure there's a better name for `merge.require_rebase_commits` - after your branch falls behind by this # of commits, it's considered stale.