### PR TITLE
Add /task/:id to redirect to deploys/tasks/rollbacks

### DIFF
--- a/app/controllers/shipit/tasks_controller.rb
+++ b/app/controllers/shipit/tasks_controller.rb
@@ -2,7 +2,7 @@ module Shipit
   class TasksController < ShipitController
     include Pagination
 
-    before_action :stack
+    before_action :stack, except: [:lookup]
 
     self.default_page_size = 20
 
@@ -50,7 +50,19 @@ module Shipit
       render json: TailTaskSerializer.new(task, context: params)
     end
 
+    def lookup
+      @task = Task.find(params[:id])
+
+      redirect_to url_for_task
+    end
+
     private
+
+    def url_for_task
+      base_task = @task.is_a?(Deploy) ? @task.becomes(Deploy) : @task
+
+      url_for([base_task.stack, base_task])
+    end
 
     def task
       @task ||= stack.tasks.find(params[:id])

--- a/app/models/shipit/commit.rb
+++ b/app/models/shipit/commit.rb
@@ -7,7 +7,7 @@ module Shipit
     belongs_to :stack
     has_many :deploys
     has_many :statuses, -> { order(created_at: :desc) }, dependent: :destroy, inverse_of: :commit
-    has_many :check_runs, -> { order(created_at: :desc) }, dependent: :destroy
+    has_many :check_runs, -> { order(created_at: :desc) }, dependent: :destroy, inverse_of: :commit
     has_many :commit_deployments, dependent: :destroy
     has_many :release_statuses, dependent: :destroy
     belongs_to :pull_request, inverse_of: :merge_commit, optional: true

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -65,6 +65,10 @@ Shipit::Engine.routes.draw do
     post :clear_git_cache, controller: :stacks
   end
 
+  scope '/task/:id', controller: :tasks do
+    get '/', action: :lookup
+  end
+
   scope '/*stack_id', stack_id: stack_id_format, as: :stack do
     get '/commit/:sha/checks' => 'commit_checks#show', as: :commit_checks
     get '/commit/:sha/checks/tail' => 'commit_checks#tail', as: :tail_commit_checks, defaults: {format: :json}

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -123,5 +123,29 @@ module Shipit
       assert_response :success
       assert_json_keys %w(status output rollback_url)
     end
+
+    test ":lookup returns stack task url if the task is an instance of Task" do
+      @task = shipit_tasks(:shipit_restart)
+
+      get :lookup, params: {id: @task.id}
+
+      assert_redirected_to stack_task_path(@task.stack, @task)
+    end
+
+    test ":lookup returns stack deploy url if the task is an instance of Deploy" do
+      @task = shipit_tasks(:shipit)
+
+      get :lookup, params: {id: @task.id}
+
+      assert_redirected_to stack_deploy_path(@task.stack, @task)
+    end
+
+    test ":lookup returns stack deploy url if the task is an instance of a subclass of Deploy" do
+      @task = shipit_tasks(:shipit_rollback)
+
+      get :lookup, params: {id: @task.id}
+
+      assert_redirected_to stack_deploy_path(@task.stack, @task)
+    end
   end
 end

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -140,7 +140,7 @@ module Shipit
       assert_redirected_to stack_deploy_path(@task.stack, @task)
     end
 
-    test ":lookup returns stack deploy url if the task is an instance of a subclass of Deploy" do
+    test ":lookup returns stack deploy url if the task is an instance of Rollback" do
       @task = shipit_tasks(:shipit_rollback)
 
       get :lookup, params: {id: @task.id}


### PR DESCRIPTION
## Problem

At the moment the user needs to know the stack path in order to create a link to a `task`, `deploy` or `rollback`, even with the given resource `id` at hand.

## Solution

Create the endpoint `/task/:id` that with the given resource id, redirects the user to the correct resource url.

## Notes

`Rollback` extends `Deploy` but doesn't have a specific view/url, because of that the code transforms any subclass of `Deploy` to look like a `Deploy` using `ActiveRecord#becomes` method.