### PR TITLE
Ignore active commits when finding the next expected commit to deploy

### DIFF
--- a/app/models/shipit/undeployed_commit.rb
+++ b/app/models/shipit/undeployed_commit.rb
@@ -2,10 +2,10 @@ module Shipit
   class UndeployedCommit < DelegateClass(Commit)
     attr_reader :index
 
-    def initialize(commit, index:, next_commit_to_deploy: nil)
+    def initialize(commit, index:, next_expected_commit_to_deploy: nil)
       super(commit)
       @index = index
-      @next_commit_to_deploy = next_commit_to_deploy
+      @next_expected_commit_to_deploy = next_expected_commit_to_deploy
     end
 
     def deploy_state(bypass_safeties = false)
@@ -40,11 +40,11 @@ module Shipit
     end
 
     def expected_to_be_deployed?
-      return false if @next_commit_to_deploy.nil?
+      return false if @next_expected_commit_to_deploy.nil?
       return false unless stack.continuous_deployment
       return false if active?
 
-      id <= @next_commit_to_deploy.id
+      id <= @next_expected_commit_to_deploy.id
     end
 
     def blocked?

--- a/app/views/shipit/commits/_commit.html.erb
+++ b/app/views/shipit/commits/_commit.html.erb
@@ -1,5 +1,5 @@
 <li class="commit <%= 'locked' if commit.locked? %>" id="commit-<%= commit.id %>">
-  <% cache commit do %>
+  <% cache [commit, commit.expected_to_be_deployed?] do %>
     <% cache commit.author do %>
       <%= render 'shipit/shared/author', author: commit.author %>
     <% end %>

--- a/test/fixtures/shipit/commits.yml
+++ b/test/fixtures/shipit/commits.yml
@@ -312,6 +312,32 @@ undeployed_5:
   deletions: 342
   updated_at: <%= 8.days.ago.to_s(:db) %>
 
+undeployed_6:
+  id: 406
+  sha: 467578b362bf2b4df5903e1c7960929361c3435a
+  message: "Merge pull request #7 from shipit-engine/yoloshipit\n\nyoloshipit!"
+  stack: shipit_undeployed
+  author: walrus
+  committer: walrus
+  authored_at: <%= 4.days.ago.to_s(:db) %>
+  committed_at: <%= 3.days.ago.to_s(:db) %>
+  additions: 420
+  deletions: 342
+  updated_at: <%= 8.days.ago.to_s(:db) %>
+
+undeployed_7:
+  id: 407
+  sha: 477578b362bf2b4df5903e1c7960929361c3435a
+  message: "Merge pull request #7 from shipit-engine/yoloshipit\n\nyoloshipit!"
+  stack: shipit_undeployed
+  author: walrus
+  committer: walrus
+  authored_at: <%= 4.days.ago.to_s(:db) %>
+  committed_at: <%= 3.days.ago.to_s(:db) %>
+  additions: 420
+  deletions: 342
+  updated_at: <%= 8.days.ago.to_s(:db) %>
+
 single:
   id: 501
   sha: 547578b362bf2b4df5903e1c7960929361c3435a

--- a/test/fixtures/shipit/stacks.yml
+++ b/test/fixtures/shipit/stacks.yml
@@ -235,7 +235,7 @@ shipit_undeployed:
   ignore_ci: true
   merge_queue_enabled: true
   tasks_count: 2
