### PR TITLE
update PyPI discovery to use twine to upload

### DIFF
--- a/app/models/shipit/deploy_spec/pypi_discovery.rb
+++ b/app/models/shipit/deploy_spec/pypi_discovery.rb
@@ -29,7 +29,11 @@ module Shipit
       end
 
       def publish_egg
-        ["assert-egg-version-tag #{setup_dot_py}", 'python setup.py register sdist upload']
+        [
+          "assert-egg-version-tag #{setup_dot_py}",
+          'python setup.py register sdist',
+          'twine upload dist/*',
+        ]
       end
     end
   end

--- a/test/models/deploy_spec_test.rb
+++ b/test/models/deploy_spec_test.rb
@@ -323,7 +323,11 @@ module Shipit
       file = Pathname.new('/tmp/fake_setup.py')
       file.write('foo')
       @spec.stubs(:setup_dot_py).returns(file)
-      steps = ['assert-egg-version-tag /tmp/fake_setup.py', 'python setup.py register sdist upload']
+      steps = [
+        'assert-egg-version-tag /tmp/fake_setup.py',
+        'python setup.py register sdist',
+        'twine upload dist/*',
+      ]
       assert_equal steps, @spec.deploy_steps
     end
 


### PR DESCRIPTION
I'm unable to deploy shopify_python_api to PyPI. The [Python Packaging Guide](https://packaging.python.org/tutorials/packaging-projects/) now recommends using the `twine` package to upload eggs to PyPI and testing locally this seems to work fine.