### PR TITLE
Improve release status publication for rollbacks

### DIFF
--- a/app/models/shipit/rollback.rb
+++ b/app/models/shipit/rollback.rb
@@ -39,7 +39,16 @@ module Shipit
 
       case status
       when 'pending'
-        deploy.append_release_status('failure', "A rollback #{stack.to_param} was triggered")
+        if deploy.rollback_once_aborted?
+          deploy.append_release_status('failure', "A rollback of #{stack.to_param} was triggered")
+        else
+          since_commit.create_release_status!(
+            'failure',
+            user: user.presence,
+            target_url: permalink,
+            description: "A rollback of #{stack.to_param} was triggered",
+          )
+        end
       end
     end
 


### PR DESCRIPTION
There is two ways a rollback can be triggered.

You can do it with the `Abort and Rollback` button, in which case `Rollback#deploy` will refer to the aborted deploy. In this case you want to publish the failing release status on the revision that aborted deploy was trying to deploy. That's what Shipit was doing in all cases.

However you can also trigger a rollback from the main page, and in this case `Rollback#deploy` will refer to the old successful deploy you want to roll back to. In this case you want to publish the failing release status on the last successfully deployed revision. 

Note that in that last case, we can't know for sure that it's really the last release that is fault, it could any of the release between last last one and the one you are rolling back to, but I don't think Shipit can be any smarter than that.