### PR TITLE
Add undeployed commits endpoint

### DIFF
--- a/app/controllers/shipit/api/commits_controller.rb
+++ b/app/controllers/shipit/api/commits_controller.rb
@@ -6,6 +6,12 @@ module Shipit
       def index
         render_resources stack.commits.reachable.includes(:statuses)
       end
+
+      def undeployed
+        stack.undeployed_commits do |undeployed_commits|
+          render_resources undeployed_commits
+        end
+      end
     end
   end
 end

--- a/app/controllers/shipit/api/commits_controller.rb
+++ b/app/controllers/shipit/api/commits_controller.rb
@@ -4,13 +4,12 @@ module Shipit
       require_permission :read, :stack
 
       def index
-        render_resources stack.commits.reachable.includes(:statuses)
-      end
-
-      def undeployed
-        stack.undeployed_commits do |undeployed_commits|
-          render_resources undeployed_commits
+        commits = stack.commits.reachable.includes(:statuses)
+        if params[:undeployed]
+          commits = commits.newer_than(stack.last_deployed_commit)
         end
+
+        render_resources commits
       end
     end
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,9 @@ Shipit::Engine.routes.draw do
         resource :output, only: :show
       end
       resources :deploys, only: %i(index create)
-      resources :commits, only: %i(index)
+      resources :commits, only: %i(index) do
+        get :undeployed, on: :collection
+      end
       resources :pull_requests, only: %i(index show update destroy)
       post '/task/:task_name' => 'tasks#trigger', as: :trigger_task
       resources :hooks, only: %i(index create show update destroy)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,9 +25,7 @@ Shipit::Engine.routes.draw do
         resource :output, only: :show
       end
       resources :deploys, only: %i(index create)
-      resources :commits, only: %i(index) do
-        get :undeployed, on: :collection
-      end
+      resources :commits, only: %i(index)
       resources :pull_requests, only: %i(index show update destroy)
       post '/task/:task_name' => 'tasks#trigger', as: :trigger_task
       resources :hooks, only: %i(index create show update destroy)

--- a/test/controllers/api/commits_controller_test.rb
+++ b/test/controllers/api/commits_controller_test.rb
@@ -16,10 +16,10 @@ module Shipit
         assert_json '0.sha', commit.sha
       end
 
-      test "#undeployed returns a list of undeployed commits" do
-        commits = @stack.undeployed_commits.map(&:sha)
+      test "#index with undeployed=1 returns a list of undeployed commits" do
+        commits = @stack.undeployed_commits.pluck(:sha)
 
-        get :undeployed, params: {stack_id: @stack.to_param}
+        get :index, params: {stack_id: @stack.to_param, undeployed: 1}
         assert_response :ok
         JSON.parse(response.body).each do |commit|
           assert commits.include?(commit.fetch("sha"))

--- a/test/controllers/api/commits_controller_test.rb
+++ b/test/controllers/api/commits_controller_test.rb
@@ -15,6 +15,16 @@ module Shipit
         assert_response :ok
         assert_json '0.sha', commit.sha
       end
+
+      test "#undeployed returns a list of undeployed commits" do
+        commits = @stack.undeployed_commits.map(&:sha)
+
+        get :undeployed, params: {stack_id: @stack.to_param}
+        assert_response :ok
+        JSON.parse(response.body).each do |commit|
+          assert commits.include?(commit.fetch("sha"))
+        end
+      end
     end
   end
 end


### PR DESCRIPTION
Add an api endpoint to be able to look up the undeployed commits for a given stack.

@grcooper is looking into building some tooling to be able to send messages to people who are waiting for their commits to be deployed. This will help enable that. 