### PR TITLE
Fix incorrect stack not being skipped when selecting deploy commit for reverts.

### DIFF
--- a/app/assets/stylesheets/_pages/_deploy.scss
+++ b/app/assets/stylesheets/_pages/_deploy.scss
@@ -144,6 +144,12 @@
     font-size: .875rem;
     padding: .25em .45em;
   }
+
+  .short-sha-no-bg {
+    font-family: Menlo, monospace;
+    border-radius: 4px;
+    font-size: .875rem;
+  }
 }
 
 .search-bar {

--- a/app/controllers/shipit/deploys_controller.rb
+++ b/app/controllers/shipit/deploys_controller.rb
@@ -42,8 +42,8 @@ module Shipit
     end
 
     def short_commit_sha(task)
-      if previous_successful_deploy(task)
-        @short_commit_sha ||= @previous_successful_deploy.until_commit&.short_sha
+      if previous_successful_deploy_commit(task)
+        @short_commit_sha ||= @previous_successful_deploy_commit&.short_sha
       end
     end
 
@@ -65,8 +65,8 @@ module Shipit
       @deploy_params ||= params.require(:deploy).permit(:until_commit_id, env: @stack.deploy_variables.map(&:name))
     end
 
-    def previous_successful_deploy(task)
-      @previous_successful_deploy ||= task&.previous_successful
+    def previous_successful_deploy_commit(task)
+      @previous_successful_deploy_commit ||= @stack.previous_successful_deploy_commit(task&.id)
     end
   end
 end

--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -87,14 +87,14 @@ module Shipit
 
     # Rolls the stack back to the most recent **previous** successful deploy
     def trigger_revert(force: false)
-      previous_success = stack.previous_successful_deploy_commit(id)
+      previous_successfully_deploy_commit = stack.previous_successful_deploy_commit(id)
 
       rollback = Rollback.create!(
         user_id: user_id,
         stack_id: stack_id,
         parent_id: id,
         since_commit: until_commit,
-        until_commit: previous_success,
+        until_commit: previous_successfully_deploy_commit,
         allow_concurrency: force,
       )
 

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -285,7 +285,7 @@ module Shipit
     end
 
     def previous_successful_deploy(deploy_id)
-      deploys_and_rollbacks.previous_successful(deploy_id)
+      deploys_and_rollbacks.success.where("id < ?", deploy_id).last
     end
 
     def last_active_task

--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -47,10 +47,6 @@ module Shipit
         completed.last
       end
 
-      def previous_successful(id)
-        success.where('id < ?', id).last
-      end
-
       def current
         active.exclusive.last
       end
@@ -233,10 +229,6 @@ module Shipit
 
     def supports_rollback?
       false
-    end
-
-    def previous_successful
-      self.class.previous_successful(id)
     end
 
     def title

--- a/app/views/shipit/tasks/_task_output.html.erb
+++ b/app/views/shipit/tasks/_task_output.html.erb
@@ -31,10 +31,9 @@
 
       <% if task.supports_rollback? %>
         <%= link_to abort_stack_task_path(@stack, task, rollback: true), class: "btn btn--delete action-button", data: { action: "abort", rollback: true, status: task.status } do %>
-          <span class="caption--ready">Abort and Rollback</span>
-          <span class="caption--pending">Aborting with Rollback...</span>
+          <span class="caption--ready">Abort and Rollback to <span class="short-sha-no-bg"><%= short_commit_sha(task) %></span></span>
+          <span class="caption--pending">Aborting with Rollback... to <span class="short-sha-no-bg"><%= short_commit_sha(task) %></span></span>
         <% end %>
-        <span class="deploy-status">to <span class="short-sha"><%= short_commit_sha(task) %></span></span>
       <% end %>
     </div>
   </div>

--- a/test/controllers/deploys_controller_test.rb
+++ b/test/controllers/deploys_controller_test.rb
@@ -120,8 +120,11 @@ module Shipit
 
       get :show, params: {stack_id: @stack, id: latest_deploy.id, format: 'html'}
 
-      expected_result = "to <span class=\"short-sha\">#{rollback_commit.short_sha}</span>"
-      assert_select 'span', {class: "deploy-status", html: expected_result}, "deploy-status element was not found, or did not match the expected result of '#{expected_result}'"
+      expected_result = "Abort and Rollback to <span class=\"short-sha-no-bg\">#{rollback_commit.short_sha}</span>"
+      expected_rolling_back_element = "Aborting with Rollback... to <span class=\"short-sha-no-bg\">f890fd8b5f</span>"
+
+      assert_select 'span.caption--ready', {html: expected_result}, "rollback button element was not found, or did not match the expected result of '#{expected_result}'"
+      assert_select 'span.caption--pending', {html: expected_rolling_back_element}, "ready rollback button element was not found, or did not match the expected result of '#{expected_rolling_back_element}'"
     end
 
     test ":revert redirect to the proper rollback page" do


### PR DESCRIPTION
With PR https://github.com/Shopify/shipit-engine/pull/910, the Abort&Rollback button (eventually `Deploy.trigger_revert`) would try to skip unsuccessful tasks when searching for a commit to roll back to.

However, a critical case was missed. When multiple stacks are interleaving their deploys/commits, the codepath used was not correctly filtering out unrelated stacks. Unfortunately, the codepath used by the tests would end up with the correct context, and was correctly filtering.

This PR fixes that problem by removing the Task methods altogether, as it makes more sense for Deploys (and UI controllers) to ask the Stack about what the most recent successful deploy was on said stack prior to a given id. This implicitly filters to deploys _of_ that stack.

In addition to this, a UI bug was fixed where the prospective rollback sha was always shown, even when a rollback option was not present. Instead, the element will now be hidden where appropriate, as seen here:

<img width="909" alt="deploy without sha" src="https://user-images.githubusercontent.com/3689583/60137209-4029ea00-9774-11e9-962e-f5847b45ab12.png">

<img width="1098" alt="rollback with sha" src="https://user-images.githubusercontent.com/3689583/60137223-46b86180-9774-11e9-85ed-c6f01026233e.png">

I adjusted the controller test to verify that the text is shown at the correct times. I adjusted the span class to make this test as robust as possible.

Lastly, I've added a regression test that interleaves an unrelated stack's deploy and ensures that it (and its commits) are not selected when reverting.