### PR TITLE
Track rollback safeness in shipit

### DIFF
--- a/app/assets/javascripts/merge_status.coffee
+++ b/app/assets/javascripts/merge_status.coffee
@@ -30,7 +30,7 @@ class MergeStatusPoller
 
   previousLastModified = null
   refreshPage: =>
-    @fetchPage window.location.toString(), (html, response) =>
+    @fetchPage @reloadUrl(), (html, response) =>
       @updateDocument(html, response)
       setTimeout(@refreshPage, POLL_INTERVAL)
 
@@ -41,6 +41,13 @@ class MergeStatusPoller
       if html && container = document.querySelector('[data-layout-content]')
         container.innerHTML = html
         @onPageChange()
+
+  reloadUrl: =>
+    rollback_checkbox = document.querySelector('input[name="rollbackable"]:checked')
+    if rollback_checkbox == null
+      return window.location.toString()
+    else
+      return window.location.toString() + "&rollbackable=" + rollback_checkbox.value
 
   isMergeQueueEnabled: =>
     document.querySelector('.merge-status-container .js-details-container')?.hasAttribute('data-queue-enabled')

--- a/app/assets/javascripts/merge_status.coffee
+++ b/app/assets/javascripts/merge_status.coffee
@@ -43,11 +43,8 @@ class MergeStatusPoller
         @onPageChange()
 
   reloadUrl: =>
-    rollback_checkbox = document.querySelector('input[name="rollbackable"]:checked')
-    if rollback_checkbox == null
-      return window.location.toString()
-    else
-      return window.location.toString() + "&rollbackable=" + rollback_checkbox.value
+    mergeForm =  document.querySelector('form#merge-form')
+    window.location.toString() + '&' + new URLSearchParams(new FormData(mergeForm)).toString()
 
   isMergeQueueEnabled: =>
     document.querySelector('.merge-status-container .js-details-container')?.hasAttribute('data-queue-enabled')

--- a/app/assets/stylesheets/_pages/_commits.scss
+++ b/app/assets/stylesheets/_pages/_commits.scss
@@ -153,6 +153,14 @@
   color: $red;
 }
 
+.rollbackable-yes {
+  color: $green;
+}
+
+.rollbackable-no {
+  color: $red;
+}
+
 
 // COMMIT ACTIONS
 // -----------------------------------------------------------------------------

--- a/app/assets/stylesheets/_pages/_commits.scss
+++ b/app/assets/stylesheets/_pages/_commits.scss
@@ -354,6 +354,11 @@
   color: #555;
 }
 
