### PR TITLE
Remove 'always-auth=true'

### DIFF
--- a/app/models/shipit/deploy_spec/npm_discovery.rb
+++ b/app/models/shipit/deploy_spec/npm_discovery.rb
@@ -143,10 +143,6 @@ module Shipit
         file(".npmrc")
       end
 
-      def npmrc_contents(registry)
-        "always-auth=true\n#{registry}"
-      end
-
       def registry
         scope = Shipit.npm_org_scope
         prefix = scoped_package? ? "#{scope}:registry" : "registry"
@@ -161,7 +157,7 @@ module Shipit
       def publish_npm_package
         return ['misconfigured-npm-publish-config'] unless valid_publish_config?
 
-        generate_npmrc = "generate-local-npmrc \"#{npmrc_contents(registry)}\""
+        generate_npmrc = "generate-local-npmrc \"#{registry}\""
         check_tags = 'assert-npm-version-tag'
         # `yarn publish` requires user input, so always use npm.
         publish = "npm publish --tag #{dist_tag(package_version)} --access #{publish_config_access}"

--- a/test/models/deploy_spec_test.rb
+++ b/test/models/deploy_spec_test.rb
@@ -818,7 +818,7 @@ module Shipit
       Shipit.stubs(:private_npm_registry).returns('some_private_registry')
       @spec.stubs(:scoped_package?).returns(true)
       @spec.stubs(:publish_config_access).returns('restricted')
-      assert_equal "always-auth=true\n#{registry}", @spec.npmrc_contents(@spec.registry)
+      assert_equal registry, @spec.registry
     end
 
     test '#npmrc_contents returns a public scoped package configuration when the package is scoped and public' do
@@ -826,14 +826,14 @@ module Shipit
       Shipit.stubs(:npm_org_scope).returns('@shopify')
       @spec.stubs(:scoped_package?).returns(true)
       @spec.stubs(:publish_config_access).returns('public')
-      assert_equal "always-auth=true\n#{registry}", @spec.npmrc_contents(@spec.registry)
+      assert_equal registry, @spec.registry
     end
 
     test '#npmrc_contents returns a public non-scoped package configuration when the package is not scoped and public' do
       registry = "registry=https://registry.npmjs.org/"
       @spec.stubs(:scoped_package?).returns(false)
       @spec.stubs(:publish_config_access).returns('public')
-      assert_equal "always-auth=true\n#{registry}", @spec.npmrc_contents(@spec.registry)
+      assert_equal registry, @spec.registry
     end
 
     test '#publish_lerna_packages guesses npm tag' do
@@ -920,7 +920,7 @@ module Shipit
 
       @spec.stubs(:publish_config_access).returns('restricted')
       @spec.stubs(:enforce_publish_config?).returns(true)
-      @spec.stubs(:npmrc_contents).returns('fake')
+      @spec.stubs(:registry).returns('fake')
 
       generate_npmrc = 'generate-local-npmrc "fake"'
       npm_publish = 'npm publish --tag latest --access restricted'


### PR DESCRIPTION
Remove the `always-auth=true` setting in the local `.npmrc` file that is generated on deploy. It's caused some troubles. 

Originally, we set this to true because PackageCloud [docs](https://packagecloud.io/docs) suggest the following: 

> The always-auth field is required when using Yarn with a private repository.

However, to support some project using npm on shopify-build, we've removed this [here](https://github.com/Shopify/shopify-build/pull/1056). Also, looking at yarn [source](https://github.com/yarnpkg/yarn/blob/d2302073e9e9554a2977f3cac2bf5a156859b50f/src/registries/npm-registry.js#L147) `auth-always` it seems that `auth-always=true` is required for non-scoped private packages. All our packages are all `@shopify` scoped so this shouldn't affect us. I ran some small tests locally, to verify this.


Another related issue was brought to my attention today. The `shopify/easdk` had trouble deploying privately.  [shipit logs](https://shipit.shopify.io/shopify/easdk/production)

```
ENEEDAUTH
auth required for publishing
You need to authorize this machine using 'npm adduser'
``` 

I'm not sure why this happened now, and not last week when we beta tested a number of private packages because the `auth-always=true` was set this whole time. One of my hunches to fix this was removing `always-auth=true` since it fixed our issue in  `shopify-build`. 

I was able to validate this by checking in a local `.npmrc` that doesn't `always-auth=true`. [shipit logs](https://shipit.shopify.io/shopify/npm-package-test/test)

@gf3, you can validate this (and unblock yourself, sorry!) by checking in an `.npmrc` into your repo with the following:
 
```
@shopify:registry=https://packages.shopify.io/shopify/node/npm/
```