### PR TITLE
Distinguish deploy timeouts from deploy failures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Distinguish deploy timeouts from deploy failures.
 * Added blocking statuses. If they are missing or failing, they will prevent deploy even if they were reported on any of the commits in the deploy range.
 * Fix shipit.yml updates not being taken into account for the `fetch` command.
 * Fix failing membership webhooks for non fully downcase organization names.

--- a/app/assets/stylesheets/_pages/_commits.scss
+++ b/app/assets/stylesheets/_pages/_commits.scss
@@ -281,7 +281,9 @@
 }
 
 .status--error,
-[data-deploy-status='error'] {
+[data-deploy-status='error'],
+.status--timedout,
+[data-deploy-status='timedout'] {
   border-color: #333;
 
   .status__icon {

--- a/app/assets/stylesheets/_pages/_deploy.scss
+++ b/app/assets/stylesheets/_pages/_deploy.scss
@@ -93,7 +93,8 @@
   }
 
   &[data-status="failure"],
-  &[data-status="error"] {
+  &[data-status="error"],
+  &[data-status="timedout"] {
     .deploy-banner-status {
       background-color: $bright-red;
       width: 100%;
@@ -196,7 +197,8 @@
 
   &[data-status="failed"],
   &[data-status="failure"],
-  &[data-status="error"] {
+  &[data-status="error"],
+  &[data-status="timedout"] {
     border-color: $bright-red;
   }
 

--- a/app/jobs/shipit/perform_task_job.rb
+++ b/app/jobs/shipit/perform_task_job.rb
@@ -19,6 +19,9 @@ module Shipit
       checkout_repository
       perform_task
       @task.complete!
+    rescue Command::TimedOut => error
+      @task.write("\n#{error.message}\n")
+      @task.report_timeout!(error)
     rescue Command::Error => error
       @task.write("\n#{error.message}\n")
       @task.report_failure!(error)

--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -89,6 +89,10 @@ module Shipit
         transition all => :error
       end
 
+      event :giveup do # :timeout would cause a name clash
+        transition all => :timedout
+      end
+
       event :aborting do
         transition all - %i(aborted) => :aborting
       end
@@ -98,7 +102,7 @@ module Shipit
       end
 
       event :flap do
-        transition %i(failed error success) => :flapping
+        transition %i(failed error timedout success) => :flapping
       end
 
       state :pending
@@ -106,6 +110,7 @@ module Shipit
       state :failed
       state :success
       state :error
+      state :timedout
       state :aborting
       state :aborted
       state :flapping
@@ -122,6 +127,10 @@ module Shipit
       else
         failure!
       end
+    end
+
+    def report_timeout!(_error)
+      giveup!
     end
 
     def report_error!(error)

--- a/test/jobs/perform_task_job_test.rb
+++ b/test/jobs/perform_task_job_test.rb
@@ -67,12 +67,21 @@ module Shipit
       @job.perform(@deploy)
     end
 
-    test "mark deploy as error if a command timeout" do
-      Command.any_instance.expects(:stream!).at_least_once.raises(Command::TimedOut)
+    test "mark deploy as error an unexpected exception is raised" do
+      Command.any_instance.expects(:stream!).at_least_once.raises(Command::Denied)
 
       @job.perform(@deploy)
 
       assert_equal 'failed', @deploy.reload.status
+      assert_includes @deploy.chunk_output, 'Denied'
+    end
+
+    test "mark deploy as timedout if a command timeout" do
+      Command.any_instance.expects(:stream!).at_least_once.raises(Command::TimedOut)
+
+      @job.perform(@deploy)
+
+      assert_equal 'timedout', @deploy.reload.status
       assert_includes @deploy.chunk_output, 'TimedOut'
     end
 


### PR DESCRIPTION
I don't have a designer at hand, so I had to reuse the `error` icon:

![capture d ecran 2018-03-15 a 13 30 53](https://user-images.githubusercontent.com/19192189/37464170-d7bf65b2-2857-11e8-8c02-09fb2b292bd9.png)

