### PR TITLE
Fix/override skip npm setting

### DIFF
--- a/lib/snippets/publish-lerna-independent-packages
+++ b/lib/snippets/publish-lerna-independent-packages
@@ -29,7 +29,7 @@ const packages = PackageUtilities.topologicallyBatchPackages(unsortedPackages, t
   .filter(({name}) => taggedPackages.includes(name));
 
 packages.forEach(({name, version}) => {
-  const command = `node_modules/.bin/lerna publish --yes --skip-git --force-publish=${name} --repo-version=${version} --scope=${name} --npm-tag ${npmTag(
+  const command = `node_modules/.bin/lerna publish --yes --skip-npm=false --skip-git --force-publish=${name} --repo-version=${version} --scope=${name} --npm-tag=${npmTag(
     version,
   )}`;
 


### PR DESCRIPTION
## Problem
Lerna packages were still not always publishing correctly. Sometimes they would report success but seem to [fail silently](https://shipit.shopify.io/themallen/lerna-tests/production/deploys/540941) before updating. It turns out the script was actually succeeding, it was just running as if `skip-npm` had been specified. This happened only in cases where `skip-npm` was present in the project's `lerna.json`.

## Solution
We want to always force an npm publish on CI, and always skip npm when local. Since command line arguments override `lerna.json` settings we just specify an explicit `false` for CI.

## 🎩  instructions
- clone https://github.com/TheMallen/lerna-tests
- copy `lib/snippets/publish-lerna-independent-packages.js` to the root of the project
- run `node ./publish-lerna-independent-packages.js`
- it should fail with some npm publish errors since you don't have the authority to publish these packages
