### PR TITLE
Perform tasks on a temporary branch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Checkout a temporary branch before performing tasks.
 * Use HTTPS protocol for git operations.
 * The default gem release method is now compatible with continuous delivery.
 * The default gem release method now assume Shipit can push tags back to the origin repository.

--- a/app/jobs/shipit/perform_task_job.rb
+++ b/app/jobs/shipit/perform_task_job.rb
@@ -66,7 +66,7 @@ module Shipit
         capture! @commands.fetch
       end
       capture_all! @commands.clone
-      capture! @commands.checkout(@task.until_commit)
+      capture! @commands.checkout(@task.until_commit, "shipit-#{@task.id}")
     end
 
     def capture_all!(commands)

--- a/lib/shipit/task_commands.rb
+++ b/lib/shipit/task_commands.rb
@@ -42,8 +42,12 @@ module Shipit
       ).merge(deploy_spec.machine_env).merge(@task.env)
     end
 
-    def checkout(commit)
-      git('checkout', commit.sha, chdir: @task.working_directory)
+    def checkout(commit, temporary_branch = nil)
+      if temporary_branch
+        git('checkout', '-b', temporary_branch, commit.sha, chdir: @task.working_directory)
+      else
+        git('checkout', commit.sha, chdir: @task.working_directory)
+      end
     end
 
     def clone

--- a/test/jobs/perform_task_job_test.rb
+++ b/test/jobs/perform_task_job_test.rb
@@ -16,7 +16,7 @@ module Shipit
 
       @commands.expects(:fetch).once
       @commands.expects(:clone).returns([]).once
-      @commands.expects(:checkout).with(@deploy.until_commit).once
+      @commands.expects(:checkout).with(@deploy.until_commit, "shipit-#{@deploy.id}").once
       @commands.expects(:install_dependencies).returns([]).once
       @commands.expects(:perform).returns([]).once
 


### PR DESCRIPTION
https://github.com/Shopify/shipit-engine/pull/801 actually doesn't work because `rake release` do: `git push && git push --tags` and the former doesn't work on a detached state.

So here we checkout a temporary branch before executing the deploy commands. 

One downside is that it will push empty branch to the repo, I'll try to find a proper way to clean them up  in followup. 