### PR TITLE
Convert to a GitHub app

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -25,6 +25,9 @@ Rails/OutputSafety:
 Rails/DynamicFindBy:
   Enabled: false
 
+Rails/Delegate:
+  Enabled: false
+
 Rails/ApplicationRecord:
   Enabled: false
 

--- a/app/controllers/shipit/stacks_controller.rb
+++ b/app/controllers/shipit/stacks_controller.rb
@@ -1,6 +1,6 @@
 module Shipit
   class StacksController < ShipitController
-    before_action :load_stack, only: %i(update destroy settings sync_webhooks clear_git_cache refresh)
+    before_action :load_stack, only: %i(update destroy settings clear_git_cache refresh)
 
     def new
       @stack = Stack.new
@@ -62,12 +62,6 @@ module Shipit
       end
 
       redirect_to(params[:return_to].presence || stack_settings_path(@stack), options)
-    end
-
-    def sync_webhooks
-      @stack.setup_hooks
-      flash[:success] = 'Webhooks syncing scheduled'
-      redirect_to stack_settings_path(@stack)
     end
 
     def clear_git_cache

--- a/app/controllers/shipit/webhooks_controller.rb
+++ b/app/controllers/shipit/webhooks_controller.rb
@@ -105,7 +105,6 @@ module Shipit
         Team.find_or_create_by!(github_id: params.team.id) do |team|
           team.github_team = params.team
           team.organization = params.organization.login
-          team.automatically_setup_hooks = true
         end
       end
 

--- a/app/controllers/shipit/webhooks_controller.rb
+++ b/app/controllers/shipit/webhooks_controller.rb
@@ -4,102 +4,144 @@ module Shipit
 
     respond_to :json
 
-    def push
-      branch = params['ref'].gsub('refs/heads/', '')
+    class Handler
+      class << self
+        attr_reader :param_parser
 
-      if branch == stack.branch
-        GithubSyncJob.perform_later(stack_id: stack.id)
+        def params(&block)
+          @param_parser = ExplicitParameters::Parameters.define(&block)
+        end
+      end
+
+      attr_reader :params, :payload
+
+      def initialize(payload)
+        @payload = payload
+        @params = self.class.param_parser.parse!(payload)
+      end
+
+      def process
+        raise NotImplementedError
+      end
+
+      private
+
+      def stacks
+        @stacks ||= Stack.repo(repository_name)
+      end
+
+      def repository_name
+        payload.dig('repository', 'full_name')
+      end
+    end
+
+    class PushHandler < Handler
+      params do
+        requires :ref
+      end
+      def process
+        stacks.where(branch: branch).each(&:sync_github)
+      end
+
+      private
+
+      def branch
+        params.ref.gsub('refs/heads/', '')
+      end
+    end
+
+    class StatusHandler < Handler
+      params do
+        requires :sha, String
+        requires :state, String
+        accepts :description, String
+        accepts :target_url, String
+        accepts :context, String
+        accepts :created_at, String
+
+        accepts :branches, Array do
+          requires :name, String
+        end
+      end
+      def process
+        Commit.where(sha: params.sha).each do |commit|
+          commit.create_status_from_github!(params)
+        end
+      end
+    end
+
+    class MembershipHandler < Handler
+      params do
+        requires :team do
+          requires :id, Integer
+          requires :name, String
+          requires :slug, String
+          requires :url, String
+        end
+        requires :organization do
+          requires :login, String
+        end
+        requires :member do
+          requires :login, String
+        end
+      end
+      def process
+        team = find_or_create_team!
+        member = User.find_or_create_by_login!(params.member.login)
+
+        case action
+        when 'added'
+          team.add_member(member)
+        when 'removed'
+          team.members.delete(member)
+        else
+          raise ArgumentError, "Don't know how to perform action: `#{action.inspect}`"
+        end
+      end
+
+      private
+
+      def find_or_create_team!
+        Team.find_or_create_by!(github_id: params.team.id) do |team|
+          team.github_team = params.team
+          team.organization = params.organization.login
+          team.automatically_setup_hooks = true
+        end
+      end
+
+      def action
+        # GitHub send an `action` parameter that is shadowed by Rails url parameters
+        # It's also impossible to pass an `action` parameters from a test case.
+        params[:_action] || params[:action]
+      end
+    end
+
+    HANDLERS = {
+      'push' => PushHandler,
+      'status' => StatusHandler,
+      'membership' => MembershipHandler,
+    }.freeze
+
+    def create
+      if handler = HANDLERS[event]
+        handler.new(request.parameters).process
       end
 
       head :ok
-    end
-
-    params do
-      requires :sha, String
-      requires :state, String
-      accepts :description, String
-      accepts :target_url, String
-      accepts :context, String
-      accepts :created_at, String
-
-      accepts :branches, Array do
-        requires :name, String
-      end
-    end
-    def state
-      if commit = stack.commits.find_by(sha: params.sha)
-        commit.create_status_from_github!(params)
-      end
-      head :ok
-    end
-
-    params do
-      requires :team do
-        requires :id, Integer
-        requires :name, String
-        requires :slug, String
-        requires :url, String
-      end
-      requires :organization do
-        requires :login, String
-      end
-      requires :member do
-        requires :login, String
-      end
-    end
-    def membership
-      team = find_or_create_team!
-      member = User.find_or_create_by_login!(params.member.login)
-
-      case membership_action
-      when 'added'
-        team.add_member(member)
-      when 'removed'
-        team.members.delete(member)
-      else
-        raise ArgumentError, "Don't know how to perform action: `#{params.action.inspect}`"
-      end
-      head :ok
-    end
-
-    def index
-      render text: "working"
     end
 
     private
 
-    def find_or_create_team!
-      Team.find_or_create_by!(github_id: params.team.id) do |team|
-        team.github_team = params.team
-        team.organization = params.organization.login
-        team.automatically_setup_hooks = true
-      end
-    end
-
     def verify_signature
-      head(422) unless webhook.verify_signature(request.headers['X-Hub-Signature'], request.raw_post)
+      head(422) unless Shipit.github.verify_webhook_signature(request.headers['X-Hub-Signature'], request.raw_post)
     end
 
     def check_if_ping
       head :ok if event == 'ping'
     end
 
-    def webhook
-      @webhook ||= if params[:stack_id]
-        stack.github_hooks.find_by!(event: event)
-      else
-        GithubHook::Organization.find_by!(organization: params.organization.login, event: event)
-      end
-    end
-
     def event
-      request.headers['X-Github-Event'] || action_name
-    end
-
-    def membership_action
-      # GitHub send an `action` parameter that is shadowed by Rails url parameters
-      # It's also impossible to pass an `action` parameters from a test case.
-      request.request_parameters['action'] || params[:_action]
+      request.headers.fetch('X-Github-Event')
     end
 
     def stack

--- a/app/helpers/shipit/github_url_helper.rb
+++ b/app/helpers/shipit/github_url_helper.rb
@@ -21,7 +21,7 @@ module Shipit
     module_function :github_commit_range_url
 
     def github_user_url(user, *args)
-      [Shipit.github_url, user, *args].join('/')
+      Shipit.github.url(user, *args)
     end
     module_function :github_user_url
 

--- a/app/helpers/shipit/shipit_helper.rb
+++ b/app/helpers/shipit/shipit_helper.rb
@@ -41,38 +41,10 @@ module Shipit
       tags
     end
 
-    def missing_github_oauth_message
+    def missing_github_app_message
+      # TODO: Document how to create an app
       <<-MESSAGE.html_safe
-        Shipit requires a GitHub application to authenticate users.
-        If you haven't created an application on GitHub yet, you can do so in the
-        #{link_to 'Settings', Shipit.github_url('/settings/applications/new'), target: '_blank'}
-        section of your profile. You can also create applications for organizations.
-        When setting up your application in Github, set the Homepage URL to your domain
-        and the Authorization callback URL to '<yourdomain>/github/auth/github/callback'.
-      MESSAGE
-    end
-
-    def missing_github_oauth_id_message
-      <<-MESSAGE.html_safe
-        Copy the Client ID from your GitHub application,
-        and paste it into the secrets.yml file under <code>github_oauth.id</code>.
-       MESSAGE
-    end
-
-    def missing_github_oauth_secret_message
-      <<-MESSAGE.html_safe
-        Copy the Client Secret from your GitHub application,
-        and paste it into the secrets.yml file under <code>github_oauth.secret</code>.
-       MESSAGE
-    end
-
-    def missing_github_api_credentials_message
-      <<-MESSAGE.html_safe
-        Shipit needs API access to GitHub. You can
-        #{link_to 'create an access token', Shipit.github_url('/settings/tokens'), target: '_blank'}
-        with the following permissions:
-        <code>admin:repo_hook</code>, <code>admin:org_hook</code> and <code>repo</code>
-        and add it to the secrets.yml file under the key <code>github_api.access_token</code>.
+        Shipit requires a GitHub App to authenticate users and perform API calls.
       MESSAGE
     end
 

--- a/app/jobs/shipit/destroy_job.rb
+++ b/app/jobs/shipit/destroy_job.rb
@@ -1,0 +1,9 @@
+module Shipit
+  class DestroyJob < BackgroundJob
+    queue_as :default
+
+    def perform(instance)
+      instance.destroy
+    end
+  end
+end

--- a/app/jobs/shipit/setup_github_hook_job.rb
+++ b/app/jobs/shipit/setup_github_hook_job.rb
@@ -1,11 +1,9 @@
 module Shipit
   class SetupGithubHookJob < BackgroundJob
-    include BackgroundJob::Unique
-
     queue_as :default
 
     def perform(hook)
-      hook.setup!
+      # TODO: app-migration, delete this job
     end
   end
 end

