### PR TITLE
Implement blocking statuses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Added blocking statuses. If they are missing or failing, they will prevent deploy even if they were reported on any of the commits in the deploy range.
 * Fix shipit.yml updates not being taken into account for the `fetch` command.
 * Fix failing membership webhooks for non fully downcase organization names.
 * Fix status group links not being disabled when the status url is missing (https://github.com/Shopify/shipit-engine/issues/742).

--- a/README.md
+++ b/README.md
@@ -379,7 +379,7 @@ machine:
 
 <h3 id="ci">CI</h3>
 
-**<code>ci.require</code>** contains an array of the [statuses context](https://developer.github.com/v3/repos/statuses/) you want Shipit to disallow deploys if any of them is missing.
+**<code>ci.require</code>** contains an array of the [statuses context](https://developer.github.com/v3/repos/statuses/) you want Shipit to disallow deploys if any of them is missing on the commit being deployed.
 
 For example:
 ```yml
@@ -404,6 +404,15 @@ For example:
 ci:
   allow_failures:
     - ci/circleci
+```
+
+**<code>ci.blocking</code>** contains an array of the [statuses context](https://developer.github.com/v3/repos/statuses/) you want to disallow deploys if any of them is missing or failing on any of the commits being deployed.
+
+For example:
+```yml
+ci:
+  blocking:
+    - soc/compliance
 ```
 
 <h3 id="merge-queue">Merge Queue</h3>

--- a/app/models/shipit/deploy_spec.rb
+++ b/app/models/shipit/deploy_spec.rb
@@ -135,11 +135,15 @@ module Shipit
     end
 
     def required_statuses
-      Array.wrap(config('ci', 'require'))
+      (Array.wrap(config('ci', 'require')) + blocking_statuses).uniq
     end
 
     def soft_failing_statuses
       Array.wrap(config('ci', 'allow_failures'))
+    end
+
+    def blocking_statuses
+      Array.wrap(config('ci', 'blocking'))
     end
 
     def pull_request_required_statuses

--- a/app/models/shipit/deploy_spec/file_system.rb
+++ b/app/models/shipit/deploy_spec/file_system.rb
@@ -43,6 +43,7 @@ module Shipit
             'hide' => hidden_statuses,
             'allow_failures' => soft_failing_statuses,
             'require' => required_statuses,
+            'blocking' => blocking_statuses,
           },
           'machine' => {
             'environment' => discover_machine_env.merge(machine_env),

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -384,8 +384,8 @@ module Shipit
     end
 
     delegate :plugins, :task_definitions, :hidden_statuses, :required_statuses, :soft_failing_statuses,
-             :deploy_variables, :filter_task_envs, :filter_deploy_envs, :maximum_commits_per_deploy,
-             :pause_between_deploys, to: :cached_deploy_spec
+             :blocking_statuses, :deploy_variables, :filter_task_envs, :filter_deploy_envs,
+             :maximum_commits_per_deploy, :pause_between_deploys, to: :cached_deploy_spec
 
     def monitoring?
       monitoring.present?

--- a/app/models/shipit/status/common.rb
+++ b/app/models/shipit/status/common.rb
@@ -37,6 +37,10 @@ module Shipit
         commit.hidden_statuses.include?(context)
       end
 
+      def blocking?
+        !success? && commit.blocking_statuses.include?(context)
+      end
+
       def required?
         commit.required_statuses.include?(context)
       end

--- a/test/controllers/api/stacks_controller_test.rb
+++ b/test/controllers/api/stacks_controller_test.rb
@@ -60,7 +60,7 @@ module Shipit
         assert_response :ok
         assert_json '0.id', stack.id
         assert_json do |stacks|
-          assert_equal 3, stacks.size
+          assert_equal Stack.count, stacks.size
         end
       end
 

--- a/test/fixtures/shipit/commits.yml
+++ b/test/fixtures/shipit/commits.yml
@@ -116,3 +116,42 @@ cyclimse_merged:
   deletions: 342
   updated_at: <%= 8.days.ago.to_s(:db) %>
   pull_request_id: 99
+
+soc_first:
+  id: 101
+  sha: 5e9278037b872fd9a6690523e411ecb3aa181355
+  message: "lets go"
+  stack: soc
+  author: walrus
+  committer: walrus
+  authored_at: <%= 10.days.ago.to_s(:db) %>
+  committed_at: <%= 9.days.ago.to_s(:db) %>
+  additions: 42
+  deletions: 24
+  updated_at: <%= 8.days.ago.to_s(:db) %>
+
+soc_second:
+  id: 102
+  sha: e790fd8b5f2be05d1fedb763a3605ee461c39074
+  message: "sheep it!"
+  stack: soc
+  author: walrus
+  committer: walrus
+  authored_at: <%= 8.days.ago.to_s(:db) %>
+  committed_at: <%= 7.days.ago.to_s(:db) %>
+  additions: 1
+  deletions: 1
+  updated_at: <%= 8.days.ago.to_s(:db) %>
+
+soc_third:
+  id: 103
+  sha: 477578b362bf2b4df5903e1c7960929361c39074
+  message: "fix it!"
+  stack: soc
+  author: walrus
+  committer: walrus
+  authored_at: <%= 6.days.ago.to_s(:db) %>
+  committed_at: <%= 5.days.ago.to_s(:db) %>
+  additions: 12
+  deletions: 64
+  updated_at: <%= 8.days.ago.to_s(:db) %>

--- a/test/fixtures/shipit/stacks.yml
+++ b/test/fixtures/shipit/stacks.yml
@@ -123,3 +123,38 @@ undeployed_stack:
       }
     }
   updated_at: <%= 8.days.ago.to_s(:db) %>
+
+soc:
+  repo_owner: "shopify"
+  repo_name: "soc"
+  environment: "production"
+  branch: master
+  tasks_count: 0
+  undeployed_commits_count: 2
+  cached_deploy_spec: >
+    {
+      "machine": {"environment": {}},
+      "review": {
+        "checklist": ["foo", "bar", "baz"],
+        "monitoring": [
+          {"image": "https://example.com/monitor.png", "width": 200, "height": 300}
+        ]
+      },
+      "dependencies": {"override": []},
+      "deploy": {"override": null},
+      "rollback": {"override": ["echo 'Rollback!'"]},
+      "fetch": ["echo '42'"],
+      "tasks": {
+        "restart": {
+          "action": "Restart application",
+          "description": "Restart app and job servers",
+          "steps": [
+            "cap $ENVIRONMENT deploy:restart"
+          ]
+        }
+      },
+      "ci": {
+        "blocking": ["soc/compliance"]
+      }
+    }
+  updated_at: <%= 8.days.ago.to_s(:db) %>

--- a/test/fixtures/shipit/statuses.yml
+++ b/test/fixtures/shipit/statuses.yml
@@ -98,3 +98,30 @@ shipit_pending_pr_success_travis:
   created_at: <%= 9.days.ago.to_s(:db) %>
   state: success
   target_url: "http://www.example.com"
+
+soc_first:
+  stack: soc
+  commit_id: 101 # soc_first
+  description: Woops
+  context: soc/compliance
+  created_at: <%= 9.days.ago.to_s(:db) %>
+  state: failure
+  target_url: "http://www.example.com"
+
+soc_second:
+  stack: soc
+  commit_id: 102 # soc_second
+  description: All good
+  context: soc/compliance
+  created_at: <%= 7.days.ago.to_s(:db) %>
+  state: success
+  target_url: "http://www.example.com"
+
+soc_third:
+  stack: soc
+  commit_id: 103 # soc_third
+  description: All good
+  context: soc/compliance
+  created_at: <%= 7.days.ago.to_s(:db) %>
+  state: success
+  target_url: "http://www.example.com"

--- a/test/fixtures/shipit/tasks.yml
+++ b/test/fixtures/shipit/tasks.yml
@@ -120,3 +120,17 @@ shipit_rollback:
   created_at: <%= (60 - 8).minutes.ago.to_s(:db) %>
   started_at: <%= (60 - 8).minutes.ago.to_s(:db) %>
   ended_at: <%= (60 - 7).minutes.ago.to_s(:db) %>
+
+soc_deploy:
+  id: 9
+  user: walrus
+  since_commit_id: 101 # soc_first
+  until_commit_id: 101 # soc_first
+  type: Shipit::Deploy
+  stack: soc
+  status: success
+  additions: 1
+  deletions: 1
+  created_at: <%= (60 - 1).minutes.ago.to_s(:db) %>
+  started_at: <%= (60 - 1).minutes.ago.to_s(:db) %>
+  ended_at: <%= (60 - 3).minutes.ago.to_s(:db) %>

--- a/test/models/deploy_spec_test.rb
+++ b/test/models/deploy_spec_test.rb
@@ -293,6 +293,7 @@ module Shipit
           'hide' => [],
           'allow_failures' => [],
           'require' => [],
+          'blocking' => [],
         },
         'machine' => {'environment' => {}, 'directory' => nil, 'cleanup' => true},
         'review' => {'checklist' => [], 'monitoring' => [], 'checks' => []},
@@ -457,6 +458,16 @@ module Shipit
     test "#hidden_statuses is an array even if the value is present" do
       @spec.expects(:load_config).returns('ci' => {'hide' => %w(ci/circleci ci/jenkins)})
       assert_equal %w(ci/circleci ci/jenkins), @spec.hidden_statuses
+    end
+
+    test "#required_statuses automatically includes #blocking_statuses" do
+      @spec.expects(:load_config).returns(
+        'ci' => {
+          'require' => %w(ci/circleci),
+          'blocking' => %w(soc/compliance),
+        },
+      )
+      assert_equal %w(ci/circleci soc/compliance), @spec.required_statuses
     end
 
     test "pull_request_ignored_statuses defaults to the union of ci.hide and ci.allow_failures" do


### PR DESCRIPTION
As described in the README, `blocking` statuses are statuses that are required to be successful for **all the commits included in a deploy**.

NB: There is a potential performance issue right now, but fixing it would require a pretty big refactoring, I rather tackle that in a later PR if it proved itself problematic, and keep this PR short.