### PR TITLE
Support lerna independent package versions

### DIFF
--- a/app/models/shipit/deploy_spec/lerna_discovery.rb
+++ b/app/models/shipit/deploy_spec/lerna_discovery.rb
@@ -53,7 +53,19 @@ module Shipit
       end
 
       def publish_lerna_packages
-        check_tags = 'assert-lerna-version-tag'
+        return publish_independent_packages if lerna_version == 'independent'
+        publish_fixed_version_packages
+      end
+
+      def publish_independent_packages
+        [
+          'assert-lerna-independent-version-tags',
+          'publish-lerna-independent-packages',
+        ]
+      end
+
+      def publish_fixed_version_packages
+        check_tags = 'assert-lerna-fixed-version-tag'
         # `yarn publish` requires user input, so always use npm.
         version = lerna_version
         publish =

--- a/lib/snippets/assert-lerna-fixed-version-tag
+++ b/lib/snippets/assert-lerna-fixed-version-tag
@@ -1,11 +1,6 @@
 #!/usr/bin/env bash
 
-VERSION=`node --eval "console.log(require('./lerna.json').version);"`
-if [ $VERSION == 'independent' ]; then
-  echo -e "\033[1;31mIndependent package versions are not supported.\033[0m"
-  exit 1
-fi
-
+VERSION=$(node --eval "console.log(require('./lerna.json').version);")
 echo -e "\033[0;32mTrying to publish version $VERSION\033[0m"
 
 git tag | grep "^v$VERSION$" > /dev/null
@@ -14,10 +9,10 @@ if [ $? != '0' ]; then
   exit 1
 fi
 
-TAG_REV=`git rev-list -n1 v$VERSION`
-HEAD_REV=`git rev-parse HEAD`
+TAG_REV=$(git rev-list -n1 "v$VERSION")
+HEAD_REV=$(git rev-parse HEAD)
 
-if [ $TAG_REV != $HEAD_REV ]; then
+if [ "$TAG_REV" != "$HEAD_REV" ]; then
   echo -e "\033[1;31mYou're attempting to publish \033[0;33m$HEAD_REV\033[1;31m as \033[0;33mv$VERSION\033[1;31m but it already points to \033[0;33m$TAG_REV\033[1;31m.\033[0m"
   exit 1
 fi

--- a/lib/snippets/assert-lerna-independent-version-tags
+++ b/lib/snippets/assert-lerna-independent-version-tags
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+TAGS=$(git tag --points-at HEAD)
+
+if [ -z "$TAGS" ]; then
+  HEAD_REV=$(git rev-parse HEAD)
+  echo -e "\033[1;31mNo tags associated with $HEAD_REV.  Did you push your commits and tags?\033[0m"
+  exit 1
+fi
+
+for TAG in $TAGS
+do
+  PACKAGE_NAME=$(echo "$TAG" | cut -d \@ -f 1)
+  TAG_PACKAGE_VERSION=$(echo "$TAG" | cut -d \@ -f 2)
+  ACTUAL_PACKAGE_VERSION=$(node -e "console.log(require('./packages/$PACKAGE_NAME/package.json').version)")
+
+  if [ "$TAG_PACKAGE_VERSION" != "$ACTUAL_PACKAGE_VERSION" ]; then
+    echo -e "\033[1;31m$PACKAGE_NAME is tagged as $TAG_PACKAGE_VERSION, but its package.json version is $ACTUAL_PACKAGE_VERSION.\033[0m"
+    exit 1
+  fi
+done
+
+echo -e "\033[0;32mAll clear!\033[0m"
+exit 0

--- a/lib/snippets/publish-lerna-independent-packages
+++ b/lib/snippets/publish-lerna-independent-packages
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+const {resolve} = require('path');
+const {execSync} = require('child_process')
+const Repository = require(resolve('.', 'node_modules', 'lerna', 'lib', 'Repository'));
+const PackageUtilities = require(resolve('.', 'node_modules', 'lerna', 'lib', 'PackageUtilities'));
+
+function npmTag(version) {
+  const isNext = ['-beta', '-alpha', '-rc', '-next'].some(distributionType =>
+    version.includes(distributionType),
+  );
+  return isNext ? 'next' : 'latest';
+}
+
+const taggedPackages = execSync('git tag --points-at HEAD')
+  .toString()
+  .trim()
+  .split('\n')
+  .map(tag => tag.split('@')[0]);
+
+const repository = new Repository('.');
+const unsortedPackages = PackageUtilities.getPackages({rootPath: '.', packageConfigs: repository.packageConfigs});
+const packages = PackageUtilities.topologicallyBatchPackages(unsortedPackages, true)
+  .reduce((acc, packageGroup) => [...acc, ...packageGroup], [])
+  .filter(({name}) => taggedPackages.includes(name));
+
+packages.forEach(({name, version}) => {
+  const command = `lerna publish --yes --skip-git --force-publish=${name} --repo-version=${version} --scope=${name} --npm-tag ${npmTag(
+    version,
+  )}`;
+
+  // eslint-disable-next-line no-console
+  console.log(command);
+  require('child_process').execSync(command);
+});

--- a/test/models/deploy_spec_test.rb
+++ b/test/models/deploy_spec_test.rb
@@ -659,10 +659,17 @@ module Shipit
       assert_equal ['npm install --no-progress'], @spec.dependencies_steps
     end
 
-    test '#publish_lerna_packages checks if version tag exists, and then invokes lerna deploy script' do
+    test '#publish_lerna_packages checks if independent version tags exist, and then invokes lerna deploy script' do
+      @spec.stubs(:lerna?).returns(true)
+      @spec.stubs(:lerna_version).returns('independent')
+      assert_equal 'assert-lerna-independent-version-tags', @spec.deploy_steps[0]
+      assert_equal 'publish-lerna-independent-packages', @spec.deploy_steps[1]
+    end
+
+    test '#publish_lerna_packages checks if fixed version tag exists, and then invokes lerna deploy script' do
       @spec.stubs(:lerna?).returns(true)
       @spec.stubs(:lerna_version).returns('1.0.0')
-      assert_equal 'assert-lerna-version-tag', @spec.deploy_steps[0]
+      assert_equal 'assert-lerna-fixed-version-tag', @spec.deploy_steps[0]
       assert_equal 'node_modules/.bin/lerna publish --yes --skip-git --repo-version 1.0.0 --force-publish=* --npm-tag latest', @spec.deploy_steps[1]
     end
 


### PR DESCRIPTION
Support for [independently versioned lerna monorepos](https://github.com/lerna/lerna#independent-mode---independent).  We depend on at least one of these ([graphql-tools](https://github.com/lemonmade/graphql-tools/)).

Publishing packages in the correct order necessitates heavy use of JavaScript.  This makes publication untestable :/  I'm eager for suggestions to improve on this!