### PR TITLE
Remove commit count warning

### DIFF
--- a/app/helpers/shipit/merge_status_helper.rb
+++ b/app/helpers/shipit/merge_status_helper.rb
@@ -1,7 +1,0 @@
-module Shipit
-  module MergeStatusHelper
-    def too_many_commits?(commits)
-      commits > 4
-    end
-  end
-end

--- a/app/helpers/shipit/merge_status_helper.rb
+++ b/app/helpers/shipit/merge_status_helper.rb
@@ -1,0 +1,7 @@
+module Shipit
+  module MergeStatusHelper
+    def display_commit_count_warning?(commits)
+      commits > 4 && @stack.merge_queue_enabled?
+    end
+  end
+end

--- a/app/views/shipit/merge_status/_commit_count_warning.html.erb
+++ b/app/views/shipit/merge_status/_commit_count_warning.html.erb
@@ -1,0 +1,4 @@
+<p class="status-heading text-red">
+  <%= render 'warning_icon' %>
+  Consider rebasing into a smaller number of commits containing atomic changes.
+</p>

--- a/app/views/shipit/merge_status/_commit_count_warning.html.erb
+++ b/app/views/shipit/merge_status/_commit_count_warning.html.erb
@@ -1,8 +1,0 @@
-<p class="status-heading text-red">
-  <%= render 'warning_icon' %>
-  Consider rebasing into a smaller number of commits containing atomic changes. Find out
-  <%= link_to 'why', 'https://docs.google.com/document/d/1lZlNo7ekugQDxug6Nc6pdY87VNobl3g2IQjY7R0YIIc',
-    target: '_blank',
-    rel: 'noopener'
-  %>.
-</p>

--- a/app/views/shipit/merge_status/backlogged.html.erb
+++ b/app/views/shipit/merge_status/backlogged.html.erb
@@ -17,5 +17,4 @@
     <%= link_to @stack.to_param, stack_url(@stack), target: '_blank', rel: 'noopener' %>
     is <strong>backlogged</strong>
   </span>
-  <%= render 'commit_count_warning' if too_many_commits?(params[:commits].to_i) %>
 </div>

--- a/app/views/shipit/merge_status/backlogged.html.erb
+++ b/app/views/shipit/merge_status/backlogged.html.erb
@@ -17,4 +17,5 @@
     <%= link_to @stack.to_param, stack_url(@stack), target: '_blank', rel: 'noopener' %>
     is <strong>backlogged</strong>
   </span>
+  <%= render 'commit_count_warning' if display_commit_count_warning?(params[:commits].to_i) %>
 </div>

--- a/app/views/shipit/merge_status/failure.html.erb
+++ b/app/views/shipit/merge_status/failure.html.erb
@@ -17,4 +17,5 @@
     <%= link_to @stack.to_param, stack_url(@stack), target: '_blank', rel: 'noopener' %>
     <strong>master branch is failing!</strong>
   </span>
+  <%= render 'commit_count_warning' if display_commit_count_warning?(params[:commits].to_i) %>
 </div>

--- a/app/views/shipit/merge_status/failure.html.erb
+++ b/app/views/shipit/merge_status/failure.html.erb
@@ -17,5 +17,4 @@
     <%= link_to @stack.to_param, stack_url(@stack), target: '_blank', rel: 'noopener' %>
     <strong>master branch is failing!</strong>
   </span>
-  <%= render 'commit_count_warning' if too_many_commits?(params[:commits].to_i) %>
 </div>

--- a/app/views/shipit/merge_status/locked.html.erb
+++ b/app/views/shipit/merge_status/locked.html.erb
@@ -17,4 +17,5 @@
     <%= link_to @stack.to_param, stack_url(@stack), target: '_blank', rel: 'noopener' %>
     is <strong>locked</strong> because: <strong><%= auto_link(emojify(@stack.lock_reason), html: { target: '_blank' }) %></strong>
   </span>
+  <%= render 'commit_count_warning' if display_commit_count_warning?(params[:commits].to_i) %>
 </div>

--- a/app/views/shipit/merge_status/locked.html.erb
+++ b/app/views/shipit/merge_status/locked.html.erb
@@ -17,5 +17,4 @@
     <%= link_to @stack.to_param, stack_url(@stack), target: '_blank', rel: 'noopener' %>
     is <strong>locked</strong> because: <strong><%= auto_link(emojify(@stack.lock_reason), html: { target: '_blank' }) %></strong>
   </span>
-  <%= render 'commit_count_warning' if too_many_commits?(params[:commits].to_i) %>
 </div>

--- a/app/views/shipit/merge_status/success.html.erb
+++ b/app/views/shipit/merge_status/success.html.erb
@@ -19,6 +19,4 @@
   <span class="status-meta">
     <%= link_to @stack.to_param, stack_url(@stack), target: '_blank', rel: 'noopener' %> is clear.
   </span>
-
-  <%= render 'commit_count_warning' if too_many_commits?(params[:commits].to_i) %>
 </div>

--- a/app/views/shipit/merge_status/success.html.erb
+++ b/app/views/shipit/merge_status/success.html.erb
@@ -19,4 +19,6 @@
   <span class="status-meta">
     <%= link_to @stack.to_param, stack_url(@stack), target: '_blank', rel: 'noopener' %> is clear.
   </span>
+
+  <%= render 'commit_count_warning' if display_commit_count_warning?(params[:commits].to_i) %>
 </div>


### PR DESCRIPTION
Hello from Clio! 👋 

This PR removes the commit count warning that appears on the Merge Status views:

<img width="690" alt="Screen Shot 2019-06-21 at 08 02 12" src="https://user-images.githubusercontent.com/7259082/59931942-eb484580-93fa-11e9-8e14-a912301e5de1.png">


The link appears to lead to an internal document which is publicly inaccessible (I believe [this](https://gist.github.com/casperisfine/0356ab7e809f4dc632809727fcb952d0) is the content of the document). Since the policy appears to be related to Shopify itself, I believe it makes sense to remove this from the open-source version to avoid confusion.





