### PR TITLE
Publish lerna monorepos (fixed version only)

### DIFF
--- a/app/models/shipit/deploy_spec/file_system.rb
+++ b/app/models/shipit/deploy_spec/file_system.rb
@@ -2,6 +2,7 @@ module Shipit
   class DeploySpec
     class FileSystem < DeploySpec
       include NpmDiscovery
+      include LernaDiscovery
       include PypiDiscovery
       include RubygemsDiscovery
       include CapistranoDiscovery

--- a/app/models/shipit/deploy_spec/lerna_discovery.rb
+++ b/app/models/shipit/deploy_spec/lerna_discovery.rb
@@ -1,0 +1,71 @@
+require 'json'
+
+module Shipit
+  class DeploySpec
+    module LernaDiscovery
+      def discover_dependencies_steps
+        discover_lerna_json || super
+      end
+
+      def discover_lerna_json
+        lerna_install if lerna?
+      end
+
+      def lerna_install
+        [js_command('install --no-progress'), 'node_modules/.bin/lerna bootstrap']
+      end
+
+      def discover_review_checklist
+        discover_lerna_checklist || super
+      end
+
+      def discover_lerna_checklist
+        [%(
+          <strong>Don't forget version and tag before publishing!</strong>
+          You can do this with:<br/>
+          <pre>
+          lerna publish --skip-npm
+          && git add -A
+          && git push --follow-tags
+          </pre>
+        )] if lerna?
+      end
+
+      def lerna?
+        lerna_json.exist?
+      end
+
+      def lerna_json
+        file('lerna.json')
+      end
+
+      def lerna_version
+        lerna_config = lerna_json.read
+        JSON.parse(lerna_config)['version']
+      end
+
+      def discover_lerna_packages
+        publish_lerna_packages if lerna?
+      end
+
+      def discover_deploy_steps
+        discover_lerna_packages || super
+      end
+
+      def publish_lerna_packages
+        check_tags = 'assert-lerna-version-tag'
+        # `yarn publish` requires user input, so always use npm.
+        version = lerna_version
+        publish =
+          "node_modules/.bin/lerna publish " \
+          "--yes " \
+          "--skip-git " \
+          "--repo-version #{version} " \
+          "--force-publish=* " \
+          "--npm-tag #{dist_tag(version)}"
+
+        [check_tags, publish]
+      end
+    end
+  end
+end

--- a/lib/snippets/assert-lerna-version-tag
+++ b/lib/snippets/assert-lerna-version-tag
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+
+VERSION=`node --eval "console.log(require('./lerna.json').version);"`
+if [ $VERSION == 'independent' ]; then
+  echo -e "\033[1;31mIndependent package versions are not supported.\033[0m"
+  exit 1
+fi
+
+echo -e "\033[0;32mTrying to publish version $VERSION\033[0m"
+
+git tag | grep "^v$VERSION$" > /dev/null
+if [ $? != '0' ]; then
+  echo -e "\033[1;31mYou need to create the \033[0;33mv$VERSION\033[1;31m tag first.\033[0m"
+  exit 1
+fi
+
+TAG_REV=`git rev-list -n1 v$VERSION`
+HEAD_REV=`git rev-parse HEAD`
+
+if [ $TAG_REV != $HEAD_REV ]; then
+  echo -e "\033[1;31mYou're attempting to publish \033[0;33m$HEAD_REV\033[1;31m as \033[0;33mv$VERSION\033[1;31m but it already points to \033[0;33m$TAG_REV\033[1;31m.\033[0m"
+  exit 1
+fi
+
+echo -e "\033[0;32mAll clear!\033[0m"
+exit 0


### PR DESCRIPTION
### What?
Shipit can now publish multiple JavaScript packages from a single [lerna monorepo](https://github.com/lerna/lerna).

This helps to:
* Colocate utility libraries, which'll make them easier to publish consistently
* ^ should also reduce dev friction in `shopify/web`/`shopify/polaris-react`
* Make `shopify/sewing-kit` modular

### How?
Really similar logic to `NpmDiscovery`.  This version just checks for a `lerna.json` and uses lerna to publish instead of npm.

### What's the catch?
* [Independently versioned packages](https://github.com/lerna/lerna#independent-mode---independent) aren't supported
  * I have this mostly written, but want feedback on this before I go further
* The publish flow is a little clunky; may have to submit lerna PRs to reduce friction
