### PR TITLE
Fix GitHub client reauth

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Improve GitHub API client management. Won't re-auth constantly if cache is disabled, and will keep the connection pool on re-auth.
+
 # 0.25.0
 
 * Stop storing outgoing webhooks in the database for efficiency reasons.


### PR DESCRIPTION
Fix: https://github.com/Shopify/shipit-engine/issues/816

In environment with disabled cache, the client would constantly be re-authenticated and re-instantiated, causing `Octokit::Client#last_response` to always be `nil`, which breaks `OctokitIterator`.

The PR adds a layer of in memory cache that will always works, but still fallback to Rails cache so that in multi-process environment the number of authentications is limited.