### PR TITLE
Show how long deploys have been locked for

### DIFF
--- a/app/views/shipit/stacks/_banners.html.erb
+++ b/app/views/shipit/stacks/_banners.html.erb
@@ -36,7 +36,10 @@
       <div class="banner__content">
         <h2 class="banner__title">
           <i class="icon icon--lock"></i>
-          Deploys are locked by <%= stack.lock_author.name %>
+          Deploys were locked by <%= stack.lock_author.name %>
+          <% unless stack.locked_since.nil? %>
+            <%= timeago_tag(stack.locked_since, force: true) %>
+          <% end %>
         </h2>
         <p class="banner__text">
           <%= auto_link emojify(stack.lock_reason) %>


### PR DESCRIPTION
<img width="1208" alt="image" src="https://user-images.githubusercontent.com/325821/35453934-ec5da652-0299-11e8-9a24-c155a60eb883.png">

When looking at a locked stack page it's sometimes hard to tell the gravity of the situation. If a stack has been locked for the better part of a day, odds are developers shouldn't bank on things being resolved any time soon.

**Changes**

- Moves `locked_since` logic to an `after_save` callback rather than relying on `Stack#lock`/`Stack#unlock`
- Updates the banner for locked stacks