-  undeployed_commits_count: 4
+  undeployed_commits_count: 6
   continuous_deployment: true
   cached_deploy_spec: >
     {

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -497,6 +497,7 @@ module Shipit
       deploy = @stack.trigger_deploy(shipit_commits(:first), AnonymousUser.new)
       deploy.run!
       deploy.complete!
+      @stack.reload
 
       assert_predicate @stack, :deployable?
       assert_predicate @stack, :deployed_too_recently?

--- a/test/models/undeployed_commits_test.rb
+++ b/test/models/undeployed_commits_test.rb
@@ -39,14 +39,14 @@ module Shipit
       assert_predicate @commit, :deploy_discouraged?
     end
 
-    test "#expected_to_be_deployed? returns true if the stack has continuous deployment enabled, next commit to deploy id is greater or equals to the commit id and commit is not active" do
+    test "#expected_to_be_deployed? returns true if the stack has continuous deployment enabled, next expected commit to deploy id is greater or equals to the commit id and commit is not active" do
       commit = shipit_commits(:undeployed_4)
-      next_commit_to_deploy = commit.stack.next_commit_to_deploy
-      undeployed_commit = UndeployedCommit.new(commit, index: 1, next_commit_to_deploy: next_commit_to_deploy)
+      next_expected_commit_to_deploy = commit.stack.next_expected_commit_to_deploy
+      undeployed_commit = UndeployedCommit.new(commit, index: 1, next_expected_commit_to_deploy: next_expected_commit_to_deploy)
 
-      refute_predicate next_commit_to_deploy, :nil?
+      refute_predicate next_expected_commit_to_deploy, :nil?
       assert_predicate undeployed_commit.stack, :continuous_deployment
-      assert next_commit_to_deploy.id >= undeployed_commit.id
+      assert next_expected_commit_to_deploy.id >= undeployed_commit.id
       refute_predicate undeployed_commit, :active?
 
       assert_predicate undeployed_commit, :expected_to_be_deployed?
@@ -54,12 +54,12 @@ module Shipit
 
     test "#expected_to_be_deployed? returns false if the stack has continuous deployment disabled" do
       commit = shipit_commits(:cyclimse_first)
-      next_commit_to_deploy = commit.stack.next_commit_to_deploy
-      undeployed_commit = UndeployedCommit.new(commit, index: 1, next_commit_to_deploy: next_commit_to_deploy)
+      next_expected_commit_to_deploy = commit.stack.next_expected_commit_to_deploy
+      undeployed_commit = UndeployedCommit.new(commit, index: 1, next_expected_commit_to_deploy: next_expected_commit_to_deploy)
 
-      refute_predicate next_commit_to_deploy, :nil?
+      refute_predicate next_expected_commit_to_deploy, :nil?
       refute_predicate undeployed_commit.stack, :continuous_deployment
-      assert next_commit_to_deploy.id >= undeployed_commit.id
+      assert next_expected_commit_to_deploy.id >= undeployed_commit.id
       refute_predicate undeployed_commit, :active?
 
       refute_predicate undeployed_commit, :expected_to_be_deployed?
@@ -67,12 +67,12 @@ module Shipit
 
     test "#expected_to_be_deployed? returns false if the commit is part of the active task" do
       commit = shipit_commits(:undeployed_3)
-      next_commit_to_deploy = commit.stack.next_commit_to_deploy
-      undeployed_commit = UndeployedCommit.new(commit, index: 1, next_commit_to_deploy: next_commit_to_deploy)
+      next_expected_commit_to_deploy = commit.stack.next_expected_commit_to_deploy
+      undeployed_commit = UndeployedCommit.new(commit, index: 1, next_expected_commit_to_deploy: next_expected_commit_to_deploy)
 
-      refute_predicate next_commit_to_deploy, :nil?
+      refute_predicate next_expected_commit_to_deploy, :nil?
       assert_predicate undeployed_commit.stack, :continuous_deployment
-      assert next_commit_to_deploy.id >= undeployed_commit.id
+      assert next_expected_commit_to_deploy.id >= undeployed_commit.id
       assert_predicate undeployed_commit, :active?
 
       refute_predicate undeployed_commit, :expected_to_be_deployed?
@@ -80,20 +80,19 @@ module Shipit
 
     test "#expected_to_be_deployed? returns false if there is no commit to deploy" do
       commit = shipit_commits(:undeployed_3)
-      undeployed_commit = UndeployedCommit.new(commit, index: 1, next_commit_to_deploy: nil)
+      undeployed_commit = UndeployedCommit.new(commit, index: 1, next_expected_commit_to_deploy: nil)
 
       refute_predicate undeployed_commit, :expected_to_be_deployed?
     end
 
     test "#expected_to_be_deployed? returns false if the commit has an id greater than next commit to deploy" do
-      commit = shipit_commits(:undeployed_5)
-      next_commit_to_deploy = commit.stack.next_commit_to_deploy
-      undeployed_commit = UndeployedCommit.new(commit, index: 1, next_commit_to_deploy: next_commit_to_deploy)
+      commit = shipit_commits(:undeployed_7)
+      next_expected_commit_to_deploy = commit.stack.next_expected_commit_to_deploy
+      undeployed_commit = UndeployedCommit.new(commit, index: 1, next_expected_commit_to_deploy: next_expected_commit_to_deploy)
 
-      puts "next = #{next_commit_to_deploy.inspect}"
-      refute_predicate next_commit_to_deploy, :nil?
+      refute_predicate next_expected_commit_to_deploy, :nil?
       assert_predicate undeployed_commit.stack, :continuous_deployment
-      assert undeployed_commit.id > next_commit_to_deploy.id
+      assert undeployed_commit.id > next_expected_commit_to_deploy.id
       refute_predicate undeployed_commit, :active?
 
       refute_predicate undeployed_commit, :expected_to_be_deployed?


### PR DESCRIPTION
## Problem

When a stack has `max_commits = 3` and there are 2 commits being deployed the current logic is considering only one additional commit as expected to be deployed next, instead of 3.

## Solution

Ignore active commits when finding the next expected commit to deploy.