### PR TITLE
Optionally log command output

### DIFF
--- a/app/jobs/shipit/perform_task_job.rb
+++ b/app/jobs/shipit/perform_task_job.rb
@@ -18,6 +18,7 @@ module Shipit
       @task.run!
       checkout_repository
       perform_task
+      @task.write("\nCompleted successfully\n")
       @task.report_complete!
     rescue Command::TimedOut => error
       @task.write("\n#{error.message}\n")

--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -186,6 +186,7 @@ module Shipit
     end
 
     def write(text)
+      log_output(text)
       chunks.create!(text: text)
     end
 
@@ -332,6 +333,16 @@ module Shipit
 
     def abort_key
       "#{status_key}:aborting"
+    end
+
+    def log_output(text)
+      output_line_buffer.buffer(text) do |line|
+        Shipit.task_logger.info("[#{stack.repo_name}##{id}] #{line}")
+      end
+    end
+
+    def output_line_buffer
+      @output_line_buffer ||= LineBuffer.new
     end
   end
 end

--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -49,6 +49,7 @@ require 'shipit/environment_variables'
 require 'shipit/stat'
 require 'shipit/strip_cache_control'
 require 'shipit/cast_value'
+require 'shipit/line_buffer'
 
 SafeYAML::OPTIONS[:default_mode] = :safe
 SafeYAML::OPTIONS[:deserialize_symbols] = false
@@ -59,7 +60,7 @@ module Shipit
   delegate :table_name_prefix, to: :secrets
 
   attr_accessor :disable_api_authentication, :timeout_exit_codes
-  attr_writer :internal_hook_receivers
+  attr_writer :internal_hook_receivers, :task_logger
 
   self.timeout_exit_codes = [].freeze
 
@@ -193,6 +194,10 @@ module Shipit
 
   def internal_hook_receivers
     @internal_hook_receivers ||= []
+  end
+
+  def task_logger
+    @task_logger ||= Logger.new(nil)
   end
 
   protected

--- a/lib/shipit/line_buffer.rb
+++ b/lib/shipit/line_buffer.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+module Shipit
+  class LineBuffer
+    SEPARATOR = "\n"
+
+    def initialize(queue = "")
+      @queue = queue.dup
+    end
+
+    def buffer(text, &block)
+      @queue << text
+      whole_lines.each(&block).tap { flush }
+    end
+
+    def empty?
+      @queue.empty?
+    end
+
+    private
+
+    def whole_lines
+      whole? ? lines : lines[0..-2]
+    end
+
+    def flush
+      whole? ? clear : @queue = lines.last
+    end
+
+    def whole?
+      @queue.end_with?(SEPARATOR)
+    end
+
+    def lines
+      @queue.split(SEPARATOR)
+    end
+
+    def clear
+      @queue.clear
+    end
+  end
+end

--- a/test/models/tasks_test.rb
+++ b/test/models/tasks_test.rb
@@ -17,5 +17,18 @@ module Shipit
       task = shipit_tasks(:shipit_with_title_parsing_issue)
       assert_equal 'This task (title: Using the %{WRONG_VARIABLE_NAME}) cannot be shown due to an incorrect variable name. Check your shipit.yml file', task.title
     end
+
+    test "#write sends line-buffered output to task logger" do
+      task = shipit_tasks(:shipit)
+
+      mock_task_logger = mock.tap do |m|
+        m.expects(:info).with("[shipit-engine#1] hello").once
+        m.expects(:info).never
+      end
+
+      Shipit.stubs(:task_logger).returns(mock_task_logger)
+
+      task.write("hello\nworld")
+    end
   end
 end

--- a/test/unit/line_buffer_test.rb
+++ b/test/unit/line_buffer_test.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Shipit
+  class LineBufferTest < ActiveSupport::TestCase
+    setup { @buffer = LineBuffer.new }
+
+    test "buffers partial lines" do
+      refute_predicate(@buffer.buffer("a"), :any?)
+      assert_equal(["a"], @buffer.buffer("\n").to_a)
+      assert_predicate(@buffer, :empty?)
+    end
+
+    test "splits up multiple lines" do
+      assert_equal(%w(a b), @buffer.buffer("a\nb\n").to_a)
+      assert_predicate(@buffer, :empty?)
+    end
+  end
+end


### PR DESCRIPTION
Optionally log command output to `Shipit.task_logger` with context on the current repo / deployment.

Because an output chunk can contain more or less than one line, we first buffer the output into whole lines and then format it with the current context before sending it on to the configured task logger.