### PR TITLE
Better handle Redis connection error in PerformTaskJob

### DIFF
--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -182,6 +182,12 @@ module Shipit
     end
 
     def async_refresh_deployed_revision
+      async_refresh_deployed_revision!
+    rescue => error
+      logger.warn "Failed to dispatch FetchDeployedRevisionJob: [#{error.class.name}] #{error.message}"
+    end
+
+    def async_refresh_deployed_revision!
       FetchDeployedRevisionJob.perform_later(self)
     end
 

--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -75,7 +75,13 @@ module Shipit
   end
 
   def redis(namespace = nil)
-    @redis ||= Redis.new(url: redis_url.to_s.presence, logger: Rails.logger)
+    @redis ||= Redis.new(
+      url: redis_url.to_s.presence,
+      logger: Rails.logger,
+      reconnect_attempts: 3,
+      reconnect_delay: 0.5,
+      reconnect_delay_max: 1,
+    )
     return @redis unless namespace
     Redis::Namespace.new(namespace, redis: @redis)
   end

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -716,5 +716,14 @@ module Shipit
       assert_equal 1, commits.size
       assert_equal active_task.since_commit.id, commits[0].id
     end
+
+    test "#async_refresh_deployed_revision suppresses and logs raised exception" do
+      error_message = "Error message"
+
+      Rails.logger.expects(:warn).with("Failed to dispatch FetchDeployedRevisionJob: [StandardError] #{error_message}")
+      @stack.expects(:async_refresh_deployed_revision!).raises(StandardError.new(error_message))
+
+      @stack.async_refresh_deployed_revision
+    end
   end
 end


### PR DESCRIPTION
This PR covers the issue #876 by:

- Preventing `async_refresh_deployed_version` to fail when trying to dispatch a job (when this method fails the task status transition to `error` is rolled back);
- Increasing the number of redis connections retries (from 1 to 3);
- Adding support to delayed redis connections retries (when using redis client version 4.0.3+);
