### PR TITLE
rename lock duration to lock details

### DIFF
--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -503,11 +503,11 @@ module Shipit
     def emit_lock_hooks
       return unless previous_changes.include?('lock_reason')
 
-      lock_duration = if previous_changes['lock_reason'].last.blank?
+      lock_details = if previous_changes['lock_reason'].last.blank?
         {from: previous_changes['locked_since'].first, until: Time.zone.now}
       end
 
-      Hook.emit(:lock, self, locked: locked?, lock_duration: lock_duration, stack: self)
+      Hook.emit(:lock, self, locked: locked?, lock_details: lock_details, stack: self)
     end
 
     def emit_added_hooks

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -330,7 +330,7 @@ module Shipit
     end
 
     test "locking the stack triggers a webhook" do
-      expect_hook(:lock, @stack, locked: true, lock_duration: nil, stack: @stack) do
+      expect_hook(:lock, @stack, locked: true, lock_details: nil, stack: @stack) do
         @stack.update(lock_reason: "Just for fun", lock_author: shipit_users(:walrus))
       end
     end
@@ -340,7 +340,7 @@ module Shipit
         time = Time.current
         @stack.update(lock_reason: "Just for fun", lock_author: shipit_users(:walrus))
         travel 1.day
-        expect_hook(:lock, @stack, locked: false, lock_duration: {from: time, until: Time.current}, stack: @stack) do
+        expect_hook(:lock, @stack, locked: false, lock_details: {from: time, until: Time.current}, stack: @stack) do
           @stack.update(lock_reason: nil)
         end
       end


### PR DESCRIPTION
followup on Shopify/shipit-engine#877 (comment)