### PR TITLE
[octokit_configure] Configure Octokit for enterprise URLs

### DIFF
--- a/lib/shipit/github_app.rb
+++ b/lib/shipit/github_app.rb
@@ -15,6 +15,9 @@ module Shipit
       @oauth_id = oauth[:id]
       @oauth_secret = oauth[:secret]
       @oauth_teams = Array.wrap(oauth[:teams] || oauth[:teams])
+      Octokit.configure do |c|
+        c.api_endpoint = url("/api/v3/")
+      end if enterprise?
     end
 
     def login


### PR DESCRIPTION
Hi again! Sorry for all the trouble. I've launched sidekiq, but the tasks keep failing. It looks like Octokit isn't configured to point at the github enterprise domain. The error I see is:
> sidekiq_1     | 2018-05-22T14:49:48.373Z 1 TID-ow02t85a1 WARN: Octokit::Unauthorized: POST https://api.github.com/installations/1/access_tokens: 401 - A JSON web token could not be decoded // See: https://developer.github.com/v3

After some more investigation, it looks like to use Octokit with GH Enterprise, you must set the configuration like in this pr (I was able to pull commits in the sidekiq job after doing this). I'm not, at the moment, familiar enough with Shipit to know the ramifications of this, or if I should just blanket add it to each file that has an invocation of `Octokit::Client` or if there's a better/more global way to set this (sorry I'm way out of the rails game too). If you can give me some guidance, I'll do my best to do it, or I'm happy to let you take it over. Want to be helpful, not a burden. Thanks for your help!