### PR TITLE
Remove global `Process.kill` stub in tests

### DIFF
--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -42,7 +42,6 @@ class ActiveSupport::TestCase
 
   setup do
     @routes = Shipit::Engine.routes
-    Process.stubs(:kill)
     Shipit.github.api.stubs(:login).returns('shipit')
   end
 


### PR DESCRIPTION
I lost a bunch of time to this while working on #882, and the suite is green without it so let's 🔥 