+.commit-summary__rollbackable {
+  padding: 0px 30px;
+  font-weight: bold;
+}
+
 .commit-summary__sha {
   font-size: 0.875rem;
   color: $grey;

--- a/app/assets/stylesheets/merge_status.scss
+++ b/app/assets/stylesheets/merge_status.scss
@@ -1,3 +1,10 @@
 .merge-status-container {
   max-width: 700px;
 }
+
+.rollbackability {
+  margin-bottom: 15px;
+  input {
+    margin-left: 10px;
+  }
+}

--- a/app/controllers/shipit/api/pull_requests_controller.rb
+++ b/app/controllers/shipit/api/pull_requests_controller.rb
@@ -13,7 +13,7 @@ module Shipit
       end
 
       def update
-        pull_request = PullRequest.request_merge!(stack, params[:id], current_user)
+        pull_request = PullRequest.request_merge!(stack, params[:id], current_user, params[:unsafe_to_rollback])
         if pull_request.waiting?
           head :accepted
         elsif pull_request.merged?

--- a/app/controllers/shipit/merge_status_controller.rb
+++ b/app/controllers/shipit/merge_status_controller.rb
@@ -22,7 +22,7 @@ module Shipit
     end
 
     def enqueue
-      PullRequest.request_merge!(stack, params[:number], current_user)
+      PullRequest.request_merge!(stack, params[:number], current_user, params[:rollbackable])
       render stack_status, layout: !request.xhr?
     end
 

--- a/app/controllers/shipit/merge_status_controller.rb
+++ b/app/controllers/shipit/merge_status_controller.rb
@@ -22,7 +22,7 @@ module Shipit
     end
 
     def enqueue
-      PullRequest.request_merge!(stack, params[:number], current_user, params[:rollbackable])
+      PullRequest.request_merge!(stack, params[:number], current_user, params[:unsafe_to_rollback])
       render stack_status, layout: !request.xhr?
     end
 

--- a/app/controllers/shipit/pull_requests_controller.rb
+++ b/app/controllers/shipit/pull_requests_controller.rb
@@ -6,7 +6,7 @@ module Shipit
 
     def create
       if pr_number = PullRequest.extract_number(stack, params[:number_or_url])
-        pull_request = PullRequest.request_merge!(stack, pr_number, current_user)
+        pull_request = PullRequest.request_merge!(stack, pr_number, current_user, params[:unsafe_to_rollback])
         flash[:success] = "Pull request ##{pull_request.number} added to the queue."
       else
         flash[:warning] = "Invalid or missing pull request number."

--- a/app/models/shipit/commit.rb
+++ b/app/models/shipit/commit.rb
@@ -257,7 +257,7 @@ module Shipit
         self.pull_request_number = pull_request.number
         self.pull_request_title = pull_request.title
         self.author = pull_request.merge_requested_by if pull_request.merge_requested_by
-        self.rollbackable = pull_request.rollbackable
+        self.unsafe_to_rollback = pull_request.unsafe_to_rollback
       end
 
       self.pull_request_number = message_parser.pull_request_number unless self[:pull_request_number]

--- a/app/models/shipit/commit.rb
+++ b/app/models/shipit/commit.rb
@@ -257,6 +257,7 @@ module Shipit
         self.pull_request_number = pull_request.number
         self.pull_request_title = pull_request.title
         self.author = pull_request.merge_requested_by if pull_request.merge_requested_by
+        self.rollbackable = pull_request.rollbackable
       end
 
       self.pull_request_number = message_parser.pull_request_number unless self[:pull_request_number]

--- a/app/models/shipit/commit.rb
+++ b/app/models/shipit/commit.rb
@@ -7,7 +7,7 @@ module Shipit
     belongs_to :stack
     has_many :deploys
     has_many :statuses, -> { order(created_at: :desc) }, dependent: :destroy, inverse_of: :commit
-    has_many :check_runs, -> { order(created_at: :desc) }, dependent: :destroy
+    has_many :check_runs, -> { order(created_at: :desc) }, dependent: :destroy, inverse_of: :commit
     has_many :commit_deployments, dependent: :destroy
     has_many :release_statuses, dependent: :destroy
     belongs_to :pull_request, inverse_of: :merge_commit, optional: true

--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -111,11 +111,11 @@ module Shipit
     end
 
     def safe_to_rollback?
-      !commits.any?{|commit| commit.rollbackable == false}
+      !commits.any?(&:unsafe_to_rollback)
     end
 
     def safe_to_rollback_to?
-      !stack.deploys.newer_than(id).until(stack.last_completed_deploy.id).any? { |deploy| !deploy.safe_to_rollback? }
+      stack.deploys.newer_than(id).until(stack.last_completed_deploy.id).all?(&:safe_to_rollback?)
     end
 
     def currently_deployed?

--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -111,7 +111,7 @@ module Shipit
     end
 
     def safe_to_rollback?
-      !commits.any?(&:unsafe_to_rollback)
+      commits.none?(&:unsafe_to_rollback)
     end
 
     def safe_to_rollback_to?

--- a/app/models/shipit/pull_request.rb
+++ b/app/models/shipit/pull_request.rb
@@ -119,13 +119,13 @@ module Shipit
       end
     end
 
-    def self.request_merge!(stack, number, user, rollbackable)
+    def self.request_merge!(stack, number, user, unsafe_to_rollback)
       now = Time.now.utc
       pull_request = begin
         create_with(
           merge_requested_at: now,
           merge_requested_by: user.presence,
-          rollbackable: rollbackable
+          unsafe_to_rollback: unsafe_to_rollback,
         ).find_or_create_by!(
           stack: stack,
           number: number,

--- a/app/models/shipit/pull_request.rb
+++ b/app/models/shipit/pull_request.rb
@@ -133,7 +133,7 @@ module Shipit
       rescue ActiveRecord::RecordNotUnique
         retry
       end
-      pull_request.update!(merge_requested_by: user.presence, rollbackable: rollbackable)
+      pull_request.update!(merge_requested_by: user.presence, unsafe_to_rollback: unsafe_to_rollback)
       pull_request.retry! if pull_request.rejected? || pull_request.canceled? || pull_request.revalidating?
       pull_request.schedule_refresh!
       pull_request

--- a/app/views/shipit/commits/_commit.html.erb
+++ b/app/views/shipit/commits/_commit.html.erb
@@ -18,10 +18,10 @@
         <%= timeago_tag(commit.committed_at, force: true) %>
       </p>
       <p class="commit-meta">
-        <% if commit.rollbackable%>
-          <span class='rollbackable-yes'> Safe to rollback </span>
-        <% elsif commit.rollbackable == false %>
+        <% if commit.unsafe_to_rollback%>
           <span class='rollbackable-no'> Unsafe to rollback </span>
+        <% elsif commit.unsafe_to_rollback == false %>
+          <span class='rollbackable-yes'> Safe to rollback </span>
         <% else %>
           <!-- Do not display anything if rollbackable is nil -->
         <% end %>

--- a/app/views/shipit/commits/_commit.html.erb
+++ b/app/views/shipit/commits/_commit.html.erb
@@ -17,6 +17,15 @@
       <p class="commit-meta">
         <%= timeago_tag(commit.committed_at, force: true) %>
       </p>
+      <p class="commit-meta">
+        <% if commit.rollbackable%>
+          <span class='rollbackable-yes'> Safe to rollback </span>
+        <% elsif commit.rollbackable == false %>
+          <span class='rollbackable-no'> Unsafe to rollback </span>
+        <% else %>
+          <!-- Do not display anything if rollbackable is nil -->
+        <% end %>
+      </p>
     </div>
     <div class="commit-lock" >
       <%= link_to stack_commit_path(commit.stack, commit), class: 'action-lock-commit', data: {tooltip: t('commit.lock')} do %>

--- a/app/views/shipit/deploys/_deploy.html.erb
+++ b/app/views/shipit/deploys/_deploy.html.erb
@@ -38,6 +38,14 @@
           in <%= deploy.duration %>
         <% end %>
       </p>
+      <p class="commit-meta">
+        <% if deploy.safe_to_rollback? %>
+          <span class='rollbackable-yes'> Safe to rollback </span>
+        <% else %>
+          <span class='rollbackable-no'> Unsafe to rollback </span>
+        <% end %>
+      </p>
+
     </div>
 
     <% if @stack.release_status? %>

--- a/app/views/shipit/deploys/_summary.html.erb
+++ b/app/views/shipit/deploys/_summary.html.erb
@@ -5,6 +5,15 @@
         <%= github_avatar commit.author, size: 24 %>
       </div>
       <span class="commit-summary__title"><%= render_commit_message_with_link commit %></span>
+      <span class="commit-summary__rollbackable">
+        <% if commit.rollbackable%>
+          <span class='rollbackable-yes'> Safe to rollback </span>
+        <% elsif commit.rollbackable == false %>
+          <span class='rollbackable-no'> Unsafe to rollback </span>
+        <% else %>
+          <!-- Do not display anything if rollbackable is nil -->
+        <% end %>
+      </span>
       <a href="<%= github_commit_url commit %>" class="commit-summary__sha number">
         <i class="ico-<%= commit.state %>-small"></i> <%= commit.short_sha %>
       </a>

--- a/app/views/shipit/deploys/_summary.html.erb
+++ b/app/views/shipit/deploys/_summary.html.erb
@@ -6,10 +6,10 @@
       </div>
       <span class="commit-summary__title"><%= render_commit_message_with_link commit %></span>
       <span class="commit-summary__rollbackable">
-        <% if commit.rollbackable%>
-          <span class='rollbackable-yes'> Safe to rollback </span>
-        <% elsif commit.rollbackable == false %>
+        <% if commit.unsafe_to_rollback %>
           <span class='rollbackable-no'> Unsafe to rollback </span>
+        <% elsif commit.unsafe_to_rollback == false %>
+          <span class='rollbackable-yes'> Safe to rollback </span>
         <% else %>
           <!-- Do not display anything if rollbackable is nil -->
         <% end %>

--- a/app/views/shipit/deploys/rollback.html.erb
+++ b/app/views/shipit/deploys/rollback.html.erb
@@ -1,13 +1,14 @@
 <%= render partial: 'shipit/stacks/header', locals: { stack: @stack } %>
 
 <div class="wrapper">
-  <section class="warning">
-    <h2>Are you sure it's safe to rollback?</h2>
-    <ul>
-      <li>Does the code you want to rollback contain migrations?</li>
-      <li>If so, is the old code compatible with the new schema?</li>
-    </ul>
-  </section>
+  <% unless @deploy.safe_to_rollback_to? %>
+    <section class="warning">
+      <h2>You are about to rollback a commit marked as unsafe to rollback</h2>
+      <ul>
+        <li>Please review the unsafe commits below</li>
+      </ul>
+    </section>
+  <% end %>
 
   <section>
     <header class="section-header">

--- a/app/views/shipit/merge_status/_merge_queue_button.html.erb
+++ b/app/views/shipit/merge_status/_merge_queue_button.html.erb
@@ -2,25 +2,21 @@
 <% if pull_request.try!(&:waiting?) %>
   <%= form_tag dequeue_pull_request_path(stack, pull_request_number), method: 'delete', class: classes, data: {remote: true} do %>
     <%= hidden_field_tag 'referrer', params[:referrer] %>
-    <button type="submit" data-disable-with="Removing from merge queue…" class="btn">
-      Remove from merge queue
-    </button>
+    <span class='branch-action-btn float-right'>
+      <button type="submit" data-disable-with="Removing from merge queue…" class="btn">
+        Remove from merge queue
+      </button>
+    </span>
   <% end %>
 <% else %>
-  <%= form_tag enqueue_pull_request_path(stack, pull_request_number), method: 'put', class: classes, data: {remote: true} do %>
+  <%= form_tag enqueue_pull_request_path(stack, pull_request_number), method: 'put', class: classes, data: {remote: true}, id: 'merge-form' do %>
     <%= hidden_field_tag 'referrer', params[:referrer] %>
 
     <div class='rollbackability'>
-      <%= label_tag :rollbackable do %>
-        Is this change <%= link_to('safe to rollback?', 'https://development.shopify.io/guides/shipping/safe_to_merge#Signs_your_PR_is_safe_to_rollback', target: :_blank) %>
+      <%= label_tag :unsafe_to_rollback do %>
+        This change is <%= link_to('unsafe to rollback', 'https://development.shopify.io/guides/shipping/safe_to_merge#Signs_your_PR_is_safe_to_rollback', target: :_blank) %>
       <% end %>
-      <% if params[:rollbackable] == 'false' %>
-        <%= radio_button_tag :rollbackable, true %> Yes
-        <%= radio_button_tag :rollbackable, false, checked: true %> No
-      <% else %>
-        <%= radio_button_tag :rollbackable, true, checked: true %> Yes
-        <%= radio_button_tag :rollbackable, false %> No
-      <% end %>
+      <%= check_box_tag :unsafe_to_rollback, true, params[:unsafe_to_rollback] == 'true' %>
     </div>
 
     <span class='branch-action-btn float-right'>

--- a/app/views/shipit/merge_status/_merge_queue_button.html.erb
+++ b/app/views/shipit/merge_status/_merge_queue_button.html.erb
@@ -1,4 +1,4 @@
-<% classes = 'branch-action-btn float-right js-immediate-updates js-handle-pull-merging-errors' %>
+<% classes = 'js-immediate-updates js-handle-pull-merging-errors' %>
 <% if pull_request.try!(&:waiting?) %>
   <%= form_tag dequeue_pull_request_path(stack, pull_request_number), method: 'delete', class: classes, data: {remote: true} do %>
     <%= hidden_field_tag 'referrer', params[:referrer] %>
@@ -9,8 +9,24 @@
 <% else %>
   <%= form_tag enqueue_pull_request_path(stack, pull_request_number), method: 'put', class: classes, data: {remote: true} do %>
     <%= hidden_field_tag 'referrer', params[:referrer] %>
-    <button type="submit" data-disable-with="Adding to merge queue…" class="btn btn-primary">
-      Add to merge queue
-    </button>
+
+    <div class='rollbackability'>
+      <%= label_tag :rollbackable do %>
+        Is this change <%= link_to('safe to rollback?', 'https://development.shopify.io/guides/shipping/safe_to_merge#Signs_your_PR_is_safe_to_rollback', target: :_blank) %>
+      <% end %>
+      <% if params[:rollbackable] == 'false' %>
+        <%= radio_button_tag :rollbackable, true %> Yes
+        <%= radio_button_tag :rollbackable, false, checked: true %> No
+      <% else %>
+        <%= radio_button_tag :rollbackable, true, checked: true %> Yes
+        <%= radio_button_tag :rollbackable, false %> No
+      <% end %>
+    </div>
+
+    <span class='branch-action-btn float-right'>
+      <button type="submit" data-disable-with="Adding to merge queue…" class="btn btn-primary">
+        Add to merge queue
+      </button>
+    </span>
   <% end %>
 <% end %>

--- a/app/views/shipit/pull_requests/_pull_request.html.erb
+++ b/app/views/shipit/pull_requests/_pull_request.html.erb
@@ -18,10 +18,10 @@
       <% end %>
     </p>
     <p class="pr-meta">
-      <% if pull_request.rollbackable %>
-        <span class='rollbackable-yes'> Safe to rollback </span>
-      <% elsif pull_request.rollbackable == false %>
+      <% if pull_request.unsafe_to_rollback %>
         <span class='rollbackable-no'> Unsafe to rollback </span>
+      <% elsif pull_request.unsafe_to_rollback == false %>
+        <span class='rollbackable-yes'> Safe to rollback </span>
       <% else %>
         <!-- Do not display anything if rollbackable is null -->
       <% end %>

--- a/app/views/shipit/pull_requests/_pull_request.html.erb
+++ b/app/views/shipit/pull_requests/_pull_request.html.erb
@@ -17,6 +17,15 @@
         <em class="warning">Need revalidation.</em>
       <% end %>
     </p>
+    <p class="pr-meta">
+      <% if pull_request.rollbackable %>
+        <span class='rollbackable-yes'> Safe to rollback </span>
+      <% elsif pull_request.rollbackble == false %>
+        <span class='rollbackable-no'> Unsafe to rollback </span>
+      <% else %>
+        <!-- Do not display anything if rollbackable is nil -->
+      <% end %>
+    </p>
   </div>
   <% if pull_request.revalidating? %>
     <div class="commit-actions">

--- a/app/views/shipit/pull_requests/_pull_request.html.erb
+++ b/app/views/shipit/pull_requests/_pull_request.html.erb
@@ -20,10 +20,10 @@
     <p class="pr-meta">
       <% if pull_request.rollbackable %>
         <span class='rollbackable-yes'> Safe to rollback </span>
-      <% elsif pull_request.rollbackble == false %>
+      <% elsif pull_request.rollbackable == false %>
         <span class='rollbackable-no'> Unsafe to rollback </span>
       <% else %>
-        <!-- Do not display anything if rollbackable is nil -->
+        <!-- Do not display anything if rollbackable is null -->
       <% end %>
     </p>
   </div>

--- a/db/migrate/20190403142443_add_rollbackable_to_commits.rb
+++ b/db/migrate/20190403142443_add_rollbackable_to_commits.rb
@@ -1,5 +1,5 @@
 class AddRollbackableToCommits < ActiveRecord::Migration[5.2]
   def change
-    add_column :commits, :rollbackable, :boolean
+    add_column :commits, :unsafe_to_rollback, :boolean
   end
 end

--- a/db/migrate/20190403142443_add_rollbackable_to_commits.rb
+++ b/db/migrate/20190403142443_add_rollbackable_to_commits.rb
@@ -1,0 +1,5 @@
+class AddRollbackableToCommits < ActiveRecord::Migration[5.2]
+  def change
+    add_column :commits, :rollbackable, :boolean
+  end
+end

--- a/db/migrate/20190404184348_add_rollbackable_to_pull_requests.rb
+++ b/db/migrate/20190404184348_add_rollbackable_to_pull_requests.rb
@@ -1,0 +1,5 @@
+class AddRollbackableToPullRequests < ActiveRecord::Migration[5.2]
+  def change
+    add_column :pull_requests, :rollbackable, :boolean
+  end
+end

--- a/db/migrate/20190404184348_add_rollbackable_to_pull_requests.rb
+++ b/db/migrate/20190404184348_add_rollbackable_to_pull_requests.rb
@@ -1,5 +1,5 @@
 class AddRollbackableToPullRequests < ActiveRecord::Migration[5.2]
   def change
-    add_column :pull_requests, :rollbackable, :boolean
+    add_column :pull_requests, :unsafe_to_rollback, :boolean
   end
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_04_04_184348) do
+ActiveRecord::Schema.define(version: 2019_04_08_160858) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text "permissions", limit: 65535
@@ -250,6 +250,7 @@ ActiveRecord::Schema.define(version: 2019_04_04_184348) do
     t.datetime "ended_at"
     t.boolean "ignored_safeties", default: false, null: false
     t.integer "aborted_by_id"
+    t.boolean "rollbackable"
     t.index ["rolled_up", "created_at", "status"], name: "index_tasks_on_rolled_up_and_created_at_and_status"
     t.index ["since_commit_id"], name: "index_tasks_on_since_commit_id"
     t.index ["stack_id", "allow_concurrency", "status"], name: "index_active_tasks"

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -76,7 +76,7 @@ ActiveRecord::Schema.define(version: 2019_04_04_184348) do
     t.string "pull_request_title", limit: 1024
     t.integer "pull_request_id"
     t.boolean "locked", default: false, null: false
-    t.boolean "rollbackable"
+    t.boolean "unsafe_to_rollback"
     t.index ["author_id"], name: "index_commits_on_author_id"
     t.index ["committer_id"], name: "index_commits_on_committer_id"
     t.index ["created_at"], name: "index_commits_on_created_at"
@@ -166,7 +166,7 @@ ActiveRecord::Schema.define(version: 2019_04_04_184348) do
     t.datetime "merged_at"
     t.string "base_ref", limit: 1024
     t.integer "base_commit_id"
-    t.boolean "rollbackable"
+    t.boolean "unsafe_to_rollback"
     t.index ["head_id"], name: "index_pull_requests_on_head_id"
     t.index ["merge_requested_by_id"], name: "index_pull_requests_on_merge_requested_by_id"
     t.index ["merge_status"], name: "index_pull_requests_on_merge_status"

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_10_10_150947) do
+ActiveRecord::Schema.define(version: 2019_04_04_184348) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text "permissions", limit: 65535
@@ -76,6 +76,7 @@ ActiveRecord::Schema.define(version: 2018_10_10_150947) do
     t.string "pull_request_title", limit: 1024
     t.integer "pull_request_id"
     t.boolean "locked", default: false, null: false
