### PR TITLE
Add information about who aborted a deploy

### DIFF
--- a/app/controllers/shipit/tasks_controller.rb
+++ b/app/controllers/shipit/tasks_controller.rb
@@ -42,7 +42,7 @@ module Shipit
     end
 
     def abort
-      task.abort!(rollback_once_aborted: params[:rollback].present?)
+      task.abort!(rollback_once_aborted: params[:rollback].present?, aborted_by: current_user)
       head :ok
     end
 

--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -14,6 +14,7 @@ module Shipit
     belongs_to :deploy, foreign_key: :parent_id, required: false # required for fixtures
 
     belongs_to :user, optional: true
+    belongs_to :aborted_by, class_name: 'User', optional: true
     belongs_to :stack, counter_cache: true
     belongs_to :until_commit, class_name: 'Commit'
     belongs_to :since_commit, class_name: 'Commit'
@@ -236,8 +237,8 @@ module Shipit
       end
     end
 
-    def abort!(rollback_once_aborted: false)
-      update!(rollback_once_aborted: rollback_once_aborted)
+    def abort!(rollback_once_aborted: false, aborted_by:)
+      update!(rollback_once_aborted: rollback_once_aborted, aborted_by_id: aborted_by.id)
 
       if alive?
         aborting

--- a/app/views/shipit/deploys/_deploy.html.erb
+++ b/app/views/shipit/deploys/_deploy.html.erb
@@ -21,6 +21,7 @@
         <span class="code-additions">+<%= deploy.additions %></span>
         <span class="code-deletions">-<%= deploy.deletions %></span>
         <% if deploy.ignored_safeties? %><span class="ignored-safeties">ignoring safeties</span><% end %>
+        <% if deploy.aborted_by %><span class="aborted-by">aborted by <%= deploy.aborted_by.login %></span><% end %>
       </p>
       <p class="commit-meta">
         <% if read_only %>

--- a/app/views/shipit/tasks/_task.html.erb
+++ b/app/views/shipit/tasks/_task.html.erb
@@ -26,7 +26,6 @@
         <% else %>
           <%= timeago_tag(task.created_at, force: true) %>
         <% end %>
-        
       </p>
     </div>
   </li>

--- a/db/migrate/20180202220850_add_aborted_by_to_tasks.rb
+++ b/db/migrate/20180202220850_add_aborted_by_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddAbortedByToTasks < ActiveRecord::Migration[5.1]
+  def change
+    add_column :tasks, :aborted_by_id, :integer
+  end
+end

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -70,6 +70,7 @@ module Shipit
       @task.reload
       assert_response :success
       assert_equal 'aborting', @task.reload.status
+      assert_equal shipit_users(:walrus).id, @task.aborted_by_id
       assert_equal false, @task.rollback_once_aborted?
     end
 
@@ -81,6 +82,7 @@ module Shipit
       @task.reload
       assert_response :success
       assert_equal 'aborting', @task.status
+      assert_equal shipit_users(:walrus).id, @task.aborted_by_id
       assert_equal true, @task.rollback_once_aborted?
     end
 

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20171120161420) do
+ActiveRecord::Schema.define(version: 20180202220850) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text "permissions", limit: 65535
@@ -216,6 +216,7 @@ ActiveRecord::Schema.define(version: 20171120161420) do
     t.datetime "started_at"
     t.datetime "ended_at"
     t.boolean "ignored_safeties", default: false, null: false
+    t.integer "aborted_by_id"
     t.index ["rolled_up", "created_at", "status"], name: "index_tasks_on_rolled_up_and_created_at_and_status"
     t.index ["since_commit_id"], name: "index_tasks_on_since_commit_id"
     t.index ["stack_id", "allow_concurrency", "status"], name: "index_active_tasks"


### PR DESCRIPTION
We had a problem because someone aborted a deploy and triggered a rollback and we had no way to know who triggered the abort.

Looking at the code I found that abort was an operation that didn't presented to the users who was the author of that operation so I added a new column in Task to store who aborted it and I'm presenting in the view.

cc @kmcphillips 