### PR TITLE
Stop storing hook deliveries in the database

### DIFF
--- a/app/jobs/shipit/deliver_hook_job.rb
+++ b/app/jobs/shipit/deliver_hook_job.rb
@@ -3,6 +3,7 @@ module Shipit
     queue_as :hooks
 
     def perform(delivery)
+      delivery = Hook::DeliverySpec.new(delivery) if delivery.is_a?(Hash)
       delivery.send!
     end
   end

--- a/app/models/shipit/commit.rb
+++ b/app/models/shipit/commit.rb
@@ -246,7 +246,9 @@ module Shipit
 
       unless already_deployed
         payload = {commit: self, stack: stack, status: new_status.state}
-        Hook.emit(:commit_status, stack, payload.merge(commit_status: new_status)) if previous_status != new_status
+        if previous_status != new_status
+          Hook.emit(:commit_status, stack, payload.merge(commit_status: new_status))
+        end
       end
 
       if previous_status.simple_state != new_status.simple_state

--- a/test/jobs/emit_event_job_test.rb
+++ b/test/jobs/emit_event_job_test.rb
@@ -8,7 +8,7 @@ module Shipit
     end
 
     test "#perform schedule deliveries" do
-      assert_difference -> { Delivery.scheduled.count }, 2 do
+      assert_enqueued_jobs(2, only: DeliverHookJob) do
         @job.perform(event: :deploy, stack_id: @stack.id, payload: {foo: 42}.to_json)
       end
     end


### PR DESCRIPTION
Based on production usage, it's clear that this method of dealing with webhooks is terribly inefficient.

Our production MySQL spend 80% of it's time on the `deliveries` table, even though we only have 3 registered webhooks.

<img width="1189" alt="capture d ecran 2018-08-02 a 17 24 44" src="https://user-images.githubusercontent.com/19192189/43612024-fcd4dbea-9678-11e8-8e1a-f60428620cd8.png">

There is probably a way to fix the contention and perf issue with MySQL, but ultimately besides some debugging capability once every blue moon, the `deliveries` table really isn't that useful.

This PR simply stop using it, and put all the hook attributes in the job argument, and rely on the job queue implementation for persistence.

Note that the old code is not removed yet for smoother rollout (in flight jobs), and will be removed in a future version.

