### PR TITLE
Write Task#ended_at when entering the `validating` status

### DIFF
--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -57,7 +57,7 @@ module Shipit
         task.started_at ||= Time.now.utc
       end
 
-      before_transition any => %i(success failed error timedout) do |task|
+      before_transition any => %i(success failed error timedout validating) do |task|
         task.ended_at ||= Time.now.utc
       end
 


### PR DESCRIPTION
That property is used for `deploy.delay`. 

We should consider the deploy `ended` whenever it's no longer `running`.