### PR TITLE
Flag commits scheduled to next deploy

### DIFF
--- a/app/models/shipit/commit.rb
+++ b/app/models/shipit/commit.rb
@@ -169,6 +169,18 @@ module Shipit
 
     delegate :pending?, :success?, :error?, :failure?, :blocking?, :state, to: :status
 
+    def active?
+      return false unless stack.active_task?
+
+      active_task = stack.active_task
+
+      if active_task.since_commit == active_task.until_commit
+        id == active_task.since_commit.id
+      else
+        id > active_task.since_commit.id && id <= active_task.until_commit.id
+      end
+    end
+
     def deployable?
       !locked? && (stack.ignore_ci? || (success? && !blocked?))
     end

--- a/app/models/shipit/undeployed_commit.rb
+++ b/app/models/shipit/undeployed_commit.rb
@@ -35,12 +35,22 @@ module Shipit
     end
 
     def deploy_discouraged?
-      stack.maximum_commits_per_deploy && index >= stack.maximum_commits_per_deploy
+      maximum_commits_per_deploy_reached?
+    end
+
+    def deploy_scheduled?
+      stack.continuous_deployment && !maximum_commits_per_deploy_reached? && !active?
     end
 
     def blocked?
       return @blocked if defined?(@blocked)
       @blocked = super
+    end
+
+    private
+
+    def maximum_commits_per_deploy_reached?
+      stack.maximum_commits_per_deploy && index >= stack.maximum_commits_per_deploy
     end
   end
 end

--- a/app/views/shipit/commits/_commit.html.erb
+++ b/app/views/shipit/commits/_commit.html.erb
@@ -17,6 +17,11 @@
       <p class="commit-meta">
         <%= timeago_tag(commit.committed_at, force: true) %>
       </p>
+      <% if commit.deploy_scheduled? %>
+        <p class="commit-meta">
+	  <span class="scheduled">expected to be deployed next</span>
+        </p>
+      <% end %>
     </div>
     <div class="commit-lock" >
       <%= link_to stack_commit_path(commit.stack, commit), class: 'action-lock-commit', data: {tooltip: t('commit.lock')} do %>

--- a/test/fixtures/shipit/stacks.yml
+++ b/test/fixtures/shipit/stacks.yml
@@ -62,6 +62,7 @@ shipit_canaries:
   merge_queue_enabled: true
   tasks_count: 3
   undeployed_commits_count: 1
+  continuous_deployment: true
   cached_deploy_spec: >
     {
       "machine": {"environment": {}},
@@ -235,6 +236,7 @@ shipit_undeployed:
   merge_queue_enabled: true
   tasks_count: 2
   undeployed_commits_count: 3
+  continuous_deployment: true
   cached_deploy_spec: >
     {
       "machine": {"environment": {}},

--- a/test/models/undeployed_commits_test.rb
+++ b/test/models/undeployed_commits_test.rb
@@ -39,6 +39,46 @@ module Shipit
       assert_predicate @commit, :deploy_discouraged?
     end
 
+    test "#deploy_scheduled? returns true if the stack has continuous deployment enabled, commit index is lower then the maximum commits per deploy and commit is not part of active task" do
+      commit = UndeployedCommit.new(shipit_commits(:undeployed_4), 1)
+
+      assert_predicate commit.stack, :continuous_deployment
+      assert_equal 1, commit.index
+      assert_equal 3, commit.stack.maximum_commits_per_deploy
+      refute_predicate commit, :active?
+
+      assert_predicate commit, :deploy_scheduled?
+    end
+
+    test "#deploy_scheduled? returns false if the stack has continuous deployment enabled and commit index is equal or bigger then the maximum commits per deploy" do
+      commit = UndeployedCommit.new(shipit_commits(:undeployed_4), 3)
+
+      assert_predicate commit.stack, :continuous_deployment
+      assert_equal 3, commit.index
+      assert_equal 3, commit.stack.maximum_commits_per_deploy
+
+      refute_predicate commit, :deploy_scheduled?
+    end
+
+    test "#deploy_scheduled? returns false if the stack has continuous deployment disabled" do
+      commit = UndeployedCommit.new(shipit_commits(:cyclimse_first), 1)
+
+      refute_predicate commit.stack, :continuous_deployment
+
+      refute_predicate commit, :deploy_scheduled?
+    end
+
+    test "#deploy_scheduled? returns false if the commit is part of the active task" do
+      commit = UndeployedCommit.new(shipit_commits(:undeployed_3), 1)
+
+      assert_predicate commit.stack, :continuous_deployment
+      assert_equal 1, commit.index
+      assert_equal 3, commit.stack.maximum_commits_per_deploy
+      assert_predicate commit, :active?
+
+      refute_predicate commit, :deploy_scheduled?
+    end
+
     test "#deploy_state returns `allowed` by default" do
       assert_equal 'allowed', @commit.deploy_state
     end


### PR DESCRIPTION
## Problem

In a stack with continuous deployment enabled, by looking at the list of `Undeployed Commits` it is not clear which of them are going to be grouped and deployed.

## Solution

Based on the config value `deploy.max_commits` flag the commits that are supposed to be grouped and deployed.

## Notes

This PR was created on top of #890 .

<img width="957" alt="Screenshot 2019-04-05 at 15 02 36" src="https://user-images.githubusercontent.com/961874/55629732-3a93b800-57b4-11e9-8141-cdfc28bb7cab.png">