+    t.boolean "rollbackable"
     t.index ["author_id"], name: "index_commits_on_author_id"
     t.index ["committer_id"], name: "index_commits_on_committer_id"
     t.index ["created_at"], name: "index_commits_on_created_at"
@@ -165,6 +166,7 @@ ActiveRecord::Schema.define(version: 2018_10_10_150947) do
     t.datetime "merged_at"
     t.string "base_ref", limit: 1024
     t.integer "base_commit_id"
+    t.boolean "rollbackable"
     t.index ["head_id"], name: "index_pull_requests_on_head_id"
     t.index ["merge_requested_by_id"], name: "index_pull_requests_on_merge_requested_by_id"
     t.index ["merge_status"], name: "index_pull_requests_on_merge_status"
@@ -184,9 +186,9 @@ ActiveRecord::Schema.define(version: 2018_10_10_150947) do
     t.bigint "github_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["commit_id", "github_id"], name: "index_deploy_statuses_on_commit_id_and_github_id"
-    t.index ["stack_id", "commit_id"], name: "index_deploy_statuses_on_stack_id_and_commit_id"
-    t.index ["user_id"], name: "index_deploy_statuses_on_user_id"
+    t.index ["commit_id", "github_id"], name: "index_release_statuses_on_commit_id_and_github_id"
+    t.index ["stack_id", "commit_id"], name: "index_release_statuses_on_stack_id_and_commit_id"
+    t.index ["user_id"], name: "index_release_statuses_on_user_id"
   end
 
   create_table "stacks", force: :cascade do |t|
