### PR TITLE
Switching to npm for lerna publishing

### DIFF
--- a/app/models/shipit/deploy_spec/lerna_discovery.rb
+++ b/app/models/shipit/deploy_spec/lerna_discovery.rb
@@ -41,7 +41,7 @@ module Shipit
         file('lerna.json')
       end
 
-      def lerna_version
+      def repo_version
         lerna_config = lerna_json.read
         JSON.parse(lerna_config)['version']
       end
@@ -55,12 +55,17 @@ module Shipit
       end
 
       def publish_lerna_packages
-        return publish_independent_packages if lerna_version == 'independent'
+        return publish_independent_packages if repo_version == 'independent'
         publish_fixed_version_packages
+      end
+
+      def check_lerna
+        'assert-acceptable-lerna-version'
       end
 
       def publish_independent_packages
         [
+          check_lerna,
           'assert-lerna-independent-version-tags',
           'publish-lerna-independent-packages',
         ]
@@ -69,7 +74,7 @@ module Shipit
       def publish_fixed_version_packages
         check_tags = 'assert-lerna-fixed-version-tag'
         # `yarn publish` requires user input, so always use npm.
-        version = lerna_version
+        version = repo_version
         publish =
           "node_modules/.bin/lerna publish " \
           "--yes " \
@@ -78,7 +83,7 @@ module Shipit
           "--force-publish=* " \
           "--npm-tag #{dist_tag(version)}"
 
-        [check_tags, publish]
+        [check_lerna, check_tags, publish]
       end
     end
   end

--- a/lib/snippets/assert-acceptable-lerna-version
+++ b/lib/snippets/assert-acceptable-lerna-version
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+VERSION=$(node --eval "console.log(require('./lerna.json').lerna);")
+echo -e "\033[0;32mTrying to publish using lerna $VERSION\033[0m"
+
+echo $VERSION | grep "^2\.9\.[0-9][0-9]*$" > /dev/null
+if [ $? != '0' ]; then
+  echo -e "\033[1;31mYou are using an unsupported version of lerna; only 2.9.x is supported.\033[0m"
+  exit 1
+fi
+
+echo -e "\033[0;32mAll clear!\033[0m"
+exit 0

--- a/lib/snippets/publish-lerna-independent-packages
+++ b/lib/snippets/publish-lerna-independent-packages
@@ -28,10 +28,12 @@ const packages = PackageUtilities.topologicallyBatchPackages(unsortedPackages, t
   .reduce((acc, packageGroup) => [...acc, ...packageGroup], [])
   .filter(({name}) => taggedPackages.includes(name));
 
-packages.forEach(({name, version}) => {
-  const command = `node_modules/.bin/lerna publish --yes --skip-npm=false --skip-git --force-publish=${name} --repo-version=${version} --scope=${name} --npm-tag=${npmTag(
-    version,
-  )}`;
+packages.forEach(({name, version, isPrivate}) => {
+  const access = isPrivate ? 'restricted' : 'public';
+
+  const command = `node_modules/.bin/lerna exec --scope=${
+    name
+  } -- npm publish --tag ${npmTag(version)} --access ${access}`;
 
   // eslint-disable-next-line no-console
   console.log(command);

--- a/lib/snippets/publish-lerna-independent-packages
+++ b/lib/snippets/publish-lerna-independent-packages
@@ -28,12 +28,10 @@ const packages = PackageUtilities.topologicallyBatchPackages(unsortedPackages, t
   .reduce((acc, packageGroup) => [...acc, ...packageGroup], [])
   .filter(({name}) => taggedPackages.includes(name));
 
-packages.forEach(({name, version, isPrivate}) => {
-  const access = isPrivate ? 'restricted' : 'public';
-
+packages.forEach(({name, version}) => {
   const command = `node_modules/.bin/lerna exec --scope=${
     name
-  } -- npm publish --tag ${npmTag(version)} --access ${access}`;
+  } -- npm publish --tag ${npmTag(version)}`;
 
   // eslint-disable-next-line no-console
   console.log(command);


### PR DESCRIPTION
We (i.e. @ismail-syed) have been working on getting yarn publishing working for private packages, but have not got it working yet.

As such, we decided to switch to using `npm` for publishing with `lerna` as well, since we do have that working properly for mini-repos™️.

In doing this, we also realized that we're making use of utilities in the `lerna` package that have been changed in in `lerna 3.x`. As such, we pin the lerna version to `2.9.x`.