### PR TITLE
set ended_at when transitioning to an end statuses

### DIFF
--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -57,7 +57,7 @@ module Shipit
         task.started_at ||= Time.now.utc
       end
 
-      before_transition any => %i(success failed error timedout validating) do |task|
+      before_transition running: any do |task|
         task.ended_at ||= Time.now.utc
       end
 

--- a/test/models/deploys_test.rb
+++ b/test/models/deploys_test.rb
@@ -93,6 +93,16 @@ module Shipit
       assert_equal [4, 3, 2], deploy.commits.pluck(:id)
     end
 
+    test "transitioning to an active status does not set ended_at" do
+      deploy = shipit_deploys(:shipit_pending)
+      deploy.status = 'pending'
+
+      deploy.run!
+      deploy.reload
+
+      assert_nil deploy.ended_at
+    end
+
     test "transitioning to success causes an event to be broadcasted" do
       deploy = shipit_deploys(:shipit_pending)
 


### PR DESCRIPTION
This is a follow up PR on https://github.com/Shopify/shipit-engine/pull/849#discussion_r

Some statuses are missing the `ended_at` time in the internal hooks so we are adding them here. #865 

@casperisfine can you double check if the statuses that the `END_STATUSES` make sense?