@@ -239,7 +241,7 @@ ActiveRecord::Schema.define(version: 2018_10_10_150947) do
     t.integer "additions", limit: 4, default: 0
     t.integer "deletions", limit: 4, default: 0
     t.text "definition", limit: 65535
-    t.binary "gzip_output"
+    t.binary "gzip_output", limit: 16777215
     t.boolean "rollback_once_aborted", default: false, null: false
     t.text "env"
     t.integer "confirmations", default: 0, null: false

--- a/test/models/commits_test.rb
+++ b/test/models/commits_test.rb
@@ -611,6 +611,23 @@ module Shipit
       assert_nil commit.pull_request
     end
 
+    test "merge commits are unsafe to deploy if matching Pull Request is unsafe to rollback" do
+      pull_request = shipit_pull_requests(:shipit_pending)
+      pull_request.update(unsafe_to_rollback: true)
+      commit = @stack.commits.create!(
+        author: shipit_users(:shipit),
+        authored_at: Time.now,
+        committer: shipit_users(:shipit),
+        committed_at: Time.now,
+        sha: '5590fd8b5f2be05d1fedb763a3605ee461c39074',
+        message: "Merge pull request #62 from shipit-engine/yoloshipit\n\nyoloshipit!",
+      )
+
+      assert_predicate commit, :pull_request?
+      assert_equal 62, commit.pull_request_number
+      assert commit.unsafe_to_rollback
+    end
+
     test "the merge requester if known overrides the commit author" do
       commit = @stack.commits.create!(
         author: shipit_users(:shipit),

--- a/test/models/pull_request_test.rb
+++ b/test/models/pull_request_test.rb
@@ -11,14 +11,14 @@ module Shipit
     test ".request_merge! creates a record and schedule a refresh" do
       pull_request = nil
       assert_enqueued_with(job: RefreshPullRequestJob) do
-        pull_request = PullRequest.request_merge!(@stack, 64, @user)
+        pull_request = PullRequest.request_merge!(@stack, 64, @user, nil)
       end
       assert_predicate pull_request, :persisted?
     end
 
     test ".request_merge! only track pull requests once" do
       assert_difference -> { PullRequest.count }, +1 do
-        5.times { PullRequest.request_merge!(@stack, 999, @user) }
+        5.times { PullRequest.request_merge!(@stack, 999, @user, nil) }
       end
     end
 
@@ -26,7 +26,7 @@ module Shipit
       original_merge_requested_at = @pr.merge_requested_at
       @pr.cancel!
       assert_predicate @pr, :canceled?
-      PullRequest.request_merge!(@stack, @pr.number, @user)
+      PullRequest.request_merge!(@stack, @pr.number, @user, nil)
       assert_predicate @pr.reload, :pending?
       assert_not_equal original_merge_requested_at, @pr.merge_requested_at
       assert_in_delta Time.now.utc, @pr.merge_requested_at, 2
@@ -36,7 +36,7 @@ module Shipit
       original_merge_requested_at = @pr.merge_requested_at
       @pr.reject!('merge_conflict')
       assert_predicate @pr, :rejected?
-      PullRequest.request_merge!(@stack, @pr.number, @user)
+      PullRequest.request_merge!(@stack, @pr.number, @user, nil)
       assert_predicate @pr.reload, :pending?
       assert_not_equal original_merge_requested_at, @pr.merge_requested_at
       assert_in_delta Time.now.utc, @pr.merge_requested_at, 2
@@ -47,7 +47,7 @@ module Shipit
       original_merge_requested_at = @pr.merge_requested_at
       @pr.revalidate!
       assert_predicate @pr, :revalidating?
-      PullRequest.request_merge!(@stack, @pr.number, @user)
+      PullRequest.request_merge!(@stack, @pr.number, @user, nil)
       assert_predicate @pr.reload, :pending?
       assert_equal original_merge_requested_at, @pr.merge_requested_at
     end


### PR DESCRIPTION
Button:

![image](https://user-images.githubusercontent.com/9454024/55815397-4cc86b80-5abe-11e9-8b22-1266fa077763.png)


On undeployed commits list:

![image](https://user-images.githubusercontent.com/9454024/55744632-65c01680-5a03-11e9-81c2-391bf189f12b.png)

Shipit stack:

![image](https://user-images.githubusercontent.com/9454024/55744376-c69b1f00-5a02-11e9-8bf4-9b5033ee756a.png)

In this case, `add ergodox config` is the deploy which contains a unrollbackable commit. This means that we can rollback **to** this revision, but any rollback attempt on an older revision will result in the following screen:

![image](https://user-images.githubusercontent.com/9454024/55744551-31e4f100-5a03-11e9-804e-1f2acb756d94.png)


Imo we should always give developers the option to rollback a commit even if it's marked as unsafe, because it's possible that it was marked as unsafe wrongly. At the same time, we should raise sufficient alarms so that these actions are performed with the right information. Any thoughts on the above ui/experience? Should we make it louder?

cc @Shopify/pipeline 