### PR TITLE
Retry with global GH token if the API call using a user token received a 401

### DIFF
--- a/app/models/shipit/commit_deployment.rb
+++ b/app/models/shipit/commit_deployment.rb
@@ -22,7 +22,7 @@ module Shipit
 
       response = begin
         create_deployment_on_github(author.github_api)
-      rescue Octokit::NotFound, Octokit::Forbidden
+      rescue Octokit::ClientError
         raise if Shipit.github_api == author.github_api
         # If the deploy author didn't gave us the permission to create the deployment we falback the the main shipit
         # user.

--- a/app/models/shipit/commit_deployment_status.rb
+++ b/app/models/shipit/commit_deployment_status.rb
@@ -10,7 +10,7 @@ module Shipit
       return if github_id?
       response = begin
         create_status_on_github(author.github_api)
-      rescue Octokit::NotFound, Octokit::Forbidden
+      rescue Octokit::ClientError
         raise if Shipit.github_api == author.github_api
         # If the deploy author didn't gave us the permission to create the deployment we falback the the main shipit
         # user.


### PR DESCRIPTION
I'm not 100% sure of the root cause, but user tokens can go outdated from time to time. When this happens API calls will return 401.

We were already handling that corner case, but only rescuing `403` and `404`.

This PR change the code to rescue the entire `4xx` range.