### PR TITLE
Fix GitHubApp for Enterprise installations

### DIFF
--- a/app/models/shipit/user.rb
+++ b/app/models/shipit/user.rb
@@ -46,11 +46,7 @@ module Shipit
     def github_api
       return Shipit.github.api unless github_access_token
 
-      @github_api ||= begin
-        client = Octokit::Client.new(access_token: github_access_token)
-        client.middleware = Shipit.new_faraday_stack
-        client
-      end
+      @github_api ||= Shipit.github.new_client(access_token: github_access_token)
     end
 
     def identifiers_for_ping

--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -79,7 +79,7 @@ module Shipit
 
   def legacy_github_api
     if secrets&.github_api.present?
-      @legacy_github_api ||= Octokit::Client.new(access_token: secrets.github_api['access_token'])
+      @legacy_github_api ||= github.new_client(access_token: secrets.github_api['access_token'])
     end
   end
 


### PR DESCRIPTION
Fix: https://github.com/Shopify/shipit-engine/pull/793

@tebriel I believe this should fix your issue. Unfortunately I don't have any GHE install to test it myself :/

To test this branch you can modify your `Gemfile` as is: 

```ruby 
gem 'shipit-engine', github: 'Shopify/shipit-engine', branch: 'gh-enterprise'
```

and then run `bundle update shipit-engine`.

Please let me know if it works for you.