### PR TITLE
Add base_ref and branch to PullRequestSerializer

### DIFF
--- a/app/serializers/shipit/pull_request_serializer.rb
+++ b/app/serializers/shipit/pull_request_serializer.rb
@@ -7,7 +7,7 @@ module Shipit
     has_one :head, serializer: ShortCommitSerializer
 
     attributes :id, :number, :title, :github_id, :additions, :deletions, :state, :merge_status, :mergeable,
-               :merge_requested_at, :rejection_reason, :html_url
+               :merge_requested_at, :rejection_reason, :html_url, :branch, :base_ref
 
     def html_url
       github_pull_request_url(object)


### PR DESCRIPTION
So these can be referenced in rejection notifications.