### PR TITLE
🛠 Don't expect a global lerna install

### DIFF
--- a/lib/snippets/publish-lerna-independent-packages
+++ b/lib/snippets/publish-lerna-independent-packages
@@ -24,7 +24,7 @@ const packages = PackageUtilities.topologicallyBatchPackages(unsortedPackages, t
   .filter(({name}) => taggedPackages.includes(name));
 
 packages.forEach(({name, version}) => {
-  const command = `lerna publish --yes --skip-git --force-publish=${name} --repo-version=${version} --scope=${name} --npm-tag ${npmTag(
+  const command = `node_modules/.bin/lerna publish --yes --skip-git --force-publish=${name} --repo-version=${version} --scope=${name} --npm-tag ${npmTag(
     version,
   )}`;
 


### PR DESCRIPTION
## Problem
Even after my [previous PR ](https://github.com/Shopify/shipit-engine/pull/763) independent mode lerna repos don't work in the wild.

https://shipit.shopify.io/themallen/lerna-tests/production/deploys/539131.txt

```
Error: Command failed: lerna publish --yes --skip-git --force-publish=@themallen/lerna-test-javascript-utilities --repo-version=2.2.4 --scope=@themallen/lerna-test-javascript-utilities --npm-tag latest
/bin/sh: 1: lerna: not found

    at checkExecSyncError (child_process.js:601:13)
    at Object.execSync (child_process.js:641:13)
    at packages.forEach (/artifacts/ruby/2.4.0/bundler/gems/shipit-engine-0c7f3452c1ac/lib/snippets/publish-lerna-independent-packages:38:28)
    at Array.forEach (<anonymous>)
    at Object.<anonymous> (/artifacts/ruby/2.4.0/bundler/gems/shipit-engine-0c7f3452c1ac/lib/snippets/publish-lerna-independent-packages:31:10)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
```
As we can see in the error above, we are failing to find the `lerna` script. This is because we are trying to access a global `lerna`.

## Solution
We invoke `lerna` from `node_modules/.bin` just like the other snippet does.

## Learnings / followup
This mistake was likely made because the easiest way to test these javascript snippets is just copying them to a local repo and running them. In this case it's likely that when the script was originally written there was a locally installed global `lerna` binary. **We should probably write proper tests for these snippets soon**