### PR TITLE
Only mark deployable commits as expected to be deployed next

### DIFF
--- a/app/helpers/shipit/stacks_helper.rb
+++ b/app/helpers/shipit/stacks_helper.rb
@@ -3,7 +3,7 @@ module Shipit
     COMMIT_TITLE_LENGTH = 79
 
     def redeploy_button(deployed_commit)
-      commit = UndeployedCommit.new(deployed_commit, 0)
+      commit = UndeployedCommit.new(deployed_commit, index: 0)
       url = new_stack_deploy_path(commit.stack, sha: commit.sha)
       classes = %W(btn btn--primary deploy-action #{commit.state})
 

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -261,7 +261,7 @@ module Shipit
       yield scope if block_given?
 
       scope.select(&:active?)
-           .map.with_index { |c, i| UndeployedCommit.new(c, i) }
+           .map.with_index { |c, i| UndeployedCommit.new(c, index: i, next_commit_to_deploy: next_commit_to_deploy) }
            .reverse
     end
 
@@ -273,7 +273,10 @@ module Shipit
       end
 
       yield scope if block_given?
-      scope.map.with_index { |c, i| UndeployedCommit.new(c, i) }.reverse
+
+      scope.map
+           .with_index { |c, i| UndeployedCommit.new(c, index: i, next_commit_to_deploy: next_commit_to_deploy) }
+           .reverse
     end
 
     def last_completed_deploy

--- a/app/views/shipit/commits/_commit.html.erb
+++ b/app/views/shipit/commits/_commit.html.erb
@@ -17,7 +17,7 @@
       <p class="commit-meta">
         <%= timeago_tag(commit.committed_at, force: true) %>
       </p>
-      <% if commit.deploy_scheduled? %>
+      <% if commit.expected_to_be_deployed? %>
         <p class="commit-meta">
 	  <span class="scheduled">expected to be deployed next</span>
         </p>

--- a/test/fixtures/shipit/commits.yml
+++ b/test/fixtures/shipit/commits.yml
@@ -299,6 +299,19 @@ undeployed_4:
   deletions: 342
   updated_at: <%= 8.days.ago.to_s(:db) %>
 
+undeployed_5:
+  id: 405
+  sha: 457578b362bf2b4df5903e1c7960929361c3435a
+  message: "Merge pull request #7 from shipit-engine/yoloshipit\n\nyoloshipit!"
+  stack: shipit_undeployed
+  author: walrus
+  committer: walrus
+  authored_at: <%= 4.days.ago.to_s(:db) %>
+  committed_at: <%= 3.days.ago.to_s(:db) %>
+  additions: 420
+  deletions: 342
+  updated_at: <%= 8.days.ago.to_s(:db) %>
+
 single:
   id: 501
   sha: 547578b362bf2b4df5903e1c7960929361c3435a

--- a/test/fixtures/shipit/stacks.yml
+++ b/test/fixtures/shipit/stacks.yml
@@ -232,10 +232,10 @@ shipit_undeployed:
   repo_name: "shipit-engine"
   environment: "undeployed"
   branch: master
-  ignore_ci: false
+  ignore_ci: true
   merge_queue_enabled: true
   tasks_count: 2
-  undeployed_commits_count: 3
+  undeployed_commits_count: 4
   continuous_deployment: true
   cached_deploy_spec: >
     {


### PR DESCRIPTION
This PR modifies the logic used to display the message `expected to be deployed next`. From now on it is going to show this message based on the most recent deployable commit, considering the maximum commit to deploy limit.