### PR TITLE
Don't allow k8s deployments to last more than 15 minutes

### DIFF
--- a/app/models/shipit/deploy_spec/kubernetes_discovery.rb
+++ b/app/models/shipit/deploy_spec/kubernetes_discovery.rb
@@ -28,7 +28,7 @@ module Shipit
       def discover_kubernetes
         return if kube_config.blank?
 
-        cmd = ["kubernetes-deploy"]
+        cmd = ["kubernetes-deploy", "--max-watch-seconds=#{60 * 15}"]
         if kube_config['template_dir']
           cmd << '--template-dir'
           cmd << kube_config['template_dir']
@@ -47,6 +47,7 @@ module Shipit
       def kubernetes_restart_cmd
         Shellwords.join([
           "kubernetes-restart",
+          "--max-watch-seconds=#{60 * 15}",
           kube_config.fetch('namespace'),
           kube_config.fetch('context'),
         ])

--- a/app/models/shipit/deploy_spec/kubernetes_discovery.rb
+++ b/app/models/shipit/deploy_spec/kubernetes_discovery.rb
@@ -27,7 +27,7 @@ module Shipit
 
       def timeout_duration
         duration = kube_config.fetch('timeout', '900s')
-        Duration.parse(duration).to_i if duration.present? && duration != 'false'
+        Duration.parse(duration).to_i if duration.present?
       end
 
       def discover_kubernetes

--- a/test/models/deploy_spec_test.rb
+++ b/test/models/deploy_spec_test.rb
@@ -123,7 +123,18 @@ module Shipit
           'context' => 'bar',
         },
       )
-      assert_equal ["kubernetes-deploy --max-watch-seconds=900 foo bar"], @spec.deploy_steps
+      assert_equal ["kubernetes-deploy --max-watch-seconds 900 foo bar"], @spec.deploy_steps
+    end
+
+    test "#deploy_steps `kubernetes` respects timeout false" do
+      @spec.stubs(:load_config).returns(
+        'kubernetes' => {
+          'namespace' => 'foo',
+          'context' => 'bar',
+          'timeout' => 'false',
+        },
+      )
+      assert_equal ["kubernetes-deploy foo bar"], @spec.deploy_steps
     end
 
     test "#deploy_steps returns kubernetes-deploy command if both capfile and `kubernetes` are present" do
@@ -135,7 +146,7 @@ module Shipit
           'context' => 'bar',
         },
       )
-      assert_equal ["kubernetes-deploy --max-watch-seconds=900 foo bar"], @spec.deploy_steps
+      assert_equal ["kubernetes-deploy --max-watch-seconds 900 foo bar"], @spec.deploy_steps
     end
 
     test "#deploy_steps returns kubernetes command if `kubernetes` is present and template_dir is set" do
@@ -146,7 +157,7 @@ module Shipit
           'template_dir' => 'k8s_templates/',
         },
       )
-      assert_equal ["kubernetes-deploy --max-watch-seconds=900 --template-dir k8s_templates/ foo bar"], @spec.deploy_steps
+      assert_equal ["kubernetes-deploy --max-watch-seconds 900 --template-dir k8s_templates/ foo bar"], @spec.deploy_steps
     end
 
     test "#deploy_steps prepend and append pre and post steps" do
@@ -188,7 +199,7 @@ module Shipit
           'context' => 'bar',
         },
       )
-      assert_equal ["kubernetes-deploy --max-watch-seconds=900 foo bar"], @spec.rollback_steps
+      assert_equal ["kubernetes-deploy --max-watch-seconds 900 foo bar"], @spec.rollback_steps
     end
 
     test "#rollback_steps returns kubernetes-deploy command when both capfile and `kubernetes` are present" do
@@ -200,7 +211,7 @@ module Shipit
           'context' => 'bar',
         },
       )
-      assert_equal ["kubernetes-deploy --max-watch-seconds=900 foo bar"], @spec.rollback_steps
+      assert_equal ["kubernetes-deploy --max-watch-seconds 900 foo bar"], @spec.rollback_steps
     end
 
     test '#machine_env returns an environment hash' do
