### PR TITLE
Use HTTPS protocol for git operations

### DIFF
--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -292,7 +292,7 @@ module Shipit
     end
 
     def repo_git_url
-      "git@#{Shipit.github.domain}:#{repo_owner}/#{repo_name}.git"
+      "https://#{Shipit.github.domain}/#{repo_owner}/#{repo_name}.git"
     end
 
     def base_path

--- a/config/secrets.development.example.yml
+++ b/config/secrets.development.example.yml
@@ -1,19 +1,14 @@
 host: 'http://localhost:3000'
 redis_url: 'redis://127.0.0.1:6379/0'
 
-github_api:
-  # Can be obtained there: https://github.com/settings/tokens/new
-  # The required permissions are: `admin:org_hook`, `admin:repo_hook`, `read:org` and `repo`
-  access_token:
-
-# Can be obtained there: https://github.com/settings/applications/new
+# Can be obtained there: https://github.com/settings/apps
 # Set the "Authorization callback URL" as `<host>/github/auth/github/callback`
-github_oauth: 
-  id:
-  secret:
-  # teams: # Optional
-
-# To work on the kubernetes deploy script
-# env:
-#   KUBECONFIG: # Path of the kubeconfig you want to use.
-#   GOOGLE_APPLICATION_CREDENTIALS: # Used if your kube auth provider is gcp, in which case it should be path of the service account credentials you want to use. Alternatively, you can run `gcloud auth application-default login` (and remove this variable) to use your own google account locally.
+github:
+  app_id:
+  installation_id:
+  webhook_secret: # nil
+  private_key:
+  oauth:
+    id:
+    secret:
+    teams: # Optional

--- a/config/secrets.development.shopify.yml
+++ b/config/secrets.development.shopify.yml
@@ -11,4 +11,3 @@ github:
     id:
     secret:
     teams:
-  access_token:

--- a/lib/shipit/commands.rb
+++ b/lib/shipit/commands.rb
@@ -15,10 +15,15 @@ module Shipit
         Gem::Version.new($1)
       end
     end
+
     delegate :git_version, to: :class
 
     def env
-      @env ||= Shipit.env
+      @env ||= Shipit.env.merge(
+        'GITHUB_DOMAIN' => Shipit.github.domain,
+        'GITHUB_TOKEN' => Shipit.github.token,
+        'GIT_ASKPASS' => Shipit::Engine.root.join('lib', 'snippets', 'git-askpass').realpath.to_s,
+      )
     end
 
     def git(*args)

--- a/lib/snippets/git-askpass
+++ b/lib/snippets/git-askpass
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+GITHUB_USER="${GITHUB_USER:-git}"
+GITHUB_DOMAIN="${GITHUB_DOMAIN:-github.com}"
+
+if [[ "${1}" == "Username for 'https://${GITHUB_DOMAIN}': " ]]; then
+  echo "${GITHUB_USER}"
+  exit 0
+fi
+
+if [[ "${1}" == "Password for 'https://${GITHUB_USER}@${GITHUB_DOMAIN}': " ]]; then
+  echo "${GITHUB_TOKEN}"
+  exit 0
+fi
+
+exit 1

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -80,7 +80,7 @@ module Shipit
     end
 
     test "repo_git_url" do
-      assert_equal "git@github.com:#{@stack.repo_owner}/#{@stack.repo_name}.git", @stack.repo_git_url
+      assert_equal "https://github.com/#{@stack.repo_owner}/#{@stack.repo_name}.git", @stack.repo_git_url
     end
 
     test "base_path" do


### PR DESCRIPTION
Fix: https://github.com/Shopify/shipit-engine/issues/360
Closes: https://github.com/Shopify/shipit-engine/issues/366

  - Public repos will be cloned without credentials
  - Private ones will be cloned and fetched using the GitHub App short-lived token
  - It means you can push tags back etc (ref: https://github.com/Shopify/shipit-engine/pull/801)
  - This makes the Shipit setup much simpler in most cases. You won't have to provide proper SSH access to github with a bot user etc.
 