--- a/app/models/shipit/anonymous_user.rb
+++ b/app/models/shipit/anonymous_user.rb
@@ -23,6 +23,9 @@ module Shipit
     def id
     end
 
+    def github_id
+    end
+
     def logged_in?
       false
     end

--- a/app/models/shipit/anonymous_user.rb
+++ b/app/models/shipit/anonymous_user.rb
@@ -49,7 +49,7 @@ module Shipit
     end
 
     def github_api
-      Shipit.github_api
+      Shipit.github.api
     end
   end
 end

--- a/app/models/shipit/commit.rb
+++ b/app/models/shipit/commit.rb
@@ -92,7 +92,7 @@ module Shipit
     end
 
     def refresh_statuses!
-      github_statuses = stack.handle_github_redirections { Shipit.github_api.statuses(github_repo_name, sha) }
+      github_statuses = stack.handle_github_redirections { Shipit.github.api.statuses(github_repo_name, sha) }
       github_statuses.each do |status|
         create_status_from_github!(status)
       end
@@ -170,7 +170,7 @@ module Shipit
     end
 
     def github_commit
-      @github_commit ||= Shipit.github_api.commit(github_repo_name, sha)
+      @github_commit ||= Shipit.github.api.commit(github_repo_name, sha)
     end
 
     def schedule_fetch_stats!

--- a/app/models/shipit/commit_deployment.rb
+++ b/app/models/shipit/commit_deployment.rb
@@ -23,19 +23,19 @@ module Shipit
       response = begin
         create_deployment_on_github(author.github_api)
       rescue Octokit::ClientError
-        raise if Shipit.github_api == author.github_api
+        raise if Shipit.github.api == author.github_api
         # If the deploy author didn't gave us the permission to create the deployment we falback the the main shipit
         # user.
         #
         # Octokit currently raise NotFound, but I'm convinced it should be Forbidden if the user can see the repository.
         # So to be future proof I catch boths.
-        create_deployment_on_github(Shipit.github_api)
+        create_deployment_on_github(Shipit.github.api)
       end
       update!(github_id: response.id, api_url: response.url)
     end
 
     def pull_request_head
-      pull_request = Shipit.github_api.pull_request(stack.github_repo_name, commit.pull_request_number)
+      pull_request = Shipit.github.api.pull_request(stack.github_repo_name, commit.pull_request_number)
       pull_request.head.sha
     end
 

--- a/app/models/shipit/commit_deployment_status.rb
+++ b/app/models/shipit/commit_deployment_status.rb
@@ -11,13 +11,13 @@ module Shipit
       response = begin
         create_status_on_github(author.github_api)
       rescue Octokit::ClientError
-        raise if Shipit.github_api == author.github_api
+        raise if Shipit.github.api == author.github_api
         # If the deploy author didn't gave us the permission to create the deployment we falback the the main shipit
         # user.
         #
         # Octokit currently raise NotFound, but I'm convinced it should be Forbidden if the user can see the repository.
         # So to be future proof I catch boths.
-        create_status_on_github(Shipit.github_api)
+        create_status_on_github(Shipit.github.api)
       end
       update!(github_id: response.id, api_url: response.url)
     end

--- a/app/models/shipit/github_hook.rb
+++ b/app/models/shipit/github_hook.rb
@@ -1,28 +1,12 @@
 module Shipit
   class GithubHook < ActiveRecord::Base
-    include SecureCompare
-
+    # TODO: app-migration, delete class
     belongs_to :stack, required: false # Required for fixtures
 
     before_create :generate_secret
     before_destroy :teardown!
 
-    def verify_signature(signature, message)
-      algorithm, signature = signature.split("=", 2)
-      return false unless algorithm == 'sha1'
-
-      secure_compare(signature, OpenSSL::HMAC.hexdigest(algorithm, secret, message))
-    end
-
     delegate :github_repo_name, to: :stack
-    def setup!
-      hook = already_setup? ? update_hook! : create_hook!
-      update!(github_id: hook.id, api_url: hook.rels[:self].href)
-    end
-
-    def schedule_setup!
-      SetupGithubHookJob.perform_later(self)
-    end
 
     def teardown!
       destroy_hook! if already_setup?
@@ -39,30 +23,8 @@ module Shipit
 
     private
 
-    def update_hook!
-      edit_hook!
-    rescue Octokit::NotFound
-      create_hook!
-    end
-
-    def endpoint_url
-      raise NotImplementedError.new('Subclasses must implement a `endpoint_url` method')
-    end
-
-    def hook_properties
-      {url: endpoint_url, content_type: 'json', secret: secret}
-    end
-
     def generate_secret
       self.secret = SecureRandom.hex
-    end
-
-    def url_helpers
-      Shipit::Engine.routes.url_helpers
-    end
-
-    def host
-      Shipit.host
     end
 
     def api
@@ -74,36 +36,9 @@ module Shipit
 
       private
 
-      def create_hook!
-        api.create_hook(github_repo_name, 'web', properties, events: [event], active: true)
-      end
-
-      def edit_hook!
-        api.edit_hook(github_repo_name, github_id, 'web', properties, events: [event], active: true)
-      end
-
       def destroy_hook!
         api.remove_hook(github_repo_name, github_id)
       rescue Octokit::NotFound
-      end
-
-      def properties
-        {
-          url: endpoint_url,
-          content_type: 'json',
-          secret: secret,
-        }
-      end
-
-      def endpoint_url
-        case event
-        when 'push'
-          url_helpers.push_stack_webhooks_url(stack_id, host: host)
-        when 'status'
-          url_helpers.state_stack_webhooks_url(stack_id, host: host)
-        else
-          raise ArgumentError, "Unknown GithubHook::Repo event: `#{event.inspect}`"
-        end
       end
     end
 
@@ -112,34 +47,9 @@ module Shipit
 
       private
 
-      def create_hook!
-        api.create_org_hook(organization, properties, events: [event], active: true)
-      end
-
-      def edit_hook!
-        api.edit_org_hook(organization, github_id, properties, events: [event], active: true)
-      end
-
       def destroy_hook!
         api.remove_org_hook(organization, github_id)
       rescue Octokit::NotFound
-      end
-
-      def properties
-        {
-          url: endpoint_url,
-          content_type: 'json',
-          secret: secret,
-        }
-      end
-
-      def endpoint_url
-        case event
-        when 'membership'
-          url_helpers.membership_webhooks_url(host: host)
-        else
-          raise ArgumentError, "Unknown GithubHook::Organization event: `#{event.inspect}`"
-        end
       end
     end
   end

--- a/app/models/shipit/github_hook.rb
+++ b/app/models/shipit/github_hook.rb
@@ -3,7 +3,6 @@ module Shipit
     # TODO: app-migration, delete class
     belongs_to :stack, required: false # Required for fixtures
 
-    before_create :generate_secret
     before_destroy :teardown!
 
     delegate :github_repo_name, to: :stack
@@ -21,14 +20,8 @@ module Shipit
       github_id?
     end
 
-    private
-
-    def generate_secret
-      self.secret = SecureRandom.hex
-    end
-
     def api
-      Shipit.github.api
+      Shipit.legacy_github_api
     end
 
     class Repo < GithubHook

--- a/app/models/shipit/github_hook.rb
+++ b/app/models/shipit/github_hook.rb
@@ -28,7 +28,7 @@ module Shipit
     end
 
     def api
-      Shipit.github_api
+      Shipit.github.api
     end
 
     class Repo < GithubHook

--- a/app/models/shipit/github_status.rb
+++ b/app/models/shipit/github_status.rb
@@ -8,7 +8,7 @@ module Shipit
       end
 
       def refresh_status
-        Rails.cache.write(CACHE_KEY, Shipit.github_api.github_status)
+        Rails.cache.write(CACHE_KEY, Shipit.github.api.github_status)
       rescue Faraday::Error, Octokit::ServerError
       end
     end

--- a/app/models/shipit/pull_request.rb
+++ b/app/models/shipit/pull_request.rb
@@ -110,7 +110,7 @@ module Shipit
       case number_or_url
       when /\A#?(\d+)\z/
         $1.to_i
