### PR TITLE
Make CheckRuns mark CI as enabled for a stack like Statuses do already

### DIFF
--- a/app/models/shipit/check_run.rb
+++ b/app/models/shipit/check_run.rb
@@ -11,6 +11,8 @@ module Shipit
 
     validates :conclusion, inclusion: {in: CONCLUSIONS, allow_nil: true}
 
+    after_create :enable_ci_on_stack
+
     class << self
       def create_or_update_by!(selector:, attributes: {})
         create!(selector.merge(attributes))
@@ -66,6 +68,12 @@ module Shipit
 
     def to_partial_path
       'shipit/statuses/status'
+    end
+
+    private
+
+    def enable_ci_on_stack
+      commit.stack.enable_ci!
     end
   end
 end

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -426,7 +426,7 @@ module Shipit
 
     def ci_enabled?
       Rails.cache.fetch(ci_enabled_cache_key) do
-        commits.joins(:statuses).any?
+        commits.joins(:statuses).any? || commits.joins(:check_runs).any?
       end
     end
 

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -611,5 +611,26 @@ module Shipit
       @stack.deploy_url = "ssh://abc"
       assert_predicate @stack, :valid?
     end
+
+    test "#ci_enabled? is true if there are any commits with a status" do
+      Shipit::CheckRun.where(stack_id: @stack.id).destroy_all
+      assert Shipit::Status.where(stack_id: @stack.id).count > 0
+      Rails.cache.delete(@stack.send(:ci_enabled_cache_key))
+      assert @stack.ci_enabled?
+    end
+
+    test "#ci_enabled? is true if there are any check runs" do
+      Shipit::Status.where(stack_id: @stack.id).destroy_all
+      assert Shipit::CheckRun.where(stack_id: @stack.id).count > 0
+      Rails.cache.delete(@stack.send(:ci_enabled_cache_key))
+      assert @stack.ci_enabled?
+    end
+
+    test "#ci_enabled? is false if there are no check_runs or statuses" do
+      Shipit::Status.where(stack_id: @stack.id).destroy_all
+      Shipit::CheckRun.where(stack_id: @stack.id).destroy_all
+      Rails.cache.delete(@stack.send(:ci_enabled_cache_key))
+      refute @stack.ci_enabled?
+    end
   end
 end


### PR DESCRIPTION
Right now, if you have only Github Checks on a stack, you get the "Heads Up your stack is not configured for CI banner", even if there are checks being sucked in and displayed with commits. Checks should mark CI as enabled just the same methinks.