### PR TITLE
Prevent continuous delivery if the last active task is validating

### DIFF
--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -175,6 +175,8 @@ module Shipit
 
     def deployed_too_recently?
       if task = last_active_task
+        return true if task.validating?
+
         task.ended_at? && (task.ended_at + pause_between_deploys).future?
       end
     end

--- a/test/fixtures/shipit/stacks.yml
+++ b/test/fixtures/shipit/stacks.yml
@@ -72,12 +72,12 @@ shipit_canaries:
         ]
       },
       "dependencies": {"override": []},
-      "deploy": {"override": null, "interval": 60, "max_commits": 3, "variables": [{"name": "SAFETY_DISABLED", "title": "Set to 1 to do dangerous things", "default": 0}]},
+      "deploy": {"override": null, "max_commits": 3, "variables": [{"name": "SAFETY_DISABLED", "title": "Set to 1 to do dangerous things", "default": 0}]},
       "rollback": {"override": ["echo 'Rollback!'"]},
       "fetch": ["echo '42'"],
       "status": {
         "context": "shipit/canaries",
-        "delay": 60
+        "delay": 480
       },
       "tasks": {
         "restart": {

--- a/test/fixtures/shipit/statuses.yml
+++ b/test/fixtures/shipit/statuses.yml
@@ -125,3 +125,12 @@ soc_third:
   created_at: <%= 7.days.ago.to_s(:db) %>
   state: success
   target_url: "http://www.example.com"
+
+canaries_fifth_success:
+  stack: shipit_canaries
+  commit_id: 305
+  description: All good
+  context: ci/travis
+  created_at: <%= 7.days.ago.to_s(:db) %>
+  state: success
+  target_url: "http://www.example.com"


### PR DESCRIPTION
With regard to continuous delivery, a `validating` deploy should be considered as still "active".

