### PR TITLE
Revalidate merge request as soon as they are expired

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Revalidate merge request as soon as they are expired, and not when they could be merged again.
 * Allow to configure Shipit to intepret some exit statuses as timeouts instead of regular failures.
 * Distinguish deploy timeouts from deploy failures.
 * Added blocking statuses. If they are missing or failing, they will prevent deploy even if they were reported on any of the commits in the deploy range.

--- a/app/jobs/shipit/merge_pull_requests_job.rb
+++ b/app/jobs/shipit/merge_pull_requests_job.rb
@@ -9,6 +9,7 @@ module Shipit
         pull_request.refresh!
         pull_request.reject_unless_mergeable!
         pull_request.cancel! if pull_request.closed?
+        pull_request.revalidate! if pull_request.need_revalidation?
       end
 
       return false unless stack.allows_merges?

--- a/app/models/shipit/pull_request.rb
+++ b/app/models/shipit/pull_request.rb
@@ -156,10 +156,6 @@ module Shipit
       raise InvalidTransition unless pending?
 
       raise NotReady if not_mergeable_yet?
-      if need_revalidation?
-        revalidate!
-        return false
-      end
 
       Shipit.github_api.merge_pull_request(
         stack.github_repo_name,

--- a/test/fixtures/shipit/pull_requests.yml
+++ b/test/fixtures/shipit/pull_requests.yml
@@ -105,6 +105,23 @@ shipit_mergeable_pending_ci:
   additions: 23
   deletions: 43
 
+shipit_pending_expired:
+  stack: shipit
+  number: 68
+  title: Noice !
+  merge_status: pending
+  merge_requested_at: <%= 50.minute.ago.to_s(:db) %>
+  revalidated_at: <%= 25.minute.ago.to_s(:db) %>
+  merge_requested_by: walrus
+  github_id: 48484848484848
+  api_url: https://api.github.com/repos/shopify/shipit-engine/pulls/68
+  state: open
+  branch: feature-68
+  head_id: 8
+  mergeable: true
+  additions: 23
+  deletions: 43
+
 cyclimse_pending_merged:
   id: 99
   stack: cyclimse

--- a/test/models/pull_request_test.rb
+++ b/test/models/pull_request_test.rb
@@ -190,14 +190,6 @@ module Shipit
       assert_equal 'requires_rebase', @pr.rejection_reason
     end
 
-    test "#merge! revalidates the PR if it has been enqueued for too long" do
-      @pr.update!(revalidated_at: 5.hours.ago)
-
-      assert_predicate @pr, :need_revalidation?
-      assert_equal false, @pr.merge!
-      assert_predicate @pr, :revalidating?
-    end
-
     test "#merge! raises a PullRequest::NotReady if the PR isn't mergeable yet" do
       @pr.update!(mergeable: nil)
 


### PR DESCRIPTION
Fix: https://github.com/Shopify/shipit-engine/issues/766
Fix: https://github.com/Shopify/shipit-engine/issues/736

As described here: https://github.com/Shopify/shipit-engine/issues/766#issuecomment-375257722

Previously we were only triggering the revalidation once the stack was allowing merges again. The idea was to avoid spamming users with revalidation requests in case a stack would be locked for a very long time.

However the downside is that on unlock old PRs would be asked for revaliation, and newer PRs would be merged instead, resulting in an unfair situation.

This PR change the behavior so that we ask for revalidation even if the stack is still locked.

Ideally we'd have some grave period so that if you respond under a minute or 2 your PR is never considered expired, but this should be a big improvement already.