### PR TITLE
Add descriptive title to the emergency mode button

### DIFF
--- a/app/views/shipit/stacks/show.html.erb
+++ b/app/views/shipit/stacks/show.html.erb
@@ -10,9 +10,9 @@
 
       <div class="commit-list-actions">
         <% if params[:force] %>
-          <%= link_to 'Exit emergency mode', stack_path(@stack) %>
+          <%= link_to t('emergency_mode.disable'), stack_path(@stack) %>
         <% else %>
-          <%= link_to 'Enable emergency mode', stack_path(@stack, force: 1) %>
+          <%= link_to t('emergency_mode.enable'), stack_path(@stack, force: 1), title: t('emergency_mode.enable_description') %>
         <% end %>
       </div>
     </header>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,6 +60,10 @@ en:
     create:
       error:
         deploy_in_progress: Rollbacks can't be triggered if a deploy is in progress
+  emergency_mode:
+    enable: Enable emergency mode
+    enable_description: Enable all UI controls and remove safeties to allow advanced troubleshooting measures
+    disable: Exit emergency mode
 
   errors:
     messages:


### PR DESCRIPTION
Fixes #863 by adding a `title` attribute to the Emergency Mode button (link). I did try a tooltip, but the description is a bit too long to work well in that UI. This is fine.

I could not 🎩  this because I'm unclear on how to render stacks#index in development. I would appreciate it if somebody who has things running could check it out or show me the way to get things running myself. 