### PR TITLE
Use previous rollback behaviour when no previous deploy is found to roll back to.

### DIFF
--- a/app/controllers/shipit/deploys_controller.rb
+++ b/app/controllers/shipit/deploys_controller.rb
@@ -66,7 +66,7 @@ module Shipit
     end
 
     def previous_successful_deploy_commit(task)
-      @previous_successful_deploy_commit ||= @stack.previous_successful_deploy_commit(task&.id)
+      @previous_successful_deploy_commit ||= task.commit_to_rollback_to
     end
   end
 end

--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -87,14 +87,14 @@ module Shipit
 
     # Rolls the stack back to the most recent **previous** successful deploy
     def trigger_revert(force: false)
-      previous_successfully_deploy_commit = stack.previous_successful_deploy_commit(id)
+      previous_successful_commit = commit_to_rollback_to
 
       rollback = Rollback.create!(
         user_id: user_id,
         stack_id: stack_id,
         parent_id: id,
         since_commit: until_commit,
-        until_commit: previous_successfully_deploy_commit,
+        until_commit: previous_successful_commit,
         allow_concurrency: force,
       )
 

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -13,6 +13,10 @@ module Shipit
         ''
       end
 
+      def short_sha
+        ''
+      end
+
       def blank?
         true
       end

--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -312,6 +312,16 @@ module Shipit
       Shipit::Engine.routes.url_helpers.stack_task_url(stack, self)
     end
 
+    def commit_to_rollback_to
+      previous_deployed_commit = stack.previous_successful_deploy_commit(id)
+
+      if previous_deployed_commit == Shipit::Stack::NoDeployedCommit
+        since_commit
+      else
+        previous_deployed_commit
+      end
+    end
+
     private
 
     def prevent_concurrency


### PR DESCRIPTION
With PR #913, the Abort&Rollback button (eventually Deploy.trigger_revert) would try to skip unsuccessful tasks when searching for a commit to roll back to, and fix a bug where interleaved stack deploys would be used for the revert sha instead of the same stack.

Unfortunately, an edge case (no prior deploys found) was missed, resulting in a rare but blocking error.

This PR fixes the above problem by deferring to the old rollback behaviour whenever a previous-deploy could not be found. At the same time, I've made sure that the SHA shown in the button will be correct (showing the `current_deploy_task.until_commit` in the aforementioned scenario).

For context, see also:
https://github.com/Shopify/shipit-engine/pull/910
https://github.com/Shopify/shipit-engine/pull/913