### PR TITLE
Show an error message for the title when it would otherwise result in a 500

### DIFF
--- a/app/models/shipit/task_definition.rb
+++ b/app/models/shipit/task_definition.rb
@@ -35,6 +35,8 @@ module Shipit
       else
         action
       end
+    rescue KeyError
+      "This task (title: #{@title}) cannot be shown due to an incorrect variable name. Check your shipit.yml file"
     end
 
     def allow_concurrency?

--- a/test/fixtures/shipit/tasks.yml
+++ b/test/fixtures/shipit/tasks.yml
@@ -209,3 +209,30 @@ canaries_running:
   created_at: <%= (60 - 7).minutes.ago.to_s(:db) %>
   started_at: <%= (60 - 7).minutes.ago.to_s(:db) %>
   ended_at: <%= (60 - 10).minutes.ago.to_s(:db) %>
+
+shipit_with_title_parsing_issue:
+  id: 105
+  user: walrus
+  since_commit_id: 2 # second
+  until_commit_id: 2 # second
+  type: Shipit::Task
+  stack: shipit
+  status: success
+  definition: >
+    {
+      "id": "bad-title",
+      "action": "Task with bad title",
+      "title": "Using the %{WRONG_VARIABLE_NAME}",
+      "description": "This task uses the wrong variable name",
+      "variables": [
+        {"name": "VARIABLE_NAME", "title": "Any old variable"}
+      ],
+      "steps": [
+        "does not matter"
+      ]
+    }
+  env:
+    POD_ID: "12"
+  created_at: <%= (60 - 3).minutes.ago.to_s(:db) %>
+  started_at: <%= (60 - 3).minutes.ago.to_s(:db) %>
+  ended_at: <%= (60 - 4).minutes.ago.to_s(:db) %>

--- a/test/models/tasks_test.rb
+++ b/test/models/tasks_test.rb
@@ -12,5 +12,10 @@ module Shipit
       task = shipit_tasks(:shipit_restart)
       assert_equal 'Restart application', task.title
     end
+
+    test '#title returns an error message when the title raises an error' do
+      task = shipit_tasks(:shipit_with_title_parsing_issue)
+      assert_equal 'This task (title: Using the %{WRONG_VARIABLE_NAME}) cannot be shown due to an incorrect variable name. Check your shipit.yml file', task.title
+    end
   end
 end


### PR DESCRIPTION
Fixes #862.

I opted to do a very simple error message here instead of something more fancy since it doesn't seem worth the added complexity. I could also have put this fix in the TaskDefinition and delegated to description again, but that would just hide the problem.