### PR TITLE
Display deploying commits separately from undeployed commits

### DIFF
--- a/app/controllers/shipit/stacks_controller.rb
+++ b/app/controllers/shipit/stacks_controller.rb
@@ -17,7 +17,10 @@ module Shipit
       return if flash.empty? && !stale?(last_modified: @stack.updated_at)
 
       @tasks = @stack.tasks.order(id: :desc).preload(:since_commit, :until_commit, :user).limit(10)
-      @commits = @stack.undeployed_commits { |scope| scope.preload(:author, :statuses, :check_runs) }
+      @undeployed_commits = @stack.undeployed_commits(exclude_active: true) do |scope|
+        scope.preload(:author, :statuses, :check_runs)
+      end
+      @active_commits = @stack.active_commits { |scope| scope.preload(:author, :statuses, :check_runs) }
     end
 
     def lookup

--- a/app/models/shipit/commit.rb
+++ b/app/models/shipit/commit.rb
@@ -47,6 +47,11 @@ module Shipit
       where('id < ?', commit.try(:id) || commit)
     end
 
+    def self.since(commit)
+      return all unless commit
+      where('id >= ?', commit.try(:id) || commit)
+    end
+
     def self.until(commit)
       return all unless commit
       where('id <= ?', commit.try(:id) || commit)

--- a/app/models/shipit/commit.rb
+++ b/app/models/shipit/commit.rb
@@ -169,6 +169,18 @@ module Shipit
 
     delegate :pending?, :success?, :error?, :failure?, :blocking?, :state, to: :status
 
+    def active?
+      return false unless stack.active_task?
+
+      active_task = stack.active_task
+
+      if active_task.since_commit == active_task.until_commit
+        id == active_task.since_commit.id
+      else
+        id > active_task.since_commit.id && id <= active_task.until_commit.id
+      end
+    end
+
     def deployable?
       !locked? && (stack.ignore_ci? || (success? && !blocked?))
     end

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -254,16 +254,15 @@ module Shipit
     def active_commits
       return [] unless active_task?
 
-      scope = commits.reachable.until(active_task.until_commit)
-      scope = if active_task.since_commit == active_task.until_commit
-                scope.since(active_task.since_commit)
-              else
-                scope.newer_than(active_task.since_commit)
-              end
+      scope = commits.reachable
+                     .since(active_task.since_commit)
+                     .until(active_task.until_commit)
 
       yield scope if block_given?
 
-      scope.map.with_index { |c, i| UndeployedCommit.new(c, i) }.reverse
+      scope.select(&:active?)
+           .map.with_index { |c, i| UndeployedCommit.new(c, i) }
+           .reverse
     end
 
     def undeployed_commits(exclude_active: false)

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -251,8 +251,25 @@ module Shipit
       end
     end
 
-    def undeployed_commits
+    def active_commits
+      return [] unless active_task?
+
+      scope =
+        commits
+        .reachable
+        .newer_than(active_task.since_commit)
+        .until(active_task.until_commit)
+      yield scope if block_given?
+      scope.map.with_index { |c, i| UndeployedCommit.new(c, i) }.reverse
+    end
+
+    def undeployed_commits(exclude_active: false)
       scope = commits.reachable.newer_than(last_deployed_commit).order(id: :asc)
+
+      if exclude_active && active_task?
+        scope = scope.newer_than(active_task.until_commit)
+      end
+
       yield scope if block_given?
       scope.map.with_index { |c, i| UndeployedCommit.new(c, i) }.reverse
     end

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -254,12 +254,15 @@ module Shipit
     def active_commits
       return [] unless active_task?
 
-      scope =
-        commits
-        .reachable
-        .newer_than(active_task.since_commit)
-        .until(active_task.until_commit)
+      scope = commits.reachable.until(active_task.until_commit)
+      scope = if active_task.since_commit == active_task.until_commit
+                scope.since(active_task.since_commit)
+              else
+                scope.newer_than(active_task.since_commit)
+              end
+
       yield scope if block_given?
+
       scope.map.with_index { |c, i| UndeployedCommit.new(c, i) }.reverse
     end
 

