### PR TITLE
Set the true origin remote on working directory clones

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Set the proper origin remote on working directory repositories.
+
 # 0.23.0
 
 * Always fetch from the remote before a task to ensure any newly pushed tag is present.

--- a/app/jobs/shipit/perform_task_job.rb
+++ b/app/jobs/shipit/perform_task_job.rb
@@ -65,7 +65,7 @@ module Shipit
       @task.acquire_git_cache_lock do
         capture! @commands.fetch
       end
-      capture! @commands.clone
+      capture_all! @commands.clone
       capture! @commands.checkout(@task.until_commit)
     end
 

--- a/lib/shipit/stack_commands.rb
+++ b/lib/shipit/stack_commands.rb
@@ -42,7 +42,7 @@ module Shipit
       end
 
       Dir.mktmpdir do |dir|
-        git('clone', @stack.git_path, @stack.repo_name, chdir: dir).run!
+        git('clone', @stack.git_path, @stack.repo_name, '--origin', 'cache', chdir: dir).run!
         git_dir = File.join(dir, @stack.repo_name)
         git('checkout', commit.sha, chdir: git_dir).run! if commit
         yield Pathname.new(git_dir)

--- a/lib/shipit/task_commands.rb
+++ b/lib/shipit/task_commands.rb
@@ -47,7 +47,18 @@ module Shipit
     end
 
     def clone
-      git('clone', '--local', @stack.git_path, @task.working_directory, chdir: @stack.deploys_path)
+      [
+        git(
+          'clone',
+          '--local',
+          '--origin',
+          'cache',
+          @stack.git_path,
+          @task.working_directory,
+          chdir: @stack.deploys_path,
+        ),
+        git('remote', 'add', 'origin', @stack.repo_git_url, chdir: @task.working_directory),
+      ]
     end
 
     def stack_commands

--- a/test/jobs/perform_task_job_test.rb
+++ b/test/jobs/perform_task_job_test.rb
@@ -15,7 +15,7 @@ module Shipit
       Commands.expects(:for).with(@deploy).returns(@commands)
 
       @commands.expects(:fetch).once
-      @commands.expects(:clone).once
+      @commands.expects(:clone).returns([]).once
       @commands.expects(:checkout).with(@deploy.until_commit).once
       @commands.expects(:install_dependencies).returns([]).once
       @commands.expects(:perform).returns([]).once

--- a/test/unit/deploy_commands_test.rb
+++ b/test/unit/deploy_commands_test.rb
@@ -59,13 +59,16 @@ module Shipit
     end
 
     test "#clone clones the repository cache into the working directory" do
-      command = @commands.clone
-      assert_equal ['git', 'clone', '--local', @stack.git_path, @deploy.working_directory], command.args
+      commands = @commands.clone
+      assert_equal 2, commands.size
+      clone_args = ['git', 'clone', '--local', '--origin', 'cache', @stack.git_path, @deploy.working_directory]
+      assert_equal clone_args, commands.first.args
+      assert_equal ['git', 'remote', 'add', 'origin', @stack.repo_git_url], commands.second.args
     end
 
     test "#clone clones the repository cache from the deploys_path" do
-      command = @commands.clone
-      assert_equal @stack.deploys_path, command.chdir
+      commands = @commands.clone
+      assert_equal @stack.deploys_path, commands.first.chdir
     end
 
     test "#checkout checks out the deployed commit" do


### PR DESCRIPTION
Fix: https://github.com/Shopify/shipit-engine/issues/521

As described in #521, we never wanted people to be able to push back to the repository, and were using a read only access. 

However it's getting clear that it is actually needed if we want to make gem and other packages releasing better. Most release tool tend to tag stuff & push these tags to the repo.

The push access should managed using GitHub permissions anyway, so it's up to each install to allow or disallow it either globally or on a per repo basis. And if Shipit doesn't have the permission to push, at least now the error message will be easier to understand.