### PR TITLE
Rely on Rails to bump updated_at when touching a continuously delivered stack

### DIFF
--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -141,7 +141,7 @@ module Shipit
     end
 
     def continuous_delivery_delayed!
-      touch(:continuous_delivery_delayed_since, :updated_at) unless continuous_delivery_delayed?
+      touch(:continuous_delivery_delayed_since) unless continuous_delivery_delayed?
     end
 
     def trigger_continuous_delivery

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -541,6 +541,16 @@ module Shipit
       assert_equal({'SAFETY_DISABLED' => '0'}, deploy.env)
     end
 
+    test "#continuous_delivery_delayed! bumps updated_at" do
+      old_updated_at = @stack.updated_at - 3.minutes
+      @stack.update_column(updated_at: old_updated_at)
+      @stack.reload
+
+      @stack.continuous_delivery_delayed!
+
+      assert @stack.updated_at > old_updated_at
+    end
+
     test "#next_commit_to_deploy returns the last deployable commit" do
       @stack.tasks.where.not(until_commit_id: shipit_commits(:second).id).destroy_all
       assert_equal shipit_commits(:second), @stack.last_deployed_commit


### PR DESCRIPTION
We were seeing a lot of these invalid statements sent to Heroku Postgres:

```
PG::SyntaxError: ERROR:  multiple assignments to same column "updated_at"
: UPDATE "stacks" SET "updated_at" = $1, "continuous_delivery_delayed_since" = $2, "updated_at" = $3 WHERE "stacks"."id" = $4
```

originating from `Stack#continuous_delivery_delayed!` . Turns out `ActiveRecord::Base#touch` already touches the `updated_at` column so there's no need to touch it explicitly. I suspect that Shopify didn't hit this issue because they're running MySQL in production for Shipit, not Postgres.