--- a/app/models/shipit/undeployed_commit.rb
+++ b/app/models/shipit/undeployed_commit.rb
@@ -35,12 +35,22 @@ module Shipit
     end
 
     def deploy_discouraged?
-      stack.maximum_commits_per_deploy && index >= stack.maximum_commits_per_deploy
+      maximum_commits_per_deploy_reached?
+    end
+
+    def deploy_scheduled?
+      stack.continuous_deployment && !maximum_commits_per_deploy_reached? && !active?
     end
 
     def blocked?
       return @blocked if defined?(@blocked)
       @blocked = super
+    end
+
+    private
+
+    def maximum_commits_per_deploy_reached?
+      stack.maximum_commits_per_deploy && index >= stack.maximum_commits_per_deploy
     end
   end
 end

--- a/app/views/shipit/commits/_commit.html.erb
+++ b/app/views/shipit/commits/_commit.html.erb
@@ -17,6 +17,11 @@
       <p class="commit-meta">
         <%= timeago_tag(commit.committed_at, force: true) %>
       </p>
+      <% if commit.deploy_scheduled? %>
+        <p class="commit-meta">
+	  <span class="scheduled">expected to be deployed next</span>
+        </p>
+      <% end %>
     </div>
     <div class="commit-lock" >
       <%= link_to stack_commit_path(commit.stack, commit), class: 'action-lock-commit', data: {tooltip: t('commit.lock')} do %>

--- a/app/views/shipit/stacks/show.html.erb
+++ b/app/views/shipit/stacks/show.html.erb
@@ -17,7 +17,16 @@
       </div>
     </header>
     <ul class="commit-list">
-      <%= render partial: 'shipit/commits/commit', collection: @commits %>
+      <%= render partial: 'shipit/commits/commit', collection: @undeployed_commits %>
+    </ul>
+  </section>
+
+  <section>
+    <header class="section-header">
+      <h2>Currently Deploying Commits</h2>
+    </header>
+    <ul class="commit-list">
+      <%= render partial: 'shipit/commits/commit', collection: @active_commits %>
     </ul>
   </section>
 

--- a/test/fixtures/shipit/commits.yml
+++ b/test/fixtures/shipit/commits.yml
@@ -246,3 +246,55 @@ canaries_fifth:
   additions: 1
   deletions: 24
   updated_at: <%= 8.days.ago.to_s(:db) %>
+
+undeployed_1:
+  id: 401
+  sha: 4d9278037b872fd9a6690523e411ecb3aa181355
+  message: "lets go"
+  stack: shipit_undeployed
+  author: walrus
+  committer: walrus
+  authored_at: <%= 10.days.ago.to_s(:db) %>
+  committed_at: <%= 9.days.ago.to_s(:db) %>
+  additions: 42
+  deletions: 24
+  updated_at: <%= 8.days.ago.to_s(:db) %>
+
+undeployed_2:
+  id: 402
+  sha: 4890fd8b5f2be05d1fedb763a3605ee461c39074
+  message: "sheep it!"
+  stack: shipit_undeployed
+  author: walrus
+  committer: walrus
+  authored_at: <%= 8.days.ago.to_s(:db) %>
+  committed_at: <%= 7.days.ago.to_s(:db) %>
+  additions: 1
+  deletions: 1
+  updated_at: <%= 8.days.ago.to_s(:db) %>
+
+undeployed_3:
+  id: 403
+  sha: 467578b362bf2b4df5903e1c7960929361c39074
+  message: "fix it!"
+  stack: shipit_undeployed
+  author: walrus
+  committer: walrus
+  authored_at: <%= 6.days.ago.to_s(:db) %>
+  committed_at: <%= 5.days.ago.to_s(:db) %>
+  additions: 12
+  deletions: 64
+  updated_at: <%= 8.days.ago.to_s(:db) %>
+
+undeployed_4:
+  id: 404
+  sha: 447578b362bf2b4df5903e1c7960929361c3435a
+  message: "Merge pull request #7 from shipit-engine/yoloshipit\n\nyoloshipit!"
+  stack: shipit_undeployed
+  author: walrus
+  committer: walrus
+  authored_at: <%= 4.days.ago.to_s(:db) %>
+  committed_at: <%= 3.days.ago.to_s(:db) %>
+  additions: 420
+  deletions: 342
+  updated_at: <%= 8.days.ago.to_s(:db) %>

