### PR TITLE
Add rake deploy command

### DIFF
--- a/app/models/shipit/command_line_user.rb
+++ b/app/models/shipit/command_line_user.rb
@@ -1,0 +1,58 @@
+module Shipit
+  class CommandLineUser
+    def present?
+      false
+    end
+
+    def email
+      'command_line@example.com'
+    end
+
+    def login
+      'command_line'
+    end
+
+    def name
+      'CommandLine'
+    end
+
+    def avatar_url
+      'https://github.com/images/error/octocat_happy.gif'
+    end
+
+    def id
+    end
+
+    def github_id
+    end
+
+    def logged_in?
+      false
+    end
+
+    def authorized?
+      Shipit.authentication_disabled?
+    end
+
+    def stacks_contributed_to
+      []
+    end
+
+    def avatar_uri
+      User::DEFAULT_AVATAR.dup
+    end
+
+    def created_at
+      Time.at(0).utc
+    end
+    alias_method :updated_at, :created_at
+
+    def read_attribute_for_serialization(attr)
+      public_send(attr)
+    end
+
+    def github_api
+      Shipit.github.api
+    end
+  end
+end

--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -176,6 +176,11 @@ module Shipit
       PerformTaskJob.perform_later(self)
     end
 
+    def run_now!
+      raise "only persisted jobs can be run" unless persisted?
+      PerformTaskJob.perform_now(self)
+    end
+
     def write(text)
       chunks.create!(text: text)
     end

--- a/app/serializers/shipit/command_line_user_serializer.rb
+++ b/app/serializers/shipit/command_line_user_serializer.rb
@@ -1,0 +1,4 @@
+module Shipit
+  class CommandLineUserSerializer < UserSerializer
+  end
+end

--- a/lib/tasks/shipit.rake
+++ b/lib/tasks/shipit.rake
@@ -1,0 +1,27 @@
+namespace :shipit do
+  desc "Deploy from a running instance. "
+  task deploy: :environment do
+    begin
+      stack = ENV['stack']
+      revision = ENV['revision']
+
+      raise ArgumentError.new('The first argument has to be a stack, e.g. shopify/shipit/production') if stack.nil?
+      raise ArgumentError.new('The second argument has to be a revision') if revision.nil?
+
+      module Shipit
+        class Task
+          def write(text)
+            p text
+            chunks.create!(text: text)
+          end
+        end
+      end
+
+      Shipit::Stack.run_deploy_in_foreground(stack: stack, revision: revision)
+    rescue ArgumentError
+      p "Use this command as follows:"
+      p "bundle exec rake shipit:deploy stack='shopify/shipit/production' revision='$SHA'"
+      raise
+    end
+  end
+end

--- a/test/models/deploys_test.rb
+++ b/test/models/deploys_test.rb
@@ -23,6 +23,16 @@ module Shipit
       assert_raise(RuntimeError) { Deploy.new.enqueue }
     end
 
+    test "run_now! when not persisted" do
+      assert_raise(RuntimeError) { Deploy.new.run_now! }
+    end
+
+    test "run_now! runs in foreground" do
+      PerformTaskJob.any_instance.expects(:perform).once
+
+      @deploy.run_now!
+    end
+
     test "working_directory" do
       assert_equal File.join(@deploy.stack.deploys_path, @deploy.id.to_s), @deploy.working_directory
     end


### PR DESCRIPTION
This command gives the ability to trigger a deploy through the command line interface when sshed into a running Shipit Instance. This is useful when the UI isn't responsive.