### PR TITLE
On rollbacks, mark all later deploys as faulty

### DIFF
--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -39,6 +39,26 @@ module Shipit
 
     delegate :broadcast_update, :filter_deploy_envs, to: :stack
 
+    def self.newer_than(deploy)
+      return all unless deploy
+      where('id > ?', deploy.try(:id) || deploy)
+    end
+
+    def self.older_than(deploy)
+      return all unless deploy
+      where('id < ?', deploy.try(:id) || deploy)
+    end
+
+    def self.since(deploy)
+      return all unless deploy
+      where('id >= ?', deploy.try(:id) || deploy)
+    end
+
+    def self.until(deploy)
+      return all unless deploy
+      where('id <= ?', deploy.try(:id) || deploy)
+    end
+
     def build_rollback(user = nil, env: nil, force: false)
       Rollback.new(
         user_id: user&.id,

--- a/app/models/shipit/rollback.rb
+++ b/app/models/shipit/rollback.rb
@@ -36,9 +36,11 @@ module Shipit
 
     def update_release_status
       return unless stack.release_status?
-      return unless status == 'pending'
 
-      deploy.report_faulty!(description: "A rollback of #{stack.to_param} was triggered")
+      # When we rollback to a certain revision, assume that all later deploys were faulty
+      stack.deploys.newer_than(deploy.id).until(stack.last_completed_deploy.id).to_a.each do |deploy|
+        deploy.report_faulty!(description: "A rollback of #{stack.to_param} was triggered")
+      end
     end
 
     def lock_reverted_commits


### PR DESCRIPTION
Fixes https://github.com/Shopify/shipit/issues/675

There's two types of rollbacks:

1. Abort & rollback.
This action stops the current deploy, and then does a redeploy of the previous revision

2. Rollback _to_ a later revision
This action does a redeploy of the later revision

In both these cases, we are assuming that the revision we are going _to_ is safe, and that any later deploys are problematic. 

So, the logic here is to mark any later deploys as faulty on a rollback. This means that on abort + rollback, we mark the latest deploy as faulty, and on rollbacks to a later revision, we mark anything between the latest and the rollback-to revision as faulty.

cc @Shopify/pipeline 