### PR TITLE
Expire cache of commit partial when either commit or stack change

### DIFF
--- a/app/views/shipit/commits/_commit.html.erb
+++ b/app/views/shipit/commits/_commit.html.erb
@@ -1,5 +1,5 @@
 <li class="commit <%= 'locked' if commit.locked? %>" id="commit-<%= commit.id %>">
-  <% cache commit do %>
+  <% cache [commit, commit.stack] do %>
     <% cache commit.author do %>
       <%= render 'shipit/shared/author', author: commit.author %>
     <% end %>


### PR DESCRIPTION
## Problem

Some `UndeployedCommit` predicates depend on the state of the stack to be computed. At the moment the cache expires only when the commit data changes not considering changes in the stack.

## Solution

Modify the cache key to be a composition of `commit` and `commit.stack`.