### PR TITLE
Ensure that the Abort & Rollback button does not rollback to faulty deploys.

### DIFF
--- a/app/helpers/shipit/github_url_helper.rb
+++ b/app/helpers/shipit/github_url_helper.rb
@@ -55,5 +55,11 @@ module Shipit
       text = deploy.commit_range.map(&:short_sha).join('...')
       link_to(text, url, class: 'number')
     end
+
+    def link_to_github_range(stack, since_commit, until_commit)
+      url = github_commit_range_url(stack, since_commit, until_commit)
+      text = [since_commit, until_commit].map(&:short_sha).join('...')
+      link_to(text, url, class: 'number')
+    end
   end
 end

--- a/app/helpers/shipit/github_url_helper.rb
+++ b/app/helpers/shipit/github_url_helper.rb
@@ -55,11 +55,5 @@ module Shipit
       text = deploy.commit_range.map(&:short_sha).join('...')
       link_to(text, url, class: 'number')
     end
-
-    def link_to_github_range(stack, since_commit, until_commit)
-      url = github_commit_range_url(stack, since_commit, until_commit)
-      text = [since_commit, until_commit].map(&:short_sha).join('...')
-      link_to(text, url, class: 'number')
-    end
   end
 end

--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -85,16 +85,19 @@ module Shipit
       rollback
     end
 
-    # Rolls the stack back to the **previous** deploy
+    # Rolls the stack back to the most recent **previous** successful deploy
     def trigger_revert(force: false)
+      previous_success = stack.previous_successful_deploy_commit(id)
+
       rollback = Rollback.create!(
         user_id: user_id,
         stack_id: stack_id,
         parent_id: id,
         since_commit: until_commit,
-        until_commit: since_commit,
+        until_commit: previous_success,
         allow_concurrency: force,
       )
+
       rollback.enqueue
       lock_reason = "A rollback for #{until_commit.sha} has been triggered. " \
         "Please make sure the reason for the rollback has been addressed before deploying again."

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -284,12 +284,20 @@ module Shipit
       deploys_and_rollbacks.last_completed
     end
 
+    def previous_successful_deploy(deploy_id)
+      deploys_and_rollbacks.previous_successful(deploy_id)
+    end
+
     def last_active_task
       tasks.exclusive.last
     end
 
     def last_deployed_commit
       last_completed_deploy&.until_commit || NoDeployedCommit
+    end
+
+    def previous_successful_deploy_commit(deploy_id)
+      previous_successful_deploy(deploy_id)&.until_commit || NoDeployedCommit
     end
 
     def deployable?

--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -47,6 +47,10 @@ module Shipit
         completed.last
       end
 
+      def previous_successful(deploy_id)
+        success.where("id < #{deploy_id}").last
+      end
+
       def current
         active.exclusive.last
       end

--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -47,8 +47,8 @@ module Shipit
         completed.last
       end
 
-      def previous_successful(deploy_id)
-        success.where("id < #{deploy_id}").last
+      def previous_successful(id)
+        success.where('id < ?', id).last
       end
 
       def current
@@ -233,6 +233,10 @@ module Shipit
 
     def supports_rollback?
       false
+    end
+
+    def previous_successful
+      self.class.previous_successful(id)
     end
 
     def title

--- a/app/views/shipit/tasks/_task_output.html.erb
+++ b/app/views/shipit/tasks/_task_output.html.erb
@@ -34,6 +34,7 @@
           <span class="caption--ready">Abort and Rollback</span>
           <span class="caption--pending">Aborting with Rollback...</span>
         <% end %>
+        <span class="deploy-status">to <span class="short-sha"><%= short_commit_sha(task) %></span></span>
       <% end %>
     </div>
   </div>

--- a/test/models/deploys_test.rb
+++ b/test/models/deploys_test.rb
@@ -331,12 +331,148 @@ module Shipit
       assert_equal shipit_commits(:second), @stack.last_deployed_commit
     end
 
+    def create_test_stack(stack_id)
+      Shipit::Stack.create(
+        repo_owner: "shopify-test",
+        repo_name: "shipit-engine-test",
+        environment: 'production',
+        branch: "master",
+        merge_queue_enabled: true,
+        created_at: "2019-01-01 00:00:00",
+        updated_at: "2019-01-02 10:10:10",
+        id: stack_id,
+      )
+    end
+
+    def create_test_commit(id:, stack_id:, user_id:)
+      Shipit::Commit.new(
+        id: id,
+        stack_id: stack_id,
+        author_id: user_id,
+        sha: SecureRandom.hex(20),
+        additions: 2,
+        deletions: 0,
+        committer_id: user_id,
+        message: "Some commit message.",
+        authored_at: "2019-01-02 10:11:10",
+        committed_at: "2019-01-02 10:11:10",
+      )
+    end
+
+    def create_test_status(id:, commit_id:, stack_id:, state: "success")
+      Shipit::Status.new(
+        id: id,
+        description: "Description for commit #{commit_id}",
+        stack_id: stack_id,
+        commit_id: commit_id,
+        state: state,
+      )
+    end
+
+    def create_test_deploy(deploy_id:, stack_id:, user_id:, since_commit_id:, until_commit_id: since_commit_id)
+      Shipit::Deploy.new(
+        id: deploy_id,
+        stack_id: stack_id,
+        user_id: user_id,
+        since_commit_id: since_commit_id,
+        until_commit_id: until_commit_id,
+        status: "success",
+        type: "Shipit::Deploy",
+      )
+    end
+
     test "#trigger_revert rolls the stack back to before this deploy" do
