### PR TITLE
Improve deploy button captions when blocked by a status

### DIFF
--- a/app/helpers/shipit/stacks_helper.rb
+++ b/app/helpers/shipit/stacks_helper.rb
@@ -21,15 +21,20 @@ module Shipit
     def deploy_button(commit)
       url = new_stack_deploy_path(commit.stack, sha: commit.sha)
       classes = %W(btn btn--primary deploy-action #{commit.state})
+      deploy_state = commit.deploy_state(bypass_safeties?)
       data = {}
+
       if commit.deploy_disallowed?
         classes.push(bypass_safeties? ? 'btn--warning' : 'btn--disabled')
+        if deploy_state == 'blocked'
+          data[:tooltip] = t('deploy_button.hint.blocked')
+        end
       elsif commit.deploy_discouraged?
         classes.push('btn--warning')
         data[:tooltip] = t('deploy_button.hint.max_commits', maximum: commit.stack.maximum_commits_per_deploy)
       end
 
-      link_to(t("deploy_button.caption.#{commit.deploy_state(bypass_safeties?)}"), url, class: classes, data: data)
+      link_to(t("deploy_button.caption.#{deploy_state}"), url, class: classes, data: data)
     end
 
     def github_change_url(commit)

--- a/app/models/shipit/status/group.rb
+++ b/app/models/shipit/status/group.rb
@@ -52,6 +52,10 @@ module Shipit
         true
       end
 
+      def blocking?
+        statuses.any?(&:blocking?)
+      end
+
       private
 
       def reject_hidden(statuses)

--- a/app/models/shipit/undeployed_commit.rb
+++ b/app/models/shipit/undeployed_commit.rb
@@ -9,9 +9,15 @@ module Shipit
 
     def deploy_state(bypass_safeties = false)
       state = deployable? ? 'allowed' : status.state
+
       unless bypass_safeties
-        state = 'deploying' if stack.active_task?
-        state = 'locked' if locked?
+        if blocked?
+          state = 'blocked'
+        elsif locked?
+          state = 'locked'
+        elsif stack.active_task?
+          state = 'deploying'
+        end
       end
       state
     end
@@ -30,6 +36,11 @@ module Shipit
 
     def deploy_discouraged?
       stack.maximum_commits_per_deploy && index >= stack.maximum_commits_per_deploy
+    end
+
+    def blocked?
+      return @blocked if defined?(@blocked)
+      @blocked = super
     end
   end
 end

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -27,6 +27,7 @@ en:
   deploy_button:
     hint:
       max_commits: It is recommended not to deploy more than %{maximum} commits at once.
+      blocked: This commit range includes a commit that can't be deployed.
     caption:
       pending: Pending CI
       failure: Failing CI
@@ -36,6 +37,7 @@ en:
       deploying: A Deploy is in Progress
       allowed: Deploy
       missing: Missing CI
+      blocked: Blocked
   redeploy_button:
     caption:
       deploying: A Deploy is in Progress

--- a/test/models/status/group_test.rb
+++ b/test/models/status/group_test.rb
@@ -24,6 +24,12 @@ module Shipit
       assert_equal 'failure', @group.state
     end
 
+    test "#blocking? returns true if any of the status is blocking" do
+      blocking_status = shipit_statuses(:soc_first)
+      assert_predicate blocking_status, :blocking?
+      Status::Group.new(blocking_status.commit, [blocking_status])
+    end
+
     test ".compact returns a regular status if there is only one visible status" do
       status = Status::Group.compact(@commit, @commit.statuses.where(context: 'ci/travis'))
       assert_instance_of Status, status

--- a/test/models/undeployed_commits_test.rb
+++ b/test/models/undeployed_commits_test.rb
@@ -68,6 +68,15 @@ module Shipit
       assert_equal 'failure', @commit.deploy_state(true)
     end
 
+    test "#deploy_state returns `blocked` if a previous commit is blocking" do
+      blocking_commit = shipit_commits(:soc_second)
+      blocking_commit.statuses.delete_all
+      assert_predicate blocking_commit, :blocking?
+
+      commit = UndeployedCommit.new(shipit_commits(:soc_third), 0)
+      assert_equal 'blocked', commit.deploy_state
+    end
+
     test "#redeploy_state returns `allowed` by default" do
       assert_equal 'allowed', @commit.redeploy_state
     end


### PR DESCRIPTION
Ref: https://github.com/Shopify/shipit-engine/pull/760

In #760 I forgot to properly handle this new `deploy_state` in the deploy button rendering.

I also chose to add a `hint` for it because it might be difficult to understand.

Looks like this:

![capture d ecran 2018-03-05 a 12 19 47](https://user-images.githubusercontent.com/19192189/36972711-6d7b3288-2070-11e8-9bb0-8093049e270f.png)
