### PR TITLE
Mark all rollbacks on a pending stack as faulty

### DIFF
--- a/app/models/shipit/rollback.rb
+++ b/app/models/shipit/rollback.rb
@@ -36,20 +36,9 @@ module Shipit
 
     def update_release_status
       return unless stack.release_status?
+      return unless status == 'pending'
 
-      case status
-      when 'pending'
-        if deploy.rollback_once_aborted?
-          deploy.report_faulty!(description: "A rollback of #{stack.to_param} was triggered")
-        else
-          since_commit.create_release_status!(
-            'failure',
-            user: user.presence,
-            target_url: permalink,
-            description: "A rollback of #{stack.to_param} was triggered",
-          )
-        end
-      end
+      deploy.report_faulty!(description: "A rollback of #{stack.to_param} was triggered")
     end
 
     def lock_reverted_commits

--- a/test/models/deploys_test.rb
+++ b/test/models/deploys_test.rb
@@ -533,14 +533,18 @@ module Shipit
       end
     end
 
-    test "manually triggered rollbacks sets the release status as failure on the previously deployed revision" do
-      @deploy = shipit_deploys(:canaries_faulty)
-      last_deployed_commit = @deploy.stack.last_deployed_commit
+    test "manually triggered rollbacks sets the release status as failure" do
+      @deploy = shipit_deploys(:canaries_validating)
 
       assert_difference -> { ReleaseStatus.count }, +1 do
-        assert_not_equal 'failure', last_deployed_commit.release_statuses.last&.state
+        assert_equal 'validating', @deploy.status
+        assert_equal 'pending', @deploy.last_release_status.state
+
         @deploy.trigger_rollback(force: true)
-        assert_equal 'failure', last_deployed_commit.release_statuses.last.state
+        @deploy.reload
+
+        assert_equal 'faulty', @deploy.status
+        assert_equal 'failure', @deploy.last_release_status.state
       end
     end
 


### PR DESCRIPTION
If a rollback happens, whether it's an abort or straight rollback, mark the status as faulty.