### PR TITLE
Wait a bit longer than 0 seconds for the lock when checking continuous delivery

### DIFF
--- a/app/jobs/shipit/continuous_delivery_job.rb
+++ b/app/jobs/shipit/continuous_delivery_job.rb
@@ -2,6 +2,7 @@ module Shipit
   class ContinuousDeliveryJob < BackgroundJob
     include BackgroundJob::Unique
 
+    self.lock_timeout = 3 # seconds
     queue_as :default
 
     def perform(stack)


### PR DESCRIPTION
We were seeing a lot of `Redis::Lock::LockTimeout` exceptions from `Shipit::ContinuousDeliveryJob` on our rather modestly sized Shipit deploy on Heroku. I believe that because we have lots of github hooks arriving at the same time from many different CircleCI checks there is a bit of a stampede of `ContinuousDeliveryJobs` kicked off all at once. It seems correct to me they should execute serially, but, it doesn't seem correct that they should immediately exception with a `LockTimeout` if there is another one running already. The default `lock_timeout` for a `Shipit::BackgroundJob::Unique` is `0`, so, that was the behaviour before this change.

Instead, let's wait a small amount of time to see if the job can get the lock. The jobs are quick so I don't think we need to wait super long, so I chose 3 seconds.

A big question for me would be why doesn't Shopify hit this? 