### PR TITLE
Replace outdated reference to rails 5.1

### DIFF
--- a/template.rb
+++ b/template.rb
@@ -115,7 +115,7 @@ Sidekiq.configure_client do |config|
 end
 CODE
 
-inject_into_file 'config/application.rb', after: "load_defaults 5.1\n" do
+inject_into_file 'config/application.rb', after: "load_defaults 5.2\n" do
   "\n    config.active_job.queue_adapter = :sidekiq\n"
 end
 


### PR DESCRIPTION
It seems this reference to rails 5.1 was missed when upgrading to rails 5.2 8baf11ba80be0aa1b2fd3b9b0064222084c28c6b.