### PR TITLE
Fix namespaced lerna packages

### DIFF
--- a/lib/snippets/assert-lerna-independent-version-tags
+++ b/lib/snippets/assert-lerna-independent-version-tags
@@ -10,8 +10,7 @@ fi
 
 for TAG in $TAGS
 do
-  FIRST_LETTER=${TAG:0:1}
-  if [ "$FIRST_LETTER" == '@' ]; then
+  if [[ "${TAG}" == @* ]]; then
     TAG=$(echo "$TAG" | cut -d \/ -f 2)
   fi
 

--- a/lib/snippets/assert-lerna-independent-version-tags
+++ b/lib/snippets/assert-lerna-independent-version-tags
@@ -10,8 +10,14 @@ fi
 
 for TAG in $TAGS
 do
+  FIRST_LETTER=${TAG:0:1}
+  if [ "$FIRST_LETTER" == '@' ]; then
+    TAG=$(echo "$TAG" | cut -d \/ -f 2)
+  fi
+
   PACKAGE_NAME=$(echo "$TAG" | cut -d \@ -f 1)
   TAG_PACKAGE_VERSION=$(echo "$TAG" | cut -d \@ -f 2)
+
   ACTUAL_PACKAGE_VERSION=$(node -e "console.log(require('./packages/$PACKAGE_NAME/package.json').version)")
 
   if [ "$TAG_PACKAGE_VERSION" != "$ACTUAL_PACKAGE_VERSION" ]; then

--- a/lib/snippets/assert-lerna-independent-version-tags
+++ b/lib/snippets/assert-lerna-independent-version-tags
@@ -17,7 +17,6 @@ do
 
   PACKAGE_NAME=$(echo "$TAG" | cut -d \@ -f 1)
   TAG_PACKAGE_VERSION=$(echo "$TAG" | cut -d \@ -f 2)
-
   ACTUAL_PACKAGE_VERSION=$(node -e "console.log(require('./packages/$PACKAGE_NAME/package.json').version)")
 
   if [ "$TAG_PACKAGE_VERSION" != "$ACTUAL_PACKAGE_VERSION" ]; then

--- a/lib/snippets/publish-lerna-independent-packages
+++ b/lib/snippets/publish-lerna-independent-packages
@@ -15,7 +15,12 @@ const taggedPackages = execSync('git tag --points-at HEAD')
   .toString()
   .trim()
   .split('\n')
-  .map(tag => tag.split('@')[0]);
+  .map(tag => {
+    if (tag.startsWith('@')) {
+      return `@${tag.split('@')[1]}`;
+    }
+    return tag.split('@')[0];
+  });
 
 const repository = new Repository('.');
 const unsortedPackages = PackageUtilities.getPackages({rootPath: '.', packageConfigs: repository.packageConfigs});


### PR DESCRIPTION
## What
This PR updates @goodforonefare's lerna support so that the scripts for lerna independent packages no longer break when you're using namespaced npm packages.

## How / Why
Previously we assumed tags would look like `mypackage@1.1.1`, and split on `@` to separate the version from the name.  This presents a problem as namespaced imports look like `@shopify/mypackage@1.1.1`.

To get around this we simply fork on encountering an `@` as the first character.

## Caveats
This PR still assumes some weird stuff. 
- assumes packages are all in a `packages` directory
- assumes packages are not nested in sub-folders inside packages
- assumes no slashes in the name of a package other than the namespace slash

If we wanted to make this really robust we'd probably need to parse out the right directory from `lerna.json`, and do some kind of regex approach instead of what we're doing now to parse the tags. At that point I'd probably want to rewrite this bash script in ruby.

I think it's fine for now though, as deviating from those assumptions seems wrong.