### PR TITLE
Report signalled commands

### DIFF
--- a/lib/shipit/command.rb
+++ b/lib/shipit/command.rb
@@ -23,7 +23,7 @@ module Shipit
       end
     end
 
-    attr_reader :out, :code, :chdir, :env, :args, :pid, :timeout
+    attr_reader :out, :chdir, :env, :args, :pid, :timeout
 
     def initialize(*args, default_timeout: Shipit.default_inactivity_timeout, env: {}, chdir:)
       @args, options = parse_arguments(args)
@@ -58,7 +58,7 @@ module Shipit
     end
 
     def exit_message
-      "#{self} exited with status #{@code}"
+      "#{self} #{termination_status}"
     end
 
     def run
@@ -107,16 +107,15 @@ module Shipit
       begin
         read_stream(@out, &block)
       rescue TimedOut => error
-        @code = 'timeout'
         yield red("No output received in the last #{timeout} seconds.") + "\n"
         terminate!(&block)
         raise error
       rescue Errno::EIO # Somewhat expected on Linux: http://stackoverflow.com/a/10306782
       end
 
-      _, status = Process.waitpid2(@pid)
-      @code = status.exitstatus
       self
+    ensure
+      reap_child!
     end
 
     def red(text)
@@ -183,18 +182,18 @@ module Shipit
       rescue TimedOut
       rescue Errno::EIO # EIO is somewhat expected on Linux: http://stackoverflow.com/a/10306782
         # If we try to read the stream right after sending a signal, we often get an Errno::EIO.
-        if status = Process.wait(@pid, Process::WNOHANG)
-          return status
-        else
-          # If we let the child a little bit of time, it solves it.
-          retry_count -= 1
-          if retry_count > 0
-            sleep 0.05
-            retry
-          end
+        if reap_child!(block: false)
+          return true
+        end
+        # If we let the child a little bit of time, it solves it.
+        retry_count -= 1
+        if retry_count > 0
+          sleep 0.05
+          retry
         end
       end
-      Process.wait(@pid, Process::WNOHANG)
+      reap_child!(block: false)
+      true
     end
 
     def kill(sig)
@@ -214,6 +213,41 @@ module Shipit
         end
       end
       return args, options
+    end
+
+    def running?
+      !!pid && !@status
+    end
+
+    def code
+      @status&.exitstatus
+    end
+
+    def signaled?
+      @status.signaled?
+    end
+
+    def reap_child!(block: true)
+      return @status if @status
+      return unless running? # Command was never started e.g. permission denied, not found etc
+      if block
+        _, @status = Process.waitpid2(@pid)
+      elsif res = Process.waitpid2(@pid, Process::WNOHANG)
+        @status = res[1]
+      end
+      @status
+    end
+
+    def termination_status
+      if running?
+        "is running"
+      elsif success?
+        "terminated successfully"
+      elsif signaled?
+        "terminated with #{Signal.signame(@status.termsig)} signal"
+      else
+        "terminated with exit status #{code}"
+      end
     end
   end
 end

--- a/test/unit/command_test.rb
+++ b/test/unit/command_test.rb
@@ -66,5 +66,54 @@ module Shipit
       end
       assert_equal '/etc/passwd: Permission denied', error.message
     end
+
+    test 'sets code and message correctly on success' do
+      command = Command.new('true', chdir: '.')
+      assert_nil command.code
+      command.run
+      refute_predicate command, :running?
+      assert_predicate command.code, :zero?
+      assert_equal 'terminated successfully', command.termination_status
+    end
+
+    test 'sets code and message correctly on error' do
+      command = Command.new('false', chdir: '.')
+      assert_nil command.code
+      command.run
+      refute_predicate command, :running?
+      assert_predicate command.code, :nonzero?
+      assert_equal 'terminated with exit status 1', command.termination_status
+    end
+
+    test 'handles externally signalled commands correctly' do
+      command = Command.new('sleep 10', chdir: '.')
+      t = Thread.new do
+        signalled = false
+        20.times do
+          if command.running?
+            Process.kill('KILL', command.pid)
+            signalled = true
+            break
+          end
+          sleep 0.1
+        end
+        signalled
+      end
+      command.run
+      assert t.join, "subprocess wasn't signalled"
+      assert_predicate command, :signaled?
+      refute_predicate command, :running?
+      assert_nil command.code
+      assert_equal 'terminated with KILL signal', command.termination_status
+    end
+
+    test 'reports timedout command correctly' do
+      command = Command.new('sleep 10', chdir: '.', default_timeout: 0.5)
+      assert_raises(Command::TimedOut) { command.run }
+      assert_predicate command, :signaled?
+      refute_predicate command, :running?
+      assert_nil command.code
+      assert_equal 'terminated with INT signal', command.termination_status
+    end
   end
 end


### PR DESCRIPTION
Closes #882 

The purpose of this change is to have `exit_message` show something meaningful when a command is signalled to exit. 
