### PR TITLE
Allow DeploySpec#task_discovery to be extensible

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,4 @@ test/dummy/data/*
 test/dummy/.sass-cache
 
 .byebug_history
+*.sw*

--- a/app/models/shipit/deploy_spec/kubernetes_discovery.rb
+++ b/app/models/shipit/deploy_spec/kubernetes_discovery.rb
@@ -17,7 +17,7 @@ module Shipit
               'description' => "Simulates a rollout of Kubernetes deployments by using kubernetes-restart utility",
               'steps' => [kubernetes_restart_cmd],
             },
-          }
+          }.merge!(super)
         else
           super
         end


### PR DESCRIPTION
This change allows developers append to task lists without losing the tasks
defined by `KubernetesDiscovery`. The test case demonstrates how this can
be done, setting a new pattern for developers to follow.