### PR TITLE
Upgrade faraday to 0.12 series for kubernetes-deploy > 0.6.0 compatibility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -8,7 +8,7 @@ PATH
       autoprefixer-rails (~> 6.4.1)
       coffee-rails (~> 4.2)
       explicit-parameters (~> 0.3.0)
-      faraday (~> 0.9.1)
+      faraday (~> 0.12.2)
       faraday-http-cache (~> 1.2.2)
       gemoji (~> 2.1)
       jquery-rails (~> 4.1.0)
@@ -114,7 +114,7 @@ GEM
     faker (1.7.3)
       i18n (~> 0.5)
     fakeweb (1.3.0)
-    faraday (0.9.2)
+    faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (1.2.2)
       faraday (~> 0.8)
@@ -183,7 +183,7 @@ GEM
     pubsubstub (0.1.3)
       rack
       redis (~> 3.0)
-    rack (2.0.5)
+    rack (2.0.6)
     rack-test (1.1.0)
       rack (>= 1.0, < 3)
     rails (5.1.6)
@@ -236,7 +236,7 @@ GEM
       unicode-display_width (~> 1.0, >= 1.0.1)
     ruby-progressbar (1.9.0)
     safe_yaml (1.0.4)
-    sass (3.6.0)
+    sass (3.7.2)
       sass-listen (~> 4.0.0)
     sass-listen (4.0.0)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -273,7 +273,7 @@ GEM
     state_machines-activerecord (0.5.2)
       activerecord (>= 4.1, < 6.0)
       state_machines-activemodel (>= 0.5.0)
-    thor (0.20.0)
+    thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.8)
     tzinfo (1.2.5)
@@ -309,4 +309,4 @@ DEPENDENCIES
   sqlite3
 
 BUNDLED WITH
-   1.16.6
+   1.17.1

--- a/shipit-engine.gemspec
+++ b/shipit-engine.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'autoprefixer-rails', '~> 6.4.1'
   s.add_dependency 'coffee-rails', '~> 4.2'
   s.add_dependency 'explicit-parameters', '~> 0.3.0'
-  s.add_dependency 'faraday', '~> 0.9.1'
+  s.add_dependency 'faraday', '~> 0.12.2'
   s.add_dependency 'faraday-http-cache', '~> 1.2.2'
   s.add_dependency 'gemoji', '~> 2.1'
   s.add_dependency 'jquery-rails', '~> 4.1.0'


### PR DESCRIPTION
Before this change shipit-engine was locked to an older version of faraday which prevents dependency compatibility with `kubernetes-deploy`, which is a supported feature. `kubernetes-deploy` was held back to `0.6.0` which is real old, `0.22.0` was released a week or two ago. This upgrades `shipit-engine`'s faraday dependency to the same one `kubernetes-deploy` has so that `kubernetes-deploy`@`0.22.0` can be in the same bundle! Woop woop!