### PR TITLE
Allow the shovel operator to be used with internal_hook_receivers

### DIFF
--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -185,7 +185,7 @@ module Shipit
   end
 
   def internal_hook_receivers
-    @internal_hook_receivers || []
+    @internal_hook_receivers ||= []
   end
 
   protected

--- a/test/models/hook_test.rb
+++ b/test/models/hook_test.rb
@@ -55,7 +55,7 @@ module Shipit
         FakeReceiver = Module.new
         FakeReceiver.expects(:deliver).with(:deploy, @stack, 'foo' => 42)
 
-        Shipit.internal_hook_receivers = [FakeReceiver]
+        Shipit.internal_hook_receivers << FakeReceiver
         Hook.emit(:deploy, @stack, 'foo' => 42)
       ensure
         Shipit.internal_hook_receivers = original_receivers


### PR DESCRIPTION
This PR enables us to use the shovel operator for an empty `@internal_hook_receiver` instance variable.
This is a follow up on #865 