### PR TITLE
🛠️ use npm as the publish client for lerna

### DIFF
--- a/lib/snippets/publish-lerna-independent-packages
+++ b/lib/snippets/publish-lerna-independent-packages
@@ -29,7 +29,7 @@ const packages = PackageUtilities.topologicallyBatchPackages(unsortedPackages, t
   .filter(({name}) => taggedPackages.includes(name));
 
 packages.forEach(({name, version}) => {
-  const command = `node_modules/.bin/lerna publish --yes --skip-npm=false --skip-git --force-publish=${name} --repo-version=${version} --scope=${name} --npm-tag=${npmTag(
+  const command = `node_modules/.bin/lerna publish --yes --npm-client=npm --skip-npm=false --skip-git --force-publish=${name} --repo-version=${version} --scope=${name} --npm-tag=${npmTag(
     version,
   )}`;
 


### PR DESCRIPTION
Currently our lerna publishing is broken with private package clouds.

In [this PR](https://github.com/Shopify/shipit-engine/pull/775) it was suggested we use the `--npm-client` flag. This PR tries that.

I was able to run this script locally and it seemed to work and properly use `npm publish`.