### PR TITLE
Show 0 changes if there are no additions or deletions

### DIFF
--- a/app/views/shipit/commits/_commit.html.erb
+++ b/app/views/shipit/commits/_commit.html.erb
@@ -9,7 +9,7 @@
       <span class="commit-title"><%= render_commit_message_with_link commit %></span>
       <p class="commit-meta">
         <span class="sha"><%= render_commit_id_link(commit) %></span>
-        <% if commit.additions? && commit.deletions? %>
+        <% if commit.additions.present? && commit.deletions.present? %>
           <span class="code-additions">+<%= commit.additions %></span>
           <span class="code-deletions">-<%= commit.deletions %></span>
         <% end %>


### PR DESCRIPTION
In the UI, if a commit contains only additions or only deletions, no diff stats are shown.

E.g the second commit here:

<img width="421" alt="screen shot 2018-10-16 at 4 01 06 pm" src="https://user-images.githubusercontent.com/2499863/47045474-e42cb180-d160-11e8-9f9b-ec2f7c67f4dc.png">

This PR fixes this visual (imo) bug.

**Why change in the UI instead of changing `commit.additions` to return `0` by default?**
I am unsure of the semantic meaning behind `nil` additions/deletions in the domain model, so I find this the easiest way to fix things. If it's acceptable to default additions/deletions to `0`, then I'm happy to update the PR.
