### PR TITLE
Bump loofah due to security vulnerability

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -137,7 +137,7 @@ GEM
     jwt (1.5.6)
     lodash-rails (4.6.1)
       railties (>= 3.1)
-    loofah (2.2.0)
+    loofah (2.2.1)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)


### PR DESCRIPTION
Patch level gem bump to address CVE-2018-8048.