### PR TITLE
Prefer stacks with merge queue enabled in MergeStatusController

### DIFF
--- a/app/controllers/shipit/merge_status_controller.rb
+++ b/app/controllers/shipit/merge_status_controller.rb
@@ -60,7 +60,7 @@ module Shipit
       @stack ||= if params[:stack_id]
         Stack.from_param!(params[:stack_id])
       else
-        scope = Stack.order(id: :asc).where(
+        scope = Stack.order(merge_queue_enabled: :desc, id: :asc).where(
           repo_owner: referrer_parser.repo_owner,
           repo_name: referrer_parser.repo_name,
         )

--- a/test/controllers/merge_status_controller_test.rb
+++ b/test/controllers/merge_status_controller_test.rb
@@ -33,5 +33,20 @@ module Shipit
       assert_response :ok
       assert_predicate response.body, :blank?
     end
+
+    test "GET show prefers stacks with merge_queue_enabled" do
+      existing = shipit_stacks(:shipit)
+      Shipit::Stack.create(
+        repo_owner: existing.repo_owner,
+        repo_name: existing.repo_name,
+        environment: 'foo',
+        branch: existing.branch,
+        merge_queue_enabled: true,
+      )
+      existing.update!(merge_queue_enabled: false)
+      get :show, params: {referrer: 'https://github.com/Shopify/shipit-engine/pull/42', branch: 'master'}
+      assert_response :ok
+      assert_includes response.body, 'shipit-engine/foo'
+    end
   end
 end


### PR DESCRIPTION
These stacks will see more utility from HCTW, but in the case where multiple stacks point to the same repo + branch, they may not be displayed by the plugin.