--- a/test/fixtures/shipit/commits.yml
+++ b/test/fixtures/shipit/commits.yml
@@ -298,3 +298,16 @@ undeployed_4:
   additions: 420
   deletions: 342
   updated_at: <%= 8.days.ago.to_s(:db) %>
+
+single:
+  id: 501
+  sha: 547578b362bf2b4df5903e1c7960929361c3435a
+  message: "first commit"
+  stack: shipit_single
+  author: walrus
+  committer: walrus
+  authored_at: <%= 4.days.ago.to_s(:db) %>
+  committed_at: <%= 3.days.ago.to_s(:db) %>
+  additions: 420
+  deletions: 342
+  updated_at: <%= 8.days.ago.to_s(:db) %>

--- a/test/fixtures/shipit/stacks.yml
+++ b/test/fixtures/shipit/stacks.yml
@@ -5,8 +5,8 @@ shipit:
   branch: master
   ignore_ci: false
   merge_queue_enabled: true
-  tasks_count: 3
-  undeployed_commits_count: 1
+  tasks_count: 8
+  undeployed_commits_count: 2
   cached_deploy_spec: >
     {
       "machine": {"environment": {}},

--- a/test/fixtures/shipit/stacks.yml
+++ b/test/fixtures/shipit/stacks.yml
@@ -280,3 +280,41 @@ shipit_undeployed:
     }
   last_deployed_at: <%= 8.days.ago.to_s(:db) %>
   updated_at: <%= 8.days.ago.to_s(:db) %>
+
+shipit_single:
+  repo_owner: "shopify"
+  repo_name: "shipit-engine"
+  environment: "single"
+  branch: master
+  ignore_ci: false
+  merge_queue_enabled: true
+  tasks_count: 2
+  undeployed_commits_count: 1
+  cached_deploy_spec: >
+    {
+      "machine": {"environment": {}},
+      "review": {
+        "checklist": ["foo", "bar", "baz"],
+        "monitoring": [
+          {"image": "https://example.com/monitor.png", "width": 200, "height": 300}
+        ]
+      },
+      "dependencies": {"override": []},
+      "deploy": {"override": null},
+      "rollback": {"override": ["echo 'Rollback!'"]},
+      "fetch": ["echo '42'"],
+      "tasks": {
+        "restart": {
+          "action": "Restart application",
+          "description": "Restart app and job servers",
+          "steps": [
+            "cap $ENVIRONMENT deploy:restart"
+          ]
+        }
+      },
+      "ci": {
+        "blocking": ["soc/compliance"]
+      }
+    }
+  updated_at: <%= 8.days.ago.to_s(:db) %>
+  last_deployed_at: <%= 8.days.ago.to_s(:db) %>

--- a/test/fixtures/shipit/stacks.yml
+++ b/test/fixtures/shipit/stacks.yml
@@ -225,3 +225,58 @@ check_runs:
   branch: master
   tasks_count: 0
   undeployed_commits_count: 1
