### PR TITLE
Make the default gem release method CD compatible, and assume it can push tags to the origin repo

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* The default gem release method is now compatible with continuous delivery.
+* The default gem release method now assume Shipit can push tags back to the origin repository.
 * Set the proper origin remote on working directory repositories.
 
 # 0.23.0

--- a/app/models/shipit/deploy_spec/rubygems_discovery.rb
+++ b/app/models/shipit/deploy_spec/rubygems_discovery.rb
@@ -9,17 +9,6 @@ module Shipit
         publish_gem if gem?
       end
 
-      def discover_review_checklist
-        discover_gem_checklist || super
-      end
-
-      def discover_gem_checklist
-        if gem?
-          [%(<strong>Don't forget to add a tag before deploying!</strong> You can do this with:
-            git tag v<strong>x.y.z</strong> && git push --tags)]
-        end
-      end
-
       def gem?
         !!gemspec
       end
@@ -29,7 +18,7 @@ module Shipit
       end
 
       def publish_gem
-        ["assert-gem-version-tag #{gemspec}", 'bundle exec rake release']
+        ["release-gem #{gemspec}"]
       end
     end
   end

--- a/lib/snippets/release-gem
+++ b/lib/snippets/release-gem
@@ -1,0 +1,24 @@
+#!/usr/bin/env ruby
+
+require 'net/https'
+require 'uri'
+
+module RubygemsAPI
+  extend self
+
+  def published?(name, version)
+    uri = URI.parse("https://rubygems.org/api/v2/rubygems/#{name}/versions/#{version}.json")
+    Net::HTTP.get_response(uri).is_a?(Net::HTTPSuccess)
+  end
+end
+
+spec_path, *release_command = ARGV
+release_command = %w(bundle exec rake release) if release_command.empty?
+
+spec = Gem::Specification.load(spec_path)
+if RubygemsAPI.published?(spec.name, spec.version)
+  puts "#{spec.name} version #{spec.version} is already published."
+  exit 0
+else
+  exec(*release_command)
+end

--- a/test/models/deploy_spec_test.rb
+++ b/test/models/deploy_spec_test.rb
@@ -261,7 +261,7 @@ module Shipit
     test '#publish_gem first check if version tag have been created, and then invoke bundler release task' do
       @spec.stubs(:gemspec).returns('/tmp/shipit.gemspec')
       refute @spec.capistrano?
-      assert_equal ['assert-gem-version-tag /tmp/shipit.gemspec', 'bundle exec rake release'], @spec.deploy_steps
+      assert_equal ['release-gem /tmp/shipit.gemspec'], @spec.deploy_steps
     end
 
     test '#setup_dot_py gives the path of the repo setup.py if present' do


### PR DESCRIPTION
Fix: https://github.com/Shopify/shipit-engine/issues/454
Closes: https://github.com/Shopify/shipit-engine/issues/202

This new snippet:

  - Extract the gem name and version from the `*.gemspec`
  - Check if that version was already published on rubygems
  - If it was simply exit 0 with a message
  - If it wasn't then `exec` to the supplied release command (or `bundle exec rake release` if none was supplied).

This means rubygems stack will now be able to turn on continuous delivery. Whenever they bump the version string in their gemspec, a new version will be released automatically.

I leave the old snippets in place in case some people were explicitly using them.