### PR TITLE
Fix stream output polling after Rails 5 defaulted to the root key being included in JSON serializers

### DIFF
--- a/app/assets/javascripts/task/stream.js.coffee
+++ b/app/assets/javascripts/task/stream.js.coffee
@@ -40,9 +40,10 @@ class @Stream
 
   success: (response) =>
     @retries = 0
-    @broadcastOutput(response.output, response)
-    @broadcastStatus(response.status, response)
-    @start(response.url || false)
+    task = response.tail_task
+    @broadcastOutput(task.output, response)
+    @broadcastStatus(task.status, response)
+    @start(task.url || false)
 
   broadcastStatus: (status, args...) ->
     if status != @status


### PR DESCRIPTION
I can't find the commit in AMS or Rails where this happened, but on my fresh shipit install with `active_model_serializers` at `v0.9.7`, the root key is included in the JSON serialization for a task by default. New responses look like this:

```json
{
  "tail_task": {
     "url":"/fellowinsights/warehouse/production/tasks/836/tail?last_id=47197",
     "status": "running",
     "output": "$ git clone --local --origin cache...."
   }
}
```

I imagine this wasn't the case before because the OutputStream was expecting to find it's data in the root level keys of the response instead of under a root key for the object. 

This updates the task stream to work on fresh installs of shipit with Rails 5, but I don't understand why this wasn't an issue for Shopify.