### PR TITLE
Add `title` property to tasks to control the task will be displayed in the timeline

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -171,3 +171,6 @@ Style/PercentLiteralDelimiters:
 
 Style/FrozenStringLiteralComment:
   Enabled: false
+
+Style/FormatStringToken:
+  Enabled: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Add `title` property to tasks to control the task will be displayed in the timeline.
 * Allow to configure the merge method used by the merge queue.
 * Fix compatibility with GitHub Enterprise installations.
 

--- a/README.md
+++ b/README.md
@@ -503,6 +503,19 @@ tasks:
         default: 0
 ```
 
+You can also make these variables appear in the task title:
+
+```yml
+tasks:
+  failover:
+    action: "Failover a pod"
+    title: "Failover Pod %{POD_ID}"
+    steps:
+      - script/failover $POD_ID
+    variables:
+      - name: POD_ID
+```
+
 <h3 id="review-process">Review process</h3>
 
 You can display review elements, such as monitoring data or a pre-deployment checklist, on the deployment page in Shipit:

--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -79,6 +79,10 @@ module Shipit
       rollback
     end
 
+    def title
+      I18n.t("#{self.class.name.demodulize.underscore.pluralize}.description", sha: until_commit.short_sha)
+    end
+
     def rollback?
       false
     end

--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -212,6 +212,10 @@ module Shipit
       false
     end
 
+    def title
+      definition.render_title(env)
+    end
+
     def author
       user || AnonymousUser.new
     end

--- a/app/models/shipit/task_definition.rb
+++ b/app/models/shipit/task_definition.rb
@@ -26,6 +26,15 @@ module Shipit
       @variables = task_variables(config['variables'] || [])
       @checklist = config['checklist'] || []
       @allow_concurrency = config['allow_concurrency'] || false
+      @title = config['title']
+    end
+
+    def render_title(env)
+      if @title
+        @title % env.symbolize_keys
+      else
+        action
+      end
     end
 
     def allow_concurrency?
@@ -36,6 +45,7 @@ module Shipit
       {
         id: id,
         action: action,
+        title: @title,
         description: description,
         steps: steps,
         variables: variables.map(&:to_h),

--- a/app/serializers/shipit/task_serializer.rb
+++ b/app/serializers/shipit/task_serializer.rb
@@ -13,6 +13,7 @@ module Shipit
       type
       status
       action
+      title
       description
       started_at
       ended_at

--- a/app/views/shipit/tasks/_task.html.erb
+++ b/app/views/shipit/tasks/_task.html.erb
@@ -13,7 +13,7 @@
     <div class="commit-details">
       <span class="commit-title">
         <a href="<%= stack_task_path(@stack, task) %>">
-          <%= task.definition.action %>
+          <%= task.title %>
         </a>
       </span>
       <p class="commit-meta">

--- a/app/views/shipit/tasks/_task_output.html.erb
+++ b/app/views/shipit/tasks/_task_output.html.erb
@@ -8,7 +8,7 @@
   <div class="sidebar-plugins"></div>
 </div>
 
-<div class="deploy-main" data-task="<%= {repo: @stack.github_repo_name, description: task_description(task)}.to_json %>">
+<div class="deploy-main" data-task="<%= {repo: @stack.github_repo_name, description: task.title}.to_json %>">
   <span class="deploy-tasks"></span>
   <div class="deploy-banner" data-status="<%= task.status %>">
     <div class="deploy-banner-status"></div>

--- a/test/fixtures/shipit/tasks.yml
+++ b/test/fixtures/shipit/tasks.yml
@@ -134,3 +134,30 @@ soc_deploy:
   created_at: <%= (60 - 1).minutes.ago.to_s(:db) %>
   started_at: <%= (60 - 1).minutes.ago.to_s(:db) %>
   ended_at: <%= (60 - 3).minutes.ago.to_s(:db) %>
+
+shipit_rendered_failover:
+  id: 10
+  user: walrus
+  since_commit_id: 2 # second
+  until_commit_id: 2 # second
+  type: Shipit::Task
+  stack: shipit
+  status: success
+  definition: >
+    {
+      "id": "failover",
+      "action": "Failover a pod",
+      "title": "Failover pod %{POD_ID}",
+      "description": "Restart app and job servers",
+      "variables": [
+        {"name": "POD_ID", "title": "Id of the pod to failover"}
+      ],
+      "steps": [
+        "cap $ENVIRONMENT pod:failover"
+      ]
+    }
+  env:
+    POD_ID: "12"
+  created_at: <%= (60 - 3).minutes.ago.to_s(:db) %>
+  started_at: <%= (60 - 3).minutes.ago.to_s(:db) %>
+  ended_at: <%= (60 - 4).minutes.ago.to_s(:db) %>

--- a/test/models/task_definitions_test.rb
+++ b/test/models/task_definitions_test.rb
@@ -6,6 +6,7 @@ module Shipit
       @definition = TaskDefinition.new(
         'restart',
         'action' => 'Restart application',
+        'title' => 'Restart application %{FOO}',
         'description' => 'Restart app and job servers',
         'steps' => ['touch tmp/restart'],
         'allow_concurrency' => true,
@@ -36,6 +37,7 @@ module Shipit
       as_json = {
         id: 'restart',
         action: 'Restart application',
+        title: "Restart application %{FOO}",
         description: 'Restart app and job servers',
         steps: ['touch tmp/restart'],
         checklist: [],

--- a/test/models/tasks_test.rb
+++ b/test/models/tasks_test.rb
@@ -1,0 +1,16 @@
+require 'test_helper'
+
+module Shipit
+  class TasksTest < ActiveSupport::TestCase
+    test "#title interpolates env" do
+      task = shipit_tasks(:shipit_rendered_failover)
+      assert_equal({'POD_ID' => '12'}, task.env)
+      assert_equal 'Failover pod 12', task.title
+    end
+
+    test "#title returns the task action if title is not defined" do
+      task = shipit_tasks(:shipit_restart)
+      assert_equal 'Restart application', task.title
+    end
+  end
+end


### PR DESCRIPTION
Fix: https://github.com/Shopify/shipit-engine/issues/791

I went with the "template" solution, but that doesn't exclude showing all the env in another way in the future if we feel we need that as well.