@@ -344,13 +355,14 @@ module Shipit
         'kubernetes' => {
           'namespace' => 'foo',
           'context' => 'bar',
+          'timeout' => '20m',
         },
       )
       tasks = @spec.task_definitions
       assert_equal 2, tasks.size
 
       restart_task = tasks.find { |t| t.id == "restart" }
-      assert_equal ["kubernetes-restart --max-watch-seconds=900 foo bar"], restart_task.steps
+      assert_equal ["kubernetes-restart foo bar --max-watch-seconds 1200"], restart_task.steps
     end
 
     test "task definitions returns an array of VariableDefinition instances" do

--- a/test/models/deploy_spec_test.rb
+++ b/test/models/deploy_spec_test.rb
@@ -131,7 +131,7 @@ module Shipit
         'kubernetes' => {
           'namespace' => 'foo',
           'context' => 'bar',
-          'timeout' => 'false',
+          'timeout' => false,
         },
       )
       assert_equal ["kubernetes-deploy foo bar"], @spec.deploy_steps

--- a/test/models/deploy_spec_test.rb
+++ b/test/models/deploy_spec_test.rb
@@ -123,7 +123,7 @@ module Shipit
           'context' => 'bar',
         },
       )
-      assert_equal ["kubernetes-deploy foo bar"], @spec.deploy_steps
+      assert_equal ["kubernetes-deploy --max-watch-seconds=900 foo bar"], @spec.deploy_steps
     end
 
     test "#deploy_steps returns kubernetes-deploy command if both capfile and `kubernetes` are present" do
@@ -135,7 +135,7 @@ module Shipit
           'context' => 'bar',
         },
       )
-      assert_equal ["kubernetes-deploy foo bar"], @spec.deploy_steps
+      assert_equal ["kubernetes-deploy --max-watch-seconds=900 foo bar"], @spec.deploy_steps
     end
 
     test "#deploy_steps returns kubernetes command if `kubernetes` is present and template_dir is set" do
@@ -146,7 +146,7 @@ module Shipit
           'template_dir' => 'k8s_templates/',
         },
       )
-      assert_equal ["kubernetes-deploy --template-dir k8s_templates/ foo bar"], @spec.deploy_steps
+      assert_equal ["kubernetes-deploy --max-watch-seconds=900 --template-dir k8s_templates/ foo bar"], @spec.deploy_steps
     end
 
     test "#deploy_steps prepend and append pre and post steps" do
@@ -188,7 +188,7 @@ module Shipit
           'context' => 'bar',
         },
       )
-      assert_equal ["kubernetes-deploy foo bar"], @spec.rollback_steps
+      assert_equal ["kubernetes-deploy --max-watch-seconds=900 foo bar"], @spec.rollback_steps
     end
 
     test "#rollback_steps returns kubernetes-deploy command when both capfile and `kubernetes` are present" do
@@ -200,7 +200,7 @@ module Shipit
           'context' => 'bar',
         },
       )
-      assert_equal ["kubernetes-deploy foo bar"], @spec.rollback_steps
+      assert_equal ["kubernetes-deploy --max-watch-seconds=900 foo bar"], @spec.rollback_steps
     end
 
     test '#machine_env returns an environment hash' do
@@ -350,7 +350,7 @@ module Shipit
       assert_equal 2, tasks.size
 
       restart_task = tasks.find { |t| t.id == "restart" }
-      assert_equal ["kubernetes-restart foo bar"], restart_task.steps
+      assert_equal ["kubernetes-restart --max-watch-seconds=900 foo bar"], restart_task.steps
     end
 
     test "task definitions returns an array of VariableDefinition instances" do


### PR DESCRIPTION
In some circumstances kubernetes deploys can flap in a way that will cause kubernetes-deploy to believe they are making progress even though they will never succeeded. This defaults a hard time out of 15 minutes since that should be more than enough time for most use cases. 