+
+shipit_undeployed:
+  repo_owner: "shopify"
+  repo_name: "shipit-engine"
+  environment: "undeployed"
+  branch: master
+  ignore_ci: false
+  merge_queue_enabled: true
+  tasks_count: 2
+  undeployed_commits_count: 3
+  cached_deploy_spec: >
+    {
+      "machine": {"environment": {}},
+      "review": {
+        "checklist": ["foo", "bar", "baz"],
+        "monitoring": [
+          {"image": "https://example.com/monitor.png", "width": 200, "height": 300}
+        ]
+      },
+      "dependencies": {"override": []},
+      "deploy": {"override": null, "interval": 60, "max_commits": 3, "variables": [{"name": "SAFETY_DISABLED", "title": "Set to 1 to do dangerous things", "default": 0}]},
+      "rollback": {"override": ["echo 'Rollback!'"]},
+      "fetch": ["echo '42'"],
+      "tasks": {
+        "restart": {
+          "action": "Restart application",
+          "description": "Restart app and job servers",
+          "variables": [
+            {"name": "FOO", "title": "Set to 0 to foo", "default": 1},
+            {"name": "BAR", "title": "Set to 1 to bar", "default": 0},
+            {"name": "WALRUS", "title": "Walrus without a default value"}
+          ],
+          "steps": [
+            "cap $ENVIRONMENT deploy:restart"
+          ]
+        },
+        "flush_cache": {
+          "action": "Flush cache",
+          "description": "Flush the application cache",
+          "steps": [
+            "cap $ENVIRONMENT cache:flush"
+          ],
+          "allow_concurrency": true
+        }
+      },
+      "merge": {
+        "revalidate_after": 900
+      },
+      "ci": {
+        "hide": ["ci/hidden"],
+        "allow_failures": ["ci/ok_to_fail"]
+      }
+    }
+  last_deployed_at: <%= 8.days.ago.to_s(:db) %>
+  updated_at: <%= 8.days.ago.to_s(:db) %>

--- a/test/fixtures/shipit/stacks.yml
+++ b/test/fixtures/shipit/stacks.yml
@@ -62,6 +62,7 @@ shipit_canaries:
   merge_queue_enabled: true
   tasks_count: 3
   undeployed_commits_count: 1
