### PR TITLE
Allow the enclosing application to listen to hooks

### DIFF
--- a/app/models/shipit/hook.rb
+++ b/app/models/shipit/hook.rb
@@ -75,6 +75,13 @@ module Shipit
           stack_id: stack&.id,
           payload: coerce_payload(payload),
         )
+        deliver_internal_hooks(event, stack, payload)
+      end
+
+      def deliver_internal_hooks(event, stack, payload)
+        Shipit.internal_hook_receivers.each do |receiver|
+          receiver.deliver(event, stack, payload)
+        end
       end
 
       def deliver(event, stack_id, payload)

--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -58,6 +58,7 @@ module Shipit
   delegate :table_name_prefix, to: :secrets
 
   attr_accessor :disable_api_authentication, :timeout_exit_codes
+  attr_writer :internal_hook_receivers
 
   self.timeout_exit_codes = [].freeze
 
@@ -181,6 +182,10 @@ module Shipit
 
   def committer_email
     secrets.committer_email.presence || "#{app_name.underscore.dasherize}@#{host}"
+  end
+
+  def internal_hook_receivers
+    @internal_hook_receivers || []
   end
 
   protected

--- a/test/models/hook_test.rb
+++ b/test/models/hook_test.rb
@@ -42,5 +42,34 @@ module Shipit
       @hook.stack_id = 42
       assert @hook.scoped?
     end
+
+    test ".emit schedules an EmitEventJob" do
+      assert_enqueued_jobs(1, only: EmitEventJob) do
+        Hook.emit(:deploy, @stack, 'foo' => 42)
+      end
+    end
+
+    test ".emit calls #deliver on internal hooks" do
+      begin
+        original_receivers = Shipit.internal_hook_receivers
+        FakeReceiver = Module.new
+        FakeReceiver.expects(:deliver).with(:deploy, @stack, 'foo' => 42)
+
+        Shipit.internal_hook_receivers = [FakeReceiver]
+        Hook.emit(:deploy, @stack, 'foo' => 42)
+      ensure
+        Shipit.internal_hook_receivers = original_receivers
+      end
+    end
+
+    test ".emit calls no internal hooks if there are no internal_hook_receivers" do
+      begin
+        original_receivers = Shipit.internal_hook_receivers
+        Shipit.internal_hook_receivers = nil
+        Hook.emit(:deploy, @stack, 'foo' => 42)
+      ensure
+        Shipit.internal_hook_receivers = original_receivers
+      end
+    end
   end
 end


### PR DESCRIPTION
I want to send hooks using an internal format that's not appropriate to support in this repo, so it occurred to me that it would be nice for the main app to be able to subscribe to hooks itself, instead of having to maintain another app to receive hooks and then send them on. This is the simplest way I can come up with to do that, but I wanted to push this up for feedback before I add tests, since someone might have a better approach.

Notably, this doesn't have nice features like event or stack filtering built in. 

The main application has to set 
```ruby 
Shipit.internal_hook_receivers = [MyHookReceiver]

module MyHookReceiver
  def self.deliver(event, stack payload)
    #this is the required interface
  end
end
```