### PR TITLE
Fix overflow settings for commit details.

### DIFF
--- a/app/assets/stylesheets/_pages/_commits.scss
+++ b/app/assets/stylesheets/_pages/_commits.scss
@@ -77,6 +77,8 @@
     margin-bottom: 1rem;
     order: -1;
   }
+
+  @include truncate;
 }
 
 .commit-title {

--- a/app/helpers/shipit/stacks_helper.rb
+++ b/app/helpers/shipit/stacks_helper.rb
@@ -1,7 +1,5 @@
 module Shipit
   module StacksHelper
-    COMMIT_TITLE_LENGTH = 79
-
     def redeploy_button(deployed_commit)
       commit = UndeployedCommit.new(deployed_commit, index: 0)
       url = new_stack_deploy_path(commit.stack, sha: commit.sha)
@@ -46,7 +44,7 @@ module Shipit
     end
 
     def render_commit_message(pull_request_or_commit)
-      message = pull_request_or_commit.title.to_s.truncate(COMMIT_TITLE_LENGTH)
+      message = pull_request_or_commit.title.to_s
       content_tag(:span, emojify(message), class: 'event-message')
     end
 


### PR DESCRIPTION
Co-authored-by: Manon Deloupy <manon.deloupy@shopify.com>

### Summary
We don't need to truncate and add ellipsis in code. Our suspicion is that this is happening because the elements involved are not block elements.

### Before

<img width="1134" alt="Screen Shot 2019-04-30 at 3 10 24 PM" src="https://user-images.githubusercontent.com/26002/56986950-285e2d00-6b5a-11e9-969c-aa7c85c3c437.png">

### After
<img width="1053" alt="Screen Shot 2019-04-30 at 3 10 41 PM" src="https://user-images.githubusercontent.com/26002/56986949-285e2d00-6b5a-11e9-8aee-04e099dbf374.png">