-      assert_equal shipit_commits(:fourth), @stack.last_deployed_commit
-      rollback = @deploy.trigger_revert
+      stack_id = 1969
+      user_id = @user.id
+      test_stack = create_test_stack(stack_id)
+      test_stack.save
+      starting_commit_id = Shipit::Commit.last.id + 1
+
+      # Create valid commit history for the stack. We need several commits to deploy and roll back through.
+      commit_ids = (starting_commit_id..starting_commit_id + 3).to_a
+      commit_ids.each { |commit_id| create_test_commit(id: commit_id, stack_id: stack_id, user_id: user_id).save }
+      commit_ids.each_with_index { |commit_id, index| create_test_status(id: index + 1, commit_id: commit_id, stack_id: stack_id, state: "success").save }
+
+      # Three deploys of commits 1-2, 2-3 and 3-4 respectively. Reverting last should result in Deploy 3 (commit 3) being latest.
+      starting_task_id = Shipit::Task.last.id + 1
+      (starting_task_id..starting_task_id + 2).each_with_index { |task_id, index| create_test_deploy(deploy_id: task_id, stack_id: stack_id, user_id: user_id, since_commit_id: commit_ids[index], until_commit_id: commit_ids[index + 1]).save }
+
+      # Get the reference with Rails-mutated field values.
+      commit3 = Shipit::Commit.second_to_last
+      commit4 = Shipit::Commit.last
+      deploy3 = Shipit::Deploy.last
+
+      assert_equal commit4, test_stack.last_deployed_commit
+
+      deploy_to_revert = test_stack.deploys.last
+
+      assert_equal deploy3, deploy_to_revert
+
+      rollback = deploy_to_revert.trigger_revert
       rollback.run!
       rollback.complete!
-      assert_equal shipit_commits(:first), @stack.last_deployed_commit
+
+      last_deploy = test_stack.last_completed_deploy
+
+      assert_equal commit3, test_stack.last_deployed_commit
+      assert_equal commit3, last_deploy.until_commit
+      assert_equal "Shipit::Rollback", last_deploy.type
+    end
+
+    test "#trigger_revert skips unsuccessful deploys when reverting" do
+      stack_id = 1969
+      user_id = @user.id
+      test_stack = create_test_stack(stack_id)
+      test_stack.save
+      starting_commit_id = Shipit::Commit.last.id + 1
+
+      commit_ids = (starting_commit_id..starting_commit_id + 3).to_a
+      commit_ids.each { |commit_id| create_test_commit(id: commit_id, stack_id: stack_id, user_id: user_id).save }
+      commit_ids.each_with_index { |commit_id, index| create_test_status(id: index + 1, commit_id: commit_id, stack_id: stack_id, state: "success").save }
+
+      # We want the following order of Deploys:
+      # 1. Success (commits 1-2)
+      # 2. Faulty (commits 2-3)
+      # 3. Rollback to Success (-> commits 1-2)
+      # 4. Running (commits 3-4)
+      # 5. Reversion of the running deploy to the last successful deploy. (-> commits 1-2, i.e. the successful deploy.)
+
+      starting_task_id = Shipit::Task.last.id + 1
+      deploy1 = create_test_deploy(deploy_id: starting_task_id, stack_id: stack_id, user_id: user_id, since_commit_id: commit_ids[0], until_commit_id: commit_ids[1])
+      deploy1.save
+
+      deploy2 = create_test_deploy(deploy_id: starting_task_id + 1, stack_id: stack_id, user_id: user_id, since_commit_id: commit_ids[1], until_commit_id: commit_ids[2])
+      deploy2.status = "faulty"
+      deploy2.save
+
+      rollback = test_stack.deploys.second_to_last.trigger_rollback(@user)
+      rollback.run!
+      rollback.complete!
+
+      assert_equal commit_ids[1], test_stack.last_deployed_commit.id
+
+      deploy3 = create_test_deploy(deploy_id: starting_task_id + 3, stack_id: stack_id, user_id: user_id, since_commit_id: commit_ids[2], until_commit_id: commit_ids[3])
+      deploy3.status = "running"
+      deploy3.rollback_once_aborted = false
+      deploy3.save
+
+      running_deploy = deploy3.reload
+      running_deploy.abort!(aborted_by: @user)
+
+      assert_equal "error", running_deploy.status
+
+      final_rollback = running_deploy.trigger_revert
+      final_rollback.run!
+      final_rollback.complete!
+
+      last_deploy = test_stack.last_completed_deploy
+
+      # The rollback deploy should be from the last commit until the second commit.
+      assert_equal "success", last_deploy.status
+      assert_equal "Shipit::Rollback", last_deploy.type
+      assert_equal commit_ids[-1], last_deploy.since_commit_id
+      assert_equal commit_ids[1], last_deploy.until_commit_id
+      assert_equal commit_ids[1], test_stack.last_deployed_commit.id
     end
 
     test "#trigger_rollback creates a new Rollback" do


### PR DESCRIPTION
## Issue

Currently, when the `Abort & Rollback` button is used, it triggers a revert path that will roll back to the immediately previous deploy.

However, it's possible that the previous deploy(s) are themselves faulty. As a common use case of rolling back is to bail out of a deploy and to go back to a prior success, it's more desirable to roll back to the nearest prior successful deploy/commit.

This isn't an issue for manual rollbacks as we only expose the rollback button on valid prior deploys to begin with, and it's next to each individual deploy, making it unambiguous as to what you would be rolling back to.

---

## Changes

This PR changes the Abort & Rollback button (and its underlying trigger_revert method) to skip unsuccessful deploys when selecting the `until_commit` to roll back to.

To make the overall behaviour more obvious to the user, I've also added text to the task output page next to the Abort & Rollback button, which shows and links the `From...To` commit range that would be deployed if the button is pressed.

This should help to resolve https://github.com/Shopify/shipit/issues/577