+  continuous_deployment: true
   cached_deploy_spec: >
     {
       "machine": {"environment": {}},
@@ -235,6 +236,7 @@ shipit_undeployed:
   merge_queue_enabled: true
   tasks_count: 2
   undeployed_commits_count: 3
+  continuous_deployment: true
   cached_deploy_spec: >
     {
       "machine": {"environment": {}},

--- a/test/fixtures/shipit/tasks.yml
+++ b/test/fixtures/shipit/tasks.yml
@@ -264,3 +264,17 @@ shipit_undeployed_2:
   created_at: <%= (60 - 2).minutes.ago.to_s(:db) %>
   started_at: <%= (60 - 2).minutes.ago.to_s(:db) %>
   ended_at: <%= (60 - 4).minutes.ago.to_s(:db) %>
+
+shipit_single:
+  id: 301
+  user: walrus
+  since_commit_id: 501
+  until_commit_id: 501
+  type: Shipit::Deploy
+  stack: shipit_single
+  status: running
+  additions: 12
+  deletions: 64
+  created_at: <%= (60 - 2).minutes.ago.to_s(:db) %>
+  started_at: <%= (60 - 2).minutes.ago.to_s(:db) %>
+  ended_at: <%= (60 - 4).minutes.ago.to_s(:db) %>

--- a/test/fixtures/shipit/tasks.yml
+++ b/test/fixtures/shipit/tasks.yml
@@ -236,3 +236,31 @@ shipit_with_title_parsing_issue:
   created_at: <%= (60 - 3).minutes.ago.to_s(:db) %>
   started_at: <%= (60 - 3).minutes.ago.to_s(:db) %>
   ended_at: <%= (60 - 4).minutes.ago.to_s(:db) %>
+
+shipit_undeployed_1:
+  id: 201
+  user: walrus
+  since_commit_id: 401
+  until_commit_id: 401
+  type: Shipit::Deploy
+  stack: shipit_undeployed
+  status: success
+  additions: 1
+  deletions: 1
+  created_at: <%= (60 - 1).minutes.ago.to_s(:db) %>
+  started_at: <%= (60 - 1).minutes.ago.to_s(:db) %>
+  ended_at: <%= (60 - 3).minutes.ago.to_s(:db) %>
+
+shipit_undeployed_2:
+  id: 202
+  user: walrus
+  since_commit_id: 402
+  until_commit_id: 403
+  type: Shipit::Deploy
+  stack: shipit_undeployed
+  status: running
+  additions: 12
+  deletions: 64
+  created_at: <%= (60 - 2).minutes.ago.to_s(:db) %>
+  started_at: <%= (60 - 2).minutes.ago.to_s(:db) %>
+  ended_at: <%= (60 - 4).minutes.ago.to_s(:db) %>

--- a/test/models/commits_test.rb
+++ b/test/models/commits_test.rb
@@ -274,7 +274,7 @@ module Shipit
 
     test "#creating a commit update the undeployed_commits_count" do
       walrus = shipit_users(:walrus)
-      assert_equal 1, @stack.undeployed_commits_count
+      assert_equal 2, @stack.undeployed_commits_count
       @stack.commits.create!(
         author: walrus,
         committer: walrus,

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -696,13 +696,24 @@ module Shipit
       end
     end
 
-    test "#active_commits returns list of commits related to the stack active task" do
+    test "#active_commits returns list of commits newer than active task since commit and older or equal to active task until commit" do
       @stack = shipit_stacks(:shipit_undeployed)
       active_task = @stack.active_task
 
       @stack.active_commits.each do |c|
-        assert c.id.between?(active_task.since_commit.id, active_task.until_commit.id)
+        assert c.id > active_task.since_commit.id
+        assert c.id <= active_task.until_commit.id
       end
+    end
+
+    test "#active_commits returns list with a single commit when active task since and until commits are the same" do
+      @stack = shipit_stacks(:shipit_single)
+      active_task = @stack.active_task
+      commits = @stack.active_commits
+
+      assert_equal active_task.since_commit.id, active_task.until_commit.id
+      assert_equal 1, commits.size
+      assert_equal active_task.since_commit.id, commits[0].id
     end
   end
 end

--- a/test/models/undeployed_commits_test.rb
+++ b/test/models/undeployed_commits_test.rb
@@ -39,6 +39,46 @@ module Shipit
       assert_predicate @commit, :deploy_discouraged?
     end
 
+    test "#deploy_scheduled? returns true if the stack has continuous deployment enabled, commit index is lower then the maximum commits per deploy and commit is not part of active task" do
+      commit = UndeployedCommit.new(shipit_commits(:undeployed_4), 1)
+
+      assert_predicate commit.stack, :continuous_deployment
+      assert_equal 1, commit.index
+      assert_equal 3, commit.stack.maximum_commits_per_deploy
+      refute_predicate commit, :active?
+
+      assert_predicate commit, :deploy_scheduled?
+    end
+
+    test "#deploy_scheduled? returns false if the stack has continuous deployment enabled and commit index is equal or bigger then the maximum commits per deploy" do
+      commit = UndeployedCommit.new(shipit_commits(:undeployed_4), 3)
+
+      assert_predicate commit.stack, :continuous_deployment
+      assert_equal 3, commit.index
+      assert_equal 3, commit.stack.maximum_commits_per_deploy
+
+      refute_predicate commit, :deploy_scheduled?
+    end
+
+    test "#deploy_scheduled? returns false if the stack has continuous deployment disabled" do
+      commit = UndeployedCommit.new(shipit_commits(:cyclimse_first), 1)
+
+      refute_predicate commit.stack, :continuous_deployment
+
+      refute_predicate commit, :deploy_scheduled?
+    end
+
+    test "#deploy_scheduled? returns false if the commit is part of the active task" do
+      commit = UndeployedCommit.new(shipit_commits(:undeployed_3), 1)
+
+      assert_predicate commit.stack, :continuous_deployment
+      assert_equal 1, commit.index
+      assert_equal 3, commit.stack.maximum_commits_per_deploy
+      assert_predicate commit, :active?
+
+      refute_predicate commit, :deploy_scheduled?
+    end
+
     test "#deploy_state returns `allowed` by default" do
       assert_equal 'allowed', @commit.deploy_state
     end


### PR DESCRIPTION
## Problem

When a developer look at the list of undeployed commits it is not clear enough which of the undeployed commits are currently being deployed.

## Solution

Display deploying commits separately from undeployed commits.

## Screenshot

<img width="1046" alt="Screenshot 2019-04-05 at 12 21 56" src="https://user-images.githubusercontent.com/961874/55621923-1f6a7d80-579f-11e9-8538-0d80c73b7ec4.png">