-      when %r{\Ahttps://#{Regexp.escape(Shipit.github_domain)}/([^/]+)/([^/]+)/pull/(\d+)}
+      when %r{\Ahttps://#{Regexp.escape(Shipit.github.domain)}/([^/]+)/([^/]+)/pull/(\d+)}
         return unless $1.downcase == stack.repo_owner.downcase
         return unless $2.downcase == stack.repo_name.downcase
         $3.to_i
@@ -157,7 +157,7 @@ module Shipit
 
       raise NotReady if not_mergeable_yet?
 
-      Shipit.github_api.merge_pull_request(
+      Shipit.github.api.merge_pull_request(
         stack.github_repo_name,
         number,
         merge_message,
@@ -166,8 +166,8 @@ module Shipit
         merge_method: 'merge',
       )
       begin
-        if Shipit.github_api.pull_requests(stack.github_repo_name, base: branch).empty?
-          Shipit.github_api.delete_branch(stack.github_repo_name, branch)
+        if Shipit.github.api.pull_requests(stack.github_repo_name, base: branch).empty?
+          Shipit.github.api.delete_branch(stack.github_repo_name, branch)
         end
       rescue Octokit::UnprocessableEntity
         # branch was already deleted somehow
@@ -222,7 +222,7 @@ module Shipit
     end
 
     def refresh!
-      update!(github_pull_request: Shipit.github_api.pull_request(stack.github_repo_name, number))
+      update!(github_pull_request: Shipit.github.api.pull_request(stack.github_repo_name, number))
       head.refresh_statuses!
       fetched! if fetching?
       @comparison = nil
@@ -261,7 +261,7 @@ module Shipit
     end
 
     def comparison
-      @comparison ||= Shipit.github_api.compare(
+      @comparison ||= Shipit.github.api.compare(
         stack.github_repo_name,
         base_ref,
         head.sha,
@@ -284,7 +284,7 @@ module Shipit
       if commit = stack.commits.by_sha(sha)
         return commit
       else
-        github_commit = Shipit.github_api.commit(stack.github_repo_name, sha)
+        github_commit = Shipit.github.api.commit(stack.github_repo_name, sha)
         stack.commits.create_from_github!(github_commit, attributes)
       end
     rescue ActiveRecord::RecordNotUnique

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -284,11 +284,11 @@ module Shipit
     end
 
     def repo_http_url
-      Shipit.github_url("#{repo_owner}/#{repo_name}")
+      Shipit.github.url("#{repo_owner}/#{repo_name}")
     end
 
     def repo_git_url
-      "git@#{Shipit.github_domain}:#{repo_owner}/#{repo_name}.git"
+      "git@#{Shipit.github.domain}:#{repo_owner}/#{repo_name}.git"
     end
 
     def base_path
@@ -327,7 +327,7 @@ module Shipit
 
     def github_commits
       handle_github_redirections do
-        Shipit.github_api.commits(github_repo_name, sha: branch)
+        Shipit.github.api.commits(github_repo_name, sha: branch)
       end
     rescue Octokit::Conflict
       [] # Repository is empty...
@@ -345,9 +345,9 @@ module Shipit
     end
 
     def refresh_repository!
-      resource = Shipit.github_api.repo(github_repo_name)
+      resource = Shipit.github.api.repo(github_repo_name)
       if resource.try(:message) == 'Moved Permanently'
-        resource = Shipit.github_api.get(resource.url)
+        resource = Shipit.github.api.get(resource.url)
       end
       update!(repo_owner: resource.owner.login, repo_name: resource.name)
     end

--- a/app/models/shipit/team.rb
+++ b/app/models/shipit/team.rb
@@ -25,7 +25,7 @@ module Shipit
       end
 
       def find_team_on_github(organization, slug)
-        teams = Shipit::OctokitIterator.new { Shipit.github_api.org_teams(organization, per_page: 100) }
+        teams = Shipit::OctokitIterator.new { Shipit.github.api.org_teams(organization, per_page: 100) }
         teams.find { |t| t.slug == slug }
       rescue Octokit::NotFound
       end
@@ -40,7 +40,7 @@ module Shipit
     end
 
     def refresh_members!
-      github_members = Shipit::OctokitIterator.new(Shipit.github_api.get(api_url).rels[:members])
+      github_members = Shipit::OctokitIterator.new(Shipit.github.api.get(api_url).rels[:members])
       members = github_members.map { |u| User.find_or_create_from_github(u) }
       self.members = members
       save!

--- a/app/models/shipit/team.rb
+++ b/app/models/shipit/team.rb
@@ -12,8 +12,6 @@ module Shipit
       class_name: 'GithubHook::Organization',
       inverse_of: false
 
-    after_commit :setup_hooks, if: :automatically_setup_hooks?
-
     class << self
       def find_or_create_by_handle(handle)
         organization, slug = handle.split('/').map(&:downcase)
@@ -39,18 +37,6 @@ module Shipit
 
     def add_member(member)
       members.append(member) unless members.include?(member)
-    end
-
-    attr_writer :automatically_setup_hooks
-    def automatically_setup_hooks?
-      @automatically_setup_hooks
-    end
-
-    def setup_hooks(async: true)
-      REQUIRED_HOOKS.each do |event|
-        hook = github_hooks.find_or_create_by!(event: event)
-        async ? hook.schedule_setup! : hook.setup!
-      end
     end
 
     def refresh_members!

--- a/app/models/shipit/user.rb
+++ b/app/models/shipit/user.rb
@@ -12,7 +12,13 @@ module Shipit
 
     def self.find_or_create_by_login!(login)
       find_or_create_by!(login: login) do |user|
-        user.github_user = Shipit.github_api.user(login)
+        user.github_user = Shipit.github.api.user(login)
+      end
+    end
+
+    def self.find_or_create_by_github_id!(github_id)
+      find_or_create_by!(github_id: github_id) do |user|
+        user.github_user = Shipit.github.api.user(github_id)
       end
     end
 
@@ -44,7 +50,7 @@ module Shipit
     end
 
     def github_api
-      return Shipit.github_api unless github_access_token
+      return Shipit.github.api unless github_access_token
 
       @github_api ||= begin
         client = Octokit::Client.new(access_token: github_access_token)
@@ -71,7 +77,7 @@ module Shipit
     end
 
     def refresh_from_github!
-      update!(github_user: Shipit.github_api.user(github_id))
+      update!(github_user: Shipit.github.api.user(github_id))
     rescue Octokit::NotFound
       identify_renamed_user!
     end

--- a/app/serializers/shipit/user_serializer.rb
+++ b/app/serializers/shipit/user_serializer.rb
@@ -1,5 +1,5 @@
 module Shipit
   class UserSerializer < ActiveModel::Serializer
-    attributes :id, :name, :email, :login, :avatar_url, :created_at, :updated_at
+    attributes :id, :name, :email, :login, :avatar_url, :created_at, :updated_at, :github_id
   end
 end

--- a/app/views/shipit/missing_settings.html.erb
+++ b/app/views/shipit/missing_settings.html.erb
@@ -17,49 +17,18 @@
 <div class="wrapper">
   <section>
     <header class="section-header">
-      <h2>GitHub application</h2>
+      <h2>GitHub App</h2>
     </header>
 
-    <% if Shipit.github_oauth_id.blank? || Shipit.github_oauth_secret.blank? %>
-      <p><%= missing_github_oauth_message %></p>
-    <% end %>
-    <p id="github_oauth_id">
-      ID:
-    <% if Shipit.github_oauth_id.present? %>
+    <p id="github_app">
+      Config:
+    <% if Rails.application.secrets.github.present? %>
        Success!
     <% else %>
       <span class="missing">
-        <%= missing_github_oauth_id_message %>
+        <%= missing_github_app_message %>
       </span>
     <% end %>
-    </p>
-
-    <p id="github_oauth_secret">
-    Secret:
-    <% if Shipit.github_oauth_secret.present? %>
-      Success!
-    <% else %>
-      <span class="missing">
-        <%= missing_github_oauth_secret_message %>
-      </span>
-    <% end %>
-    </p>
-  </section>
-
-  <section>
-    <header class="section-header">
-      <h2>GitHub API</h2>
-    </header>
-
-    <p id="github_api">
-      Token:
-      <% if Shipit.github_api_credentials.present? %>
-        Success!
-      <% else %>
-        <span class="missing">
-          <%= missing_github_api_credentials_message %>
-        </span>
-      <% end %>
     </p>
   </section>
 

--- a/app/views/shipit/stacks/new.html.erb
+++ b/app/views/shipit/stacks/new.html.erb
@@ -9,7 +9,7 @@
         <div class="field-wrapper">
           <%= label_tag "Repo" %>
           <br>
-          <%= Shipit.github_url %>
+          <%= Shipit.github.url %>
           /
           <%= f.text_field :repo_owner, placeholder: 'e.g. Shopify', required: true, class: "repo" %>
           /

--- a/app/views/shipit/stacks/settings.html.erb
+++ b/app/views/shipit/stacks/settings.html.erb
@@ -65,10 +65,6 @@
       <h5>Resynchronize this stack</h5>
       <table>
         <tr>
-          <td><%= button_to "Webhooks", stack_sync_webhooks_path(@stack), class: "btn", method: "post" %></td>
-          <td>Ensure that all required webhooks have been created.</td>
-        </tr>
-        <tr>
           <td><%= button_to "Clear Git Cache", stack_clear_git_cache_path(@stack), class: "btn", method: "post" %></td>
           <td>Delete the local git mirror in case it's in a bad state.</td>
         </tr>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -55,7 +55,6 @@ Shipit::Engine.routes.draw do
     get :settings, controller: :stacks
     post :refresh, controller: :stacks
     get :refresh, controller: :stacks # For easier design, sorry :/
-    post :sync_webhooks, controller: :stacks
     post :clear_git_cache, controller: :stacks
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -8,18 +8,7 @@ Shipit::Engine.routes.draw do
   # Robots
   get '/status/version' => 'status#version', as: :version
 
-  resources :stacks, only: %i(new create index) do
-    resource :webhooks, only: [] do
-      post :push, :state
-    end
-  end
-
-  resources :webhooks, only: [] do
-    collection do
-      post :membership
-      get :membership
-    end
-  end
+  resources :webhooks, only: :create
 
   # API
   namespace :api do
@@ -50,6 +39,8 @@ Shipit::Engine.routes.draw do
   end
 
   # Humans
+  resources :stacks, only: %i(new create index)
+
   scope '/github/auth/github', as: :github_authentication, controller: :github_authentication do
     get '/', action: :request
     post :callback

--- a/db/migrate/20180417130436_remove_all_github_hooks.rb
+++ b/db/migrate/20180417130436_remove_all_github_hooks.rb
@@ -1,0 +1,11 @@
+class RemoveAllGithubHooks < ActiveRecord::Migration[5.1]
+  def change
+    if !Shipit.legacy_github_api && Shipit::GithubHook.any?
+      Rails.logger.error("Can't destroy github hooks because no legacy token is configred")
+    else
+      Shipit::GithubHook.find_each do |hook|
+        Shipit::DestroyJob.perform_later(hook)
+      end
+    end
+  end
+end

--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -82,9 +82,8 @@ module Shipit
   end
 
   def user
-    # TODO: figure this out in context of github app
-    if github.login
-      User.find_or_create_by_login!(github.login)
+    if github.bot_id # TODO: figure a better way to retreive this
+      User.find_or_create_by_github_id!(github.bot_id)
     else
       AnonymousUser.new
     end

--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -77,8 +77,10 @@ module Shipit
     @github ||= GitHubApp.new(secrets.github)
   end
 
-  def github_api
-    github.api # TODO: get rid of this alias
+  def legacy_github_api
+    if secrets&.github_api.present?
+      @legacy_github_api ||= Octokit::Client.new(access_token: secrets.github_api['access_token'])
+    end
   end
 
   def user

--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -30,6 +30,7 @@ require 'faraday-http-cache'
 
 require 'shipit/version'
 
+require 'shipit/github_app'
 require 'shipit/paginator'
 require 'shipit/null_serializer'
 require 'shipit/csv_serializer'
@@ -72,36 +73,20 @@ module Shipit
     Redis::Namespace.new(namespace, redis: @redis)
   end
 
-  def github_domain
-    @github_domain ||= secrets.github_domain.presence || 'github.com'.freeze
-  end
-
-  def github_enterprise?
-    github_domain != 'github.com'
-  end
-
-  def github_url(path = nil)
-    @github_url ||= "https://#{github_domain}".freeze
-    path ? File.join(@github_url, path) : @github_url
-  end
-
-  def github_api_endpoint
-    github_url('/api/v3/') if github_enterprise?
-  end
-
-  def user
-    if github_api.login
-      User.find_or_create_by_login!(github_api.login)
-    else
-      AnonymousUser.new
-    end
+  def github
+    @github ||= GitHubApp.new(secrets.github)
   end
 
   def github_api
-    @github_api ||= begin
-      client = Octokit::Client.new(github_api_credentials)
-      client.middleware = new_faraday_stack
-      client
+    github.api # TODO: get rid of this alias
+  end
+
+  def user
+    # TODO: figure this out in context of github app
+    if github.login
+      User.find_or_create_by_login!(github.login)
+    else
+      AnonymousUser.new
     end
   end
 
@@ -119,10 +104,6 @@ module Shipit
       builder.adapter Faraday.default_adapter
       yield builder if block_given?
     end
-  end
-
-  def github_api_credentials
-    {api_endpoint: github_api_endpoint}.merge((Rails.application.secrets.github_api || {}).symbolize_keys)
   end
 
   def api_clients_secret
@@ -150,39 +131,12 @@ module Shipit
   end
 
   def github_teams
-    @github_teams ||= github_teams_handles.map { |t| Team.find_or_create_by_handle(t) }
-  end
-
-  def github_teams_handles
-    (Array(github_oauth_credentials['team']) + Array(github_oauth_credentials['teams'])).sort.uniq
-  end
-
-  def github_oauth_id
-    github_oauth_credentials['id']
-  end
-
-  def github_oauth_secret
-    github_oauth_credentials['secret']
-  end
-
-  def github_oauth_credentials
-    (secrets.github_oauth || {}).to_h.stringify_keys
-  end
-
-  def github_oauth_options
-    return {} unless github_enterprise?
-    {
-      site: github_api_endpoint,
-      authorize_url: github_url('/login/oauth/authorize'),
-      token_url: github_url('/login/oauth/access_token'),
-    }
+    @github_teams ||= github.oauth_teams.map { |t| Team.find_or_create_by_handle(t) }
   end
 
   def all_settings_present?
     @all_settings_present ||= [
-      github_oauth_id,
-      github_oauth_secret,
-      github_api_credentials,
+      secrets.github, # TODO: handle GitHub settings
       redis_url,
       host,
     ].all?(&:present?)

--- a/lib/shipit/engine.rb
+++ b/lib/shipit/engine.rb
@@ -29,16 +29,10 @@ module Shipit
       ActiveModel::ArraySerializer._root = false
       ActiveModel::Serializer.include(Engine.routes.url_helpers)
 
-      if Shipit.github_oauth_credentials
+      if Shipit.github.oauth?
         OmniAuth::Strategies::GitHub.configure path_prefix: '/github/auth'
         app.middleware.use OmniAuth::Builder do
-          provider(
-            :github,
-            Shipit.github_oauth_id,
-            Shipit.github_oauth_secret,
-            scope: 'email,repo_deployment',
-            client_options: Shipit.github_oauth_options,
-          )
+          provider(:github, *Shipit.github.oauth_config)
         end
       end
     end

--- a/lib/shipit/github_app.rb
+++ b/lib/shipit/github_app.rb
@@ -1,12 +1,12 @@
 module Shipit
   class GitHubApp
     def initialize(config)
-      @webhook_secret = config[:webhook_secret]
+      @webhook_secret = config[:webhook_secret].presence
       @private_key = config[:private_key]
     end
 
     def verify_webhook_signature(signature, message)
-      return true unless webhook_secret.present?
+      return true unless webhook_secret
 
       algorithm, signature = signature.split("=", 2)
       return false unless algorithm == 'sha1'

--- a/lib/shipit/github_app.rb
+++ b/lib/shipit/github_app.rb
@@ -1,8 +1,31 @@
 module Shipit
   class GitHubApp
+    DOMAIN = 'github.com'.freeze
+    AuthenticationFailed = Class.new(StandardError)
+
+    attr_reader :oauth_teams, :domain, :bot_id
+
     def initialize(config)
+      @domain = config[:domain] || DOMAIN
       @webhook_secret = config[:webhook_secret].presence
-      @private_key = config[:private_key]
+      @bot_id = config[:bot_id]
+      @app_id = config.fetch(:app_id)
+      @installation_id = config.fetch(:installation_id)
+      @private_key = config.fetch(:private_key)
+
+      oauth = config[:oauth] || {}
+      @oauth_id = oauth[:id]
+      @oauth_secret = oauth[:secret]
+      @oauth_teams = Array.wrap(oauth[:teams] || oauth[:teams])
+    end
+
+    def login
+      raise NotImplementedError, 'Handle App login / user'
+    end
+
+    def api
+      @client = new_client if !defined?(@client) || @client.access_token != token
+      @client
     end
 
     def verify_webhook_signature(signature, message)
@@ -14,8 +37,76 @@ module Shipit
       SecureCompare.secure_compare(signature, OpenSSL::HMAC.hexdigest(algorithm, webhook_secret, message))
     end
 
+    def token
+      return 't0kEn' if Rails.env.test? # TODO: figure out something cleaner
+      return unless private_key && app_id && installation_id
+
+      Rails.cache.fetch('github:integration:token', expires_in: 50.minutes, race_condition_ttl: 10.minutes) do
+        token = Octokit::Client.new(bearer_token: authentication_payload).create_app_installation_access_token(
+          installation_id,
+          accept: 'application/vnd.github.machine-man-preview+json',
+        ).token
+        raise AuthenticationFailed if token.blank?
+        token
+      end
+    end
+
+    def oauth?
+      oauth_id.present? && oauth_secret.present?
+    end
+
+    def oauth_config
+      options = {}
+      if enterprise?
+        options = {
+          site: api_endpoint,
+          authorize_url: url('/login/oauth/authorize'),
+          token_url: url('/login/oauth/access_token'),
+        }
+      end
+
+      [
+        oauth_id,
+        oauth_secret,
+        scope: 'email,repo_deployment',
+        client_options: options,
+      ]
+    end
+
+    def url(*path)
+      @url ||= "https://#{domain}".freeze
+      path.empty? ? @url : File.join(@url, *path.map(&:to_s))
+    end
+
+    def api_endpoint
+      url('/api/v3/') if enterprise?
+    end
+
+    def enterprise?
+      domain != DOMAIN
+    end
+
     private
 
-    attr_reader :webhook_secret, :private_key
+    attr_reader :webhook_secret, :app_id, :installation_id, :private_key, :oauth_id, :oauth_secret
+
+    def new_client
+      client = Octokit::Client.new(
+        access_token: token,
+        api_endpoint: api_endpoint,
+      )
+      client.middleware = Shipit.new_faraday_stack
+      client
+    end
+
+    def authentication_payload
+      payload = {
+        iat: Time.now.to_i,
+        exp: 10.minutes.from_now.to_i,
+        iss: app_id,
+      }
+      key = OpenSSL::PKey::RSA.new(private_key)
+      JWT.encode(payload, key, 'RS256')
+    end
   end
 end

--- a/lib/shipit/github_app.rb
+++ b/lib/shipit/github_app.rb
@@ -6,15 +6,12 @@ module Shipit
     attr_reader :oauth_teams, :domain, :bot_id
 
     def initialize(config)
-      config = (config || {}).with_indifferent_access
-      @domain = config[:domain] || DOMAIN
-      @webhook_secret = config[:webhook_secret].presence
-      @bot_id = config[:bot_id]
-      @app_id = config.fetch(:app_id)
-      @installation_id = config.fetch(:installation_id)
-      @private_key = config.fetch(:private_key)
+      @config = (config || {}).with_indifferent_access
+      @domain = @config[:domain] || DOMAIN
+      @webhook_secret = @config[:webhook_secret].presence
+      @bot_id = @config[:bot_id]
 
-      oauth = (config[:oauth] || {}).with_indifferent_access
+      oauth = (@config[:oauth] || {}).with_indifferent_access
       @oauth_id = oauth[:id]
       @oauth_secret = oauth[:secret]
       @oauth_teams = Array.wrap(oauth[:teams] || oauth[:teams])
@@ -89,7 +86,19 @@ module Shipit
 
     private
 
-    attr_reader :webhook_secret, :app_id, :installation_id, :private_key, :oauth_id, :oauth_secret
+    attr_reader :webhook_secret, :oauth_id, :oauth_secret
+
+    def app_id
+      @app_id ||= @config.fetch(:app_id)
+    end
+
+    def installation_id
+      @installation_id ||= @config.fetch(:installation_id)
+    end
+
+    def private_key
+      @private_key ||= @config.fetch(:private_key)
+    end
 
     def new_client
       client = Octokit::Client.new(

--- a/lib/shipit/github_app.rb
+++ b/lib/shipit/github_app.rb
@@ -1,0 +1,21 @@
+module Shipit
+  class GitHubApp
+    def initialize(config)
+      @webhook_secret = config[:webhook_secret]
+      @private_key = config[:private_key]
+    end
+
+    def verify_webhook_signature(signature, message)
+      return true unless webhook_secret.present?
+
+      algorithm, signature = signature.split("=", 2)
+      return false unless algorithm == 'sha1'
+
+      SecureCompare.secure_compare(signature, OpenSSL::HMAC.hexdigest(algorithm, webhook_secret, message))
+    end
+
+    private
+
+    attr_reader :webhook_secret, :private_key
+  end
+end

--- a/lib/shipit/github_app.rb
+++ b/lib/shipit/github_app.rb
@@ -6,6 +6,7 @@ module Shipit
     attr_reader :oauth_teams, :domain, :bot_id
 
     def initialize(config)
+      config = (config || {}).with_indifferent_access
       @domain = config[:domain] || DOMAIN
       @webhook_secret = config[:webhook_secret].presence
       @bot_id = config[:bot_id]
@@ -13,7 +14,7 @@ module Shipit
       @installation_id = config.fetch(:installation_id)
       @private_key = config.fetch(:private_key)
 
-      oauth = config[:oauth] || {}
+      oauth = (config[:oauth] || {}).with_indifferent_access
       @oauth_id = oauth[:id]
       @oauth_secret = oauth[:secret]
       @oauth_teams = Array.wrap(oauth[:teams] || oauth[:teams])

--- a/lib/shipit/octokit_iterator.rb
+++ b/lib/shipit/octokit_iterator.rb
@@ -6,8 +6,8 @@ module Shipit
       if relation
         @response = relation.get(per_page: 100)
       else
-        yield Shipit.github_api
-        @response = Shipit.github_api.last_response
+        yield Shipit.github.api
+        @response = Shipit.github.api.last_response
       end
     end
 

--- a/lib/tasks/teams.rake
+++ b/lib/tasks/teams.rake
@@ -14,16 +14,6 @@ namespace :teams do
           puts "Failed to fetch @#{handle} members. Do you have enough permissions?"
           puts "#{error.class}: #{error.message}"
         end
-
-        if team
-          puts "Ensuring webhook presence for #{team.organization}"
-          begin
-            team.setup_hooks(async: false)
-          rescue Octokit::Unauthorized, Octokit::NotFound => error
-            puts "Failed to install webhook on #{team.organization}. Do you have enough permissions?"
-            puts "#{error.class}: #{error.message}"
-          end
-        end
       end
     end
   end

--- a/lib/tasks/webhook.rake
+++ b/lib/tasks/webhook.rake
@@ -1,6 +1,0 @@
-namespace :webhook do
-  desc "get all the webhooks back in sync"
-  task sync_all: [:environment] do
-    Shipit::Stack.find_each(&:setup_hooks)
-  end
-end

--- a/test/controllers/stacks_controller_test.rb
+++ b/test/controllers/stacks_controller_test.rb
@@ -8,24 +8,10 @@ module Shipit
       session[:user_id] = shipit_users(:walrus).id
     end
 
-    test "validates that Shipit.github_oauth_id is present" do
-      Shipit.stubs(github_oauth_credentials: {'secret' => 'abc'})
+    test "validates that Shipit.github is present" do
+      Rails.application.secrets.stubs(:github).returns(nil)
       get :index
-      assert_select "#github_oauth_id .missing"
-      assert_select ".missing", count: 1
-    end
-
-    test "validates that Shipit.github_oauth_secret is present" do
-      Shipit.stubs(github_oauth_credentials: {'id' => 'abc'})
-      get :index
-      assert_select "#github_oauth_secret .missing"
-      assert_select ".missing", count: 1
-    end
-
-    test "validates that Shipit.github_api_credentials is present" do
-      Shipit.stubs(github_api_credentials: {})
-      get :index
-      assert_select "#github_api .missing"
+      assert_select "#github_app .missing"
       assert_select ".missing", count: 1
     end
 

--- a/test/controllers/stacks_controller_test.rb
+++ b/test/controllers/stacks_controller_test.rb
@@ -142,18 +142,6 @@ module Shipit
       assert_redirected_to stack_settings_path(@stack)
     end
 
-    test "#sync_webhooks queues #{Stack::REQUIRED_HOOKS.count} SetupGithubHookJob" do
-      assert_enqueued_jobs(Stack::REQUIRED_HOOKS.count) do
-        post :sync_webhooks, params: {id: @stack.to_param}
-      end
-      assert_redirected_to stack_settings_path(@stack)
-    end
-
-    test "#sync_webhooks displays a flash message" do
-      post :sync_webhooks, params: {id: @stack.to_param}
-      assert_equal 'Webhooks syncing scheduled', flash[:success]
-    end
-
     test "#clear_git_cache queues a ClearGitCacheJob" do
       assert_enqueued_with(job: ClearGitCacheJob, args: [@stack]) do
         post :clear_git_cache, params: {id: @stack.to_param}

--- a/test/controllers/webhooks_controller_test.rb
+++ b/test/controllers/webhooks_controller_test.rb
@@ -12,7 +12,7 @@ module Shipit
       params = payload(:push_master)
 
       assert_enqueued_with(job: GithubSyncJob, args: [stack_id: @stack.id]) do
-        post :push, params: {stack_id: @stack.id}.merge(params)
+        post :create, params: params
       end
     end
 
@@ -20,7 +20,7 @@ module Shipit
       request.headers['X-Github-Event'] = 'push'
       params = payload(:push_not_master)
       assert_no_enqueued_jobs do
-        post :push, params: {stack_id: @stack.id}.merge(params)
+        post :create, params: params
       end
     end
 
@@ -31,7 +31,7 @@ module Shipit
       commit = shipit_commits(:first)
 
       assert_difference 'commit.statuses.count', 1 do
-        post :state, params: {stack_id: @stack.id}.merge(status_payload)
+        post :create, params: status_payload
       end
 
       status = commit.statuses.last
@@ -45,36 +45,27 @@ module Shipit
     test ":state with a unexisting commit respond with 200 OK" do
       request.headers['X-Github-Event'] = 'status'
       params = {'sha' => 'notarealcommit', 'state' => 'pending', 'branches' => [{'name' => 'master'}]}
-      post :state, params: {stack_id: @stack.id}.merge(params)
+      post :create, params: params
       assert_response :ok
     end
 
     test ":state in an untracked branche bails out" do
       request.headers['X-Github-Event'] = 'status'
       params = {'sha' => 'notarealcommit', 'state' => 'pending', 'branches' => []}
-      post :state, params: {stack_id: @stack.id}.merge(params)
+      post :create, params: params
       assert_response :ok
     end
 
-    test ":push returns head :ok if request is ping" do
+    test "returns head :ok if request is ping" do
       @request.headers['X-Github-Event'] = 'ping'
 
       assert_no_enqueued_jobs do
-        post :state, params: {stack_id: @stack.id, zen: 'Git is beautiful'}
+        post :create, params: {zen: 'Git is beautiful'}
         assert_response :ok
       end
     end
 
-    test ":state returns head :ok if request is ping" do
-      @request.headers['X-Github-Event'] = 'ping'
-
-      assert_no_enqueued_jobs do
-        post :state, params: {stack_id: @stack.id}
-        assert_response :ok
-      end
-    end
-
-    test ":state verifies webhook signature" do
+    test "verifies webhook signature" do
       commit = shipit_commits(:first)
 
       params = {"sha" => commit.sha, "state" => "pending", "target_url" => "https://ci.example.com/1000/output"}
@@ -83,28 +74,16 @@ module Shipit
       @request.headers['X-Github-Event'] = 'push'
       @request.headers['X-Hub-Signature'] = signature
 
-      GithubHook.any_instance.expects(:verify_signature).with(signature, URI.encode_www_form(params)).returns(false)
+      Shipit.github.expects(:verify_webhook_signature).with(signature, URI.encode_www_form(params)).returns(false)
 
-      post :push, params: {stack_id: @stack.id}.merge(params)
-      assert_response :unprocessable_entity
-    end
-
-    test ":push verifies webhook signature" do
-      params = {"ref" => "refs/heads/master"}
-      signature = 'sha1=ad1d939e9acd6bdc2415a2dd5951be0f2a796ce0'
-
-      @request.headers['X-Github-Event'] = 'push'
-      @request.headers['X-Hub-Signature'] = signature
-
-      GithubHook.any_instance.expects(:verify_signature).with(signature, URI.encode_www_form(params)).returns(false)
-
-      post :push, params: {stack_id: @stack.id}.merge(params)
+      post :create, params: params
       assert_response :unprocessable_entity
     end
 
     test ":membership creates the mentioned team on the fly" do
+      @request.headers['X-Github-Event'] = 'membership'
       assert_difference -> { Team.count }, 1 do
-        post :membership, params: membership_params.merge(team: {
+        post :create, params: membership_params.merge(team: {
           id: 48,
           name: 'Ouiche Cooks',
           slug: 'ouiche-cooks',
@@ -115,37 +94,42 @@ module Shipit
     end
 
     test ":membership creates the mentioned user on the fly" do
+      @request.headers['X-Github-Event'] = 'membership'
       Shipit.github_api.expects(:user).with('george').returns(george)
       assert_difference -> { User.count }, 1 do
-        post :membership, params: membership_params.merge(member: {login: 'george'})
+        post :create, params: membership_params.merge(member: {login: 'george'})
         assert_response :ok
       end
     end
 
     test ":membership can delete an user membership" do
+      @request.headers['X-Github-Event'] = 'membership'
       assert_difference -> { Membership.count }, -1 do
-        post :membership, params: membership_params.merge(_action: 'removed')
+        post :create, params: membership_params.merge(_action: 'removed')
         assert_response :ok
       end
     end
 
     test ":membership can append an user membership" do
+      @request.headers['X-Github-Event'] = 'membership'
       assert_difference -> { Membership.count }, 1 do
-        post :membership, params: membership_params.merge(member: {login: 'bob'})
+        post :create, params: membership_params.merge(member: {login: 'bob'})
         assert_response :ok
       end
     end
 
     test ":membership can append an user twice" do
+      @request.headers['X-Github-Event'] = 'membership'
       assert_no_difference -> { Membership.count } do
-        post :membership, params: membership_params
+        post :create, params: membership_params
         assert_response :ok
       end
     end
 
     test ":membership can delete an user twice" do
+      @request.headers['X-Github-Event'] = 'membership'
       assert_no_difference -> { Membership.count } do
-        post :membership, params: membership_params.merge(_action: 'removed', member: {login: 'bob'})
+        post :create, params: membership_params.merge(_action: 'removed', member: {login: 'bob'})
         assert_response :ok
       end
     end

--- a/test/controllers/webhooks_controller_test.rb
+++ b/test/controllers/webhooks_controller_test.rb
@@ -95,7 +95,7 @@ module Shipit
 
     test ":membership creates the mentioned user on the fly" do
       @request.headers['X-Github-Event'] = 'membership'
-      Shipit.github_api.expects(:user).with('george').returns(george)
+      Shipit.github.api.expects(:user).with('george').returns(george)
       assert_difference -> { User.count }, 1 do
         post :create, params: membership_params.merge(member: {login: 'george'})
         assert_response :ok

--- a/test/dummy/config/secrets.yml
+++ b/test/dummy/config/secrets.yml
@@ -3,6 +3,8 @@ development:
 test:
   secret_key_base: s3cr3ts3cr3ts3cr3ts3cr3ts3cr3ts3cr3t
   host: shipit.com
+  github_api:
+    token: t0k3n
   github:
     domain: # defaults to github.com
     app_id: 42

--- a/test/dummy/config/secrets.yml
+++ b/test/dummy/config/secrets.yml
@@ -4,16 +4,14 @@ test:
   secret_key_base: s3cr3ts3cr3ts3cr3ts3cr3ts3cr3ts3cr3t
   host: shipit.com
   github:
+    domain: # defaults to github.com
+    app_id: 42
+    installation_id: 43
     webhook_secret: # nil
-  github_api:
-    access_token: t0kEn
-    # login:
-    # password:
-    # api_endpoint:
-  github_oauth:
-    id: 1d
-    secret: s3cr37
-    # teams:
-    #   -
-    #   -
+    # Randomly generated
+    private_key: "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA7iUQC2uUq/gtQg0gxtyaccuicYgmq1LUr1mOWbmwM1Cv63+S\n73qo8h87FX+YyclY5fZF6SMXIys02JOkImGgbnvEOLcHnImCYrWs03msOzEIO/pG\nM0YedAPtQ2MEiLIu4y8htosVxeqfEOPiq9kQgFxNKyETzjdIA9q1md8sofuJUmPv\nibacW1PecuAMnn+P8qf0XIDp7uh6noB751KvhCaCNTAPtVE9NZ18OmNG9GOyX/pu\npQHIrPgTpTG6KlAe3r6LWvemzwsMtuRGU+K+KhK9dFIlSE+v9rA32KScO8efOh6s\nGu3rWorV4iDu14U62rzEfdzzc63YL94sUbZxbwIDAQABAoIBADLJ8r8MxZtbhYN1\nu0zOFZ45WL6v09dsBfITvnlCUeLPzYUDIzoxxcBFittN6C744x3ARS6wjimw+EdM\nTZALlCSb/sA9wMDQzt7wchhz9Zh2H5RzDu+2f54sjDh38KqancdT8PO2fAFGxX/b\nqicOVyeZB9gv6MJtJc20olBbuXAeBNfcDABF9oxF+0i+Ssg7B4VXiqgcjtGbr/Og\nqRll7AqyTArVx2xEcVfZxeZ4zGnigzcJq4te7yYpxzwk+RxblkPh54Yt4WxZ+8DI\nRsn3r6ajlpwzpwvsJFU2Txq7xBTzGQMFmy/Pnjk83kP2cogxB2+tRyjITGqTwD8b\ngg9PFCkCgYEA+7u8A0l0Cz6p0SI6c7ftVePVRiIhpawWN7og/wEmI6zUjm/3rA+R\nhrhaVKuOD8QF/HdDsqTck5gjGAjTmJz6r33/cl1Tz+pr62znsrB4r0yMKvQbKN81\nWGaWOsi2+ZXqLNv5h5wpUF0MTKlXHeKnwP5kuEvGwVn6WURFCh6PhLMCgYEA8i5e\nJjulJVGyd5HuoY3xyO7E6DjidsqRnVRq+hYpORjnHvTmSwe4+tH4ha2p9Kv2Y6k3\nC1NYY/fSMQoYCCRaYyJleI+la/9tsZqAmtms4ZB8KhFmPHf9fW75i6G0xKWyZ8K+\nE2Ft/UaEiM282593cguV6+Kt5uExnyPxLLK4FlUCgYEAwRJ/JGI8/7bjFkTTYheq\nj5q75BufhOrU6471acAe2XPgXxLfefdC3Xodxh0CS3NESBvNL4Ikr4sbN37lk4Kq\n/th7iOKtuqUIeru/hZy2I3VpeDRbdGCmEJQ2GwYA2LKztg5Nd0Y9paaIHXAwIfrK\nQUqcQ4HTAk8ZpUeoUBeaaeMCgYANLmbjb9WiPVsYVPIHCwHA7PX8qbPxwT7BsGmO\nKQyfVfKmZa/vH4F67Vi4deZNMdrcO8aKMEQcVM2065a5QrlEsgeR00eupB1lUEJ1\nqylUsZeAdqf43JMIc7TTW77KATa/nQLZbTEeWus1wvTngztuEqFbUGAks9cOkVc8\nFpIcbQKBgQDVIL8gPLmn0f+4oLF8MBC+oxtKpz14X5iJ1saGFkzW5I+nIEskpS0S\nqtirnTCnJFGdCrFwctnxiuiCmyGwpBYdjIfHyvYAHnqAtMnESzCUyeSFZiquVW5W\nMvbMmDPoV27XOHU9kIq6NXtfrkpufiyo6/VEYWozXalxKLNuqLYfPQ==\n-----END RSA PRIVATE KEY-----\n"
+    oauth:
+      id: Iv1.bf2c2c45b449bfd9
+      secret: ef694cd6e45223075d78d138ef014049052665f1
+      teams:
   redis_url: "redis://127.0.0.1:6379/7"

--- a/test/dummy/config/secrets.yml
+++ b/test/dummy/config/secrets.yml
@@ -3,6 +3,8 @@ development:
 test:
   secret_key_base: s3cr3ts3cr3ts3cr3ts3cr3ts3cr3ts3cr3t
   host: shipit.com
+  github:
+    webhook_secret: # nil
   github_api:
     access_token: t0kEn
     # login:

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180202220850) do
+ActiveRecord::Schema.define(version: 20180417130436) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text "permissions", limit: 65535

--- a/test/dummy/db/seeds.rb
+++ b/test/dummy/db/seeds.rb
@@ -6,7 +6,6 @@ FakeWeb.register_uri(:post, %r{https://example\.com/}, status: %w(200 OK))
 
 # Cheap hack to allow rake db:seed to work
 module Shipit
-  Stack.send(:define_method, :setup_hooks) {}
   Stack.send(:define_method, :sync_github) {}
   Commit.send(:define_method, :fetch_stats!) {}
   Commit.send(:define_method, :refresh_statuses!) {}

--- a/test/fixtures/payloads/push_master.json
+++ b/test/fixtures/payloads/push_master.json
@@ -5,14 +5,14 @@
   "created": false,
   "deleted": false,
   "forced": false,
-  "compare": "https://github.com/byroot/junk/compare/16c259864de2...79d29e99cb83",
+  "compare": "https://github.com/Shopify/shipit-engine/compare/16c259864de2...79d29e99cb83",
   "commits": [
     {
       "id": "79d29e99cb83e0ba16c9e30c502a60995e711e5f",
       "distinct": true,
       "message": "modif",
       "timestamp": "2014-02-28T10:27:42-08:00",
-      "url": "https://github.com/byroot/junk/commit/79d29e99cb83e0ba16c9e30c502a60995e711e5f",
+      "url": "https://github.com/Shopify/shipit-engine/commit/79d29e99cb83e0ba16c9e30c502a60995e711e5f",
       "author": {
         "name": "Guillaume Malette",
         "email": "gmalette@gmail.com",
@@ -35,7 +35,7 @@
     "distinct": true,
     "message": "modif",
     "timestamp": "2014-02-28T10:27:42-08:00",
-    "url": "https://github.com/byroot/junk/commit/79d29e99cb83e0ba16c9e30c502a60995e711e5f",
+    "url": "https://github.com/Shopify/shipit-engine/commit/79d29e99cb83e0ba16c9e30c502a60995e711e5f",
     "author": {
       "name": "Guillaume Malette",
       "email": "gmalette@gmail.com",
@@ -54,8 +54,9 @@
   },
   "repository": {
     "id": 17266426,
-    "name": "junk",
-    "url": "https://github.com/byroot/junk",
+    "name": "shipit-engine",
+    "full_name": "Shopify/shipit-engine",
+    "url": "https://github.com/Shopify/shipit-engine",
     "description": "Pure test repo, look elsewhere please.",
     "watchers": 0,
     "stargazers": 0,
@@ -63,7 +64,7 @@
     "fork": false,
     "size": 0,
     "owner": {
-      "name": "byroot",
+      "name": "Shopify",
       "email": "jean.boussier@gmail.com"
     },
     "private": false,

--- a/test/fixtures/payloads/push_not_master.json
+++ b/test/fixtures/payloads/push_not_master.json
@@ -5,14 +5,14 @@
   "created": false,
   "deleted": false,
   "forced": false,
-  "compare": "https://github.com/byroot/junk/compare/16c259864de2...79d29e99cb83",
+  "compare": "https://github.com/Shopify/shipit-engine/compare/16c259864de2...79d29e99cb83",
   "commits": [
     {
       "id": "79d29e99cb83e0ba16c9e30c502a60995e711e5f",
       "distinct": true,
       "message": "modif",
       "timestamp": "2014-02-28T10:27:42-08:00",
-      "url": "https://github.com/byroot/junk/commit/79d29e99cb83e0ba16c9e30c502a60995e711e5f",
+      "url": "https://github.com/Shopify/shipit-engine/commit/79d29e99cb83e0ba16c9e30c502a60995e711e5f",
       "author": {
         "name": "Guillaume Malette",
         "email": "gmalette@gmail.com",
@@ -35,7 +35,7 @@
     "distinct": true,
     "message": "modif",
     "timestamp": "2014-02-28T10:27:42-08:00",
-    "url": "https://github.com/byroot/junk/commit/79d29e99cb83e0ba16c9e30c502a60995e711e5f",
+    "url": "https://github.com/Shopify/shipit-engine/commit/79d29e99cb83e0ba16c9e30c502a60995e711e5f",
     "author": {
       "name": "Guillaume Malette",
       "email": "gmalette@gmail.com",
@@ -54,8 +54,9 @@
   },
   "repository": {
     "id": 17266426,
-    "name": "junk",
-    "url": "https://github.com/byroot/junk",
+    "name": "shipit-engine",
+    "full_name": "Shopify/shipit-engine",
+    "url": "https://github.com/Shopify/shipit-engine",
     "description": "Pure test repo, look elsewhere please.",
     "watchers": 0,
     "stargazers": 0,
@@ -63,7 +64,7 @@
     "fork": false,
     "size": 0,
     "owner": {
-      "name": "byroot",
+      "name": "Shopify",
       "email": "jean.boussier@gmail.com"
     },
     "private": false,

--- a/test/helpers/payloads_helper.rb
+++ b/test/helpers/payloads_helper.rb
@@ -1,6 +1,5 @@
 module PayloadsHelper
   def payload(name)
-    file = Shipit::Engine.root.join('test/fixtures/payloads', "#{name}.json")
-    JSON.parse(file.read)
+    Shipit::Engine.root.join('test/fixtures/payloads', "#{name}.json").read
   end
 end

--- a/test/jobs/destroy_stack_job_test.rb
+++ b/test/jobs/destroy_stack_job_test.rb
@@ -8,7 +8,7 @@ module Shipit
     end
 
     test "perform destroys the received stack" do
-      Shipit.github_api.expects(:remove_hook).times(@stack.github_hooks.count)
+      Shipit.github.api.expects(:remove_hook).times(@stack.github_hooks.count)
 
       assert_difference -> { Stack.count }, -1 do
         @job.perform(@stack)

--- a/test/models/commits_test.rb
+++ b/test/models/commits_test.rb
@@ -16,9 +16,9 @@ module Shipit
     end
 
     test "#pull_request? detects pull requests with unusual branch names" do
-      @pr.message = "Merge pull request #7 from Shopify/bump-👉-v1.0.1\n\nBump 👉 v1.0.1"
+      @pr.message = "Merge pull request #7 from Shopify/bump--v1.0.1\n\nBump  v1.0.1"
       assert @pr.pull_request?
-      assert_equal "Bump 👉 v1.0.1", @pr.pull_request_title
+      assert_equal "Bump  v1.0.1", @pr.pull_request_title
     end
 
     test "#pull_request_number extract the pull request id from the message" do
@@ -162,7 +162,7 @@ module Shipit
         target_url: 'http://example.com',
         created_at: 1.day.ago,
       )
-      Shipit.github_api.expects(:statuses).with(@stack.github_repo_name, @commit.sha).returns([status])
+      Shipit.github.api.expects(:statuses).with(@stack.github_repo_name, @commit.sha).returns([status])
       assert_difference '@commit.statuses.count', 1 do
         @commit.refresh_statuses!
       end
@@ -186,7 +186,7 @@ module Shipit
 
     test "fetch_stats! pulls additions and deletions from github" do
       commit = stub(stats: stub(additions: 4242, deletions: 2424))
-      Shipit.github_api.expects(:commit).with(@stack.github_repo_name, @commit.sha).returns(commit)
+      Shipit.github.api.expects(:commit).with(@stack.github_repo_name, @commit.sha).returns(commit)
       @commit.fetch_stats!
       assert_equal 4242, @commit.additions
       assert_equal 2424, @commit.deletions
@@ -194,7 +194,7 @@ module Shipit
 
     test "fetch_stats! doesn't fail if the commits have no stats" do
       commit = stub(stats: nil)
-      Shipit.github_api.expects(:commit).with(@stack.github_repo_name, @commit.sha).returns(commit)
+      Shipit.github.api.expects(:commit).with(@stack.github_repo_name, @commit.sha).returns(commit)
       assert_nothing_raised do
         @commit.fetch_stats!
       end

--- a/test/models/github_hook_test.rb
+++ b/test/models/github_hook_test.rb
@@ -8,7 +8,7 @@ module Shipit
     end
 
     test "#destroy starts by removing the hook" do
-      Shipit.github_api.expects(:remove_hook).with(@hook.github_repo_name, @hook.github_id)
+      Shipit.github.api.expects(:remove_hook).with(@hook.github_repo_name, @hook.github_id)
       assert_difference -> { GithubHook.count }, -1 do
         @hook.destroy!
       end

--- a/test/models/github_hook_test.rb
+++ b/test/models/github_hook_test.rb
@@ -7,45 +7,6 @@ module Shipit
       @hook = shipit_github_hooks(:shipit_push)
     end
 
-    test "#verify_signature is true if the signature matches" do
-      assert @hook.verify_signature('sha1=9fb52fecc2b97b7a912aca27685149d2ce571900', 'hello shipit')
-    end
-
-    test "#verify_signature is false if the signature doesn't match" do
-      refute @hook.verify_signature('sha1=9fb52fecc2b97b7a912aca27685149d2ce571900', 'hello toto')
-    end
-
-    test "#setup! create the hook on Github side" do
-      @hook = shipit_github_hooks(:cyclimse_push)
-
-      response = mock(id: 44, rels: {self: mock(href: 'https://api.github.com/somestuff')})
-      Shipit.github_api.expects(:create_hook).with(
-        @hook.github_repo_name,
-        'web',
-        includes(:url, :content_type, :secret),
-        includes(:events, :active),
-      ).returns(response)
-      @hook.setup!
-      @hook.reload
-      assert_equal 44, @hook.github_id
-      assert_equal 'https://api.github.com/somestuff', @hook.api_url
-    end
-
-    test "#setup! update the hook it it already exist" do
-      response = mock(id: 44, rels: {self: mock(href: 'https://api.github.com/somestuff')})
-      Shipit.github_api.expects(:edit_hook).with(
-        @hook.github_repo_name,
-        @hook.github_id,
-        'web',
-        includes(:url, :content_type, :secret),
-        includes(:events, :active),
-      ).returns(response)
-      @hook.setup!
-      @hook.reload
-      assert_equal 44, @hook.github_id
-      assert_equal 'https://api.github.com/somestuff', @hook.api_url
-    end
-
     test "#destroy starts by removing the hook" do
       Shipit.github_api.expects(:remove_hook).with(@hook.github_repo_name, @hook.github_id)
       assert_difference -> { GithubHook.count }, -1 do

--- a/test/models/github_hook_test.rb
+++ b/test/models/github_hook_test.rb
@@ -8,7 +8,7 @@ module Shipit
     end
 
     test "#destroy starts by removing the hook" do
-      Shipit.github.api.expects(:remove_hook).with(@hook.github_repo_name, @hook.github_id)
+      Shipit.legacy_github_api.expects(:remove_hook).with(@hook.github_repo_name, @hook.github_id)
       assert_difference -> { GithubHook.count }, -1 do
         @hook.destroy!
       end

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -213,12 +213,6 @@ module Shipit
       @stack.update_deployed_revision(last_deploy.since_commit.sha)
     end
 
-    test "#create queues 2 GithubSetupWebhooksJob" do
-      assert_enqueued_with(job: SetupGithubHookJob) do
-        Stack.create!(repo_name: 'rails', repo_owner: 'rails')
-      end
-    end
-
     test "#create queues a GithubSyncJob" do
       assert_enqueued_with(job: GithubSyncJob) do
         Stack.create!(repo_name: 'rails', repo_owner: 'rails')

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -449,16 +449,16 @@ module Shipit
       repo_permalink = 'https://api.github.com/repositories/42'
 
       commits_redirection = stub(message: 'Moved Permanently', url: File.join(repo_permalink, '/commits'))
-      Shipit.github_api.expects(:commits).with(@stack.github_repo_name, sha: 'master').returns(commits_redirection)
+      Shipit.github.api.expects(:commits).with(@stack.github_repo_name, sha: 'master').returns(commits_redirection)
 
       repo_redirection = stub(message: 'Moved Permanently', url: repo_permalink)
-      Shipit.github_api.expects(:repo).with('shopify/shipit-engine').returns(repo_redirection)
+      Shipit.github.api.expects(:repo).with('shopify/shipit-engine').returns(repo_redirection)
 
       repo_resource = stub(name: 'shipster', owner: stub(login: 'george'))
-      Shipit.github_api.expects(:get).with(repo_permalink).returns(repo_resource)
+      Shipit.github.api.expects(:get).with(repo_permalink).returns(repo_resource)
 
       commits_resource = stub
-      Shipit.github_api.expects(:commits).with('george/shipster', sha: 'master').returns(commits_resource)
+      Shipit.github.api.expects(:commits).with('george/shipster', sha: 'master').returns(commits_resource)
 
       assert_equal 'shopify/shipit-engine', @stack.github_repo_name
       assert_equal commits_resource, @stack.github_commits

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -11,9 +11,9 @@ module Shipit
     end
 
     test ".find_or_create_by_handle fetch the team from github if it's not in the db already" do
-      Shipit.github_api.expects(:org_teams).with('shopify', per_page: 100)
+      Shipit.github.api.expects(:org_teams).with('shopify', per_page: 100)
       response = stub(rels: {}, data: [new_team])
-      Shipit.github_api.expects(:last_response).returns(response)
+      Shipit.github.api.expects(:last_response).returns(response)
       assert_difference -> { Team.count }, 1 do
         Team.find_or_create_by_handle('Shopify/new-team')
       end
@@ -21,7 +21,7 @@ module Shipit
 
     test "#refresh_members! fetch all the team members from github" do
       response = stub(rels: {members: members_resource})
-      Shipit.github_api.expects(:get).with(@team.api_url).returns(response)
+      Shipit.github.api.expects(:get).with(@team.api_url).returns(response)
       assert_difference -> { User.count }, 1 do
         @team.refresh_members!
       end

--- a/test/models/users_test.rb
+++ b/test/models/users_test.rb
@@ -69,7 +69,7 @@ module Shipit
     end
 
     test "#refresh_from_github! update the user with the latest data from GitHub's API" do
-      Shipit.github_api.expects(:user).with(@user.github_id).returns(@github_user)
+      Shipit.github.api.expects(:user).with(@user.github_id).returns(@github_user)
       @user.refresh_from_github!
       @user.reload
 
@@ -82,8 +82,8 @@ module Shipit
       user.update!(github_id: @github_user.id)
       commit = user.authored_commits.last
 
-      Shipit.github_api.expects(:user).with(user.github_id).raises(Octokit::NotFound)
-      Shipit.github_api.expects(:commit).with(commit.github_repo_name, commit.sha).returns(mock(author: @github_user))
+      Shipit.github.api.expects(:user).with(user.github_id).raises(Octokit::NotFound)
+      Shipit.github.api.expects(:commit).with(commit.github_repo_name, commit.sha).returns(mock(author: @github_user))
 
       assert_equal 'bob', user.login
 
@@ -99,12 +99,12 @@ module Shipit
       assert_equal @user.github_access_token, @user.github_api.access_token
     end
 
-    test "#github_api fallbacks to Shipit.github_api if the user doesn't have an access_token" do
-      assert_equal Shipit.github_api, shipit_users(:bob).github_api
+    test "#github_api fallbacks to Shipit.github.api if the user doesn't have an access_token" do
+      assert_equal Shipit.github.api, shipit_users(:bob).github_api
     end
 
-    test "#github_api fallbacks to Shipit.github_api for anonymous users" do
-      assert_equal Shipit.github_api, AnonymousUser.new.github_api
+    test "#github_api fallbacks to Shipit.github.api for anonymous users" do
+      assert_equal Shipit.github.api, AnonymousUser.new.github_api
     end
 
     test "users with legacy encrypted access token get their token reset automatically" do

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -43,7 +43,7 @@ class ActiveSupport::TestCase
   setup do
     @routes = Shipit::Engine.routes
     Process.stubs(:kill)
-    Shipit.github_api.stubs(:login).returns('shipit')
+    Shipit.github.api.stubs(:login).returns('shipit')
   end
 
   teardown do

--- a/test/unit/github_app_test.rb
+++ b/test/unit/github_app_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+module Shipit
+  class GitHubAppTest < ActiveSupport::TestCase
+    setup do
+      @github = app
+      @enterprise = app(domain: 'github.example.com')
+    end
+
+    test "#domain defaults to github.com" do
+      assert_equal 'github.com', @github.domain
+    end
+
+    test "#url returns the HTTPS url to the github installation" do
+      assert_equal 'https://github.example.com', @enterprise.url
+      assert_equal 'https://github.example.com/foo/bar', @enterprise.url('/foo/bar')
+      assert_equal 'https://github.example.com/foo/bar/baz', @enterprise.url('foo/bar', 'baz')
+    end
+
+    test "#oauth_config.last[:client_options] is nil if domain is not overriden" do
+      assert_nil @github.oauth_config.last[:client_options][:site]
+    end
+
+    test "#oauth_config.last[:client_options] returns Enterprise endpoint if domain is overriden" do
+      assert_equal 'https://github.example.com/api/v3/', @enterprise.oauth_config.last[:client_options][:site]
+    end
+
+    private
+
+    def app(extra_config = {})
+      GitHubApp.new(default_config.deep_merge(extra_config))
+    end
+
+    def default_config
+      Rails.application.secrets.github.deep_dup
+    end
+  end
+end

--- a/test/unit/github_app_test.rb
+++ b/test/unit/github_app_test.rb
@@ -7,6 +7,12 @@ module Shipit
       @enterprise = app(domain: 'github.example.com')
     end
 
+    test "#initialize doesn't raise if given an empty config" do
+      assert_nothing_raised do
+        GitHubApp.new({})
+      end
+    end
+
     test "#domain defaults to github.com" do
       assert_equal 'github.com', @github.domain
     end

--- a/test/unit/shipit_test.rb
+++ b/test/unit/shipit_test.rb
@@ -6,60 +6,13 @@ module Shipit
       Shipit.instance_variables.each(&Shipit.method(:remove_instance_variable))
     end
 
-    test ".github_domain defaults to github.com" do
-      assert_equal 'github.com', Shipit.github_domain
-    end
-
-    test ".github_domain can be overriden" do
-      Rails.application.secrets.stubs(:github_domain).returns('github.example.com')
-      assert_equal 'github.example.com', Shipit.github_domain
-    end
-
-    test ".github_enterprise? returns false if github_domain is not overriden" do
-      refute Shipit.github_enterprise?
-    end
-
-    test ".github_enterprise? returns true if github_domain is overriden" do
-      Rails.application.secrets.stubs(:github_domain).returns('github.example.com')
-      assert Shipit.github_enterprise?
-    end
-
-    test ".github_url returns the HTTPS url to the github installation" do
-      Rails.application.secrets.stubs(:github_domain).returns('github.example.com')
-      assert_equal 'https://github.example.com', Shipit.github_url
-      assert_equal 'https://github.example.com/foo/bar', Shipit.github_url('/foo/bar')
-      assert_equal 'https://github.example.com/foo/bar', Shipit.github_url('foo/bar')
-    end
-
-    test ".github_api_endpoint returns nil if github_domain is not overriden" do
-      assert_nil Shipit.github_api_endpoint
-    end
-
-    test ".github_api_endpoint returns Enterprise endpoint if github_domain is overriden" do
-      Rails.application.secrets.stubs(:github_domain).returns('github.example.com')
-      assert_equal 'https://github.example.com/api/v3/', Shipit.github_api_endpoint
-    end
-
-    test ".github_oauth_options returns an empty hash if not enterprise" do
-      refute Shipit.github_enterprise?
-      assert_equal({}, Shipit.github_oauth_options)
-    end
-
     test ".github_teams returns an empty array if there's no team" do
       assert_equal([], Shipit.github_teams)
     end
 
-    test ".github_teams returns the team key as an array" do
-      Rails.application.secrets.stubs(:github_oauth).returns('team' => 'shopify/developers')
+    test ".github_teams returns the teams key as an array of Team" do
+      Shipit.github.stubs(:oauth_teams).returns(['shopify/developers'])
       assert_equal(['shopify/developers'], Shipit.github_teams.map(&:handle))
-    end
-
-    test ".github_teams merges the teams and team keys in a single array" do
-      Rails.application.secrets.stubs(:github_oauth).returns(
-        'team' => 'shopify/developers',
-        'teams' => ['shopify/developers', 'cyclimse/cooks'],
-      )
-      assert_equal(['cyclimse/cooks', 'shopify/developers'], Shipit.github_teams.map(&:handle))
     end
   end
 end


### PR DESCRIPTION
Fix: https://github.com/Shopify/shipit-engine/issues/495

GitHub apps are the new recommended API, and offer adaptive rate limiting based on the number of users and repos.

This change will requires a relatively backward compatibility breaking migration. So before it's released we'll have to write some migration guide.

Issues:
  - [ ] `Shipit.user` is hard to replicate. Apps do have a "bot user", but I can't seem to find a good way to retrieve it. So far I've use the API to merge PRs and then grabbed the user id from there. Edit: seems like it was asked for before and nothing much happened: https://platform.github.community/t/obtaining-the-id-of-the-bot-user/2076
  - [ ] Ocotkit isn't really ready for bot users either, patch submitted upstream: https://github.com/octokit/octokit.rb/pull/1005
  - [ ] The setup docs have to be redone, as well as a migration guide.
