### PR TITLE
Set a git ref when a deploy is successful.

### DIFF
--- a/app/jobs/shipit/update_github_last_deployed_ref_job.rb
+++ b/app/jobs/shipit/update_github_last_deployed_ref_job.rb
@@ -5,7 +5,7 @@ module Shipit
     DEPLOY_PREFIX = 'shipit-deploy'.freeze
 
     def perform(stack)
-      stack_sha = stack.deploys.where(status: "success").last.until_commit.sha
+      stack_sha = stack.last_successful_deploy_commit&.sha
       return unless stack_sha
 
       environment = stack.environment

--- a/app/jobs/shipit/update_github_last_deployed_ref_job.rb
+++ b/app/jobs/shipit/update_github_last_deployed_ref_job.rb
@@ -1,0 +1,41 @@
+module Shipit
+  class UpdateGithubLastDeployedRefJob < BackgroundJob
+    queue_as :default
+
+    DEPLOY_PREFIX = 'shipit-deploy'.freeze
+
+    def perform(stack)
+      stack_sha = stack.deploys.where(status: "success").last.until_commit.sha
+      return unless stack_sha
+
+      environment = stack.environment
+      stack_ref = create_full_ref(environment)
+      client = Shipit.github.api
+
+      full_repo_name = stack.github_repo_name
+
+      update_or_create_ref(client: client, repo_name: full_repo_name, ref: stack_ref, new_sha: stack_sha)
+    end
+
+    private
+
+    def create_full_ref(stack_environment)
+      [DEPLOY_PREFIX, stack_environment].join("/")
+    end
+
+    def create_ref(client:, repo_name:, ref:, sha:)
+      client.create_ref(repo_name, ref, sha)
+    end
+
+    def update_or_create_ref(client:, repo_name:, ref:, new_sha:)
+      client.update_ref(repo_name, ref, new_sha)
+    rescue Octokit::UnprocessableEntity => e
+      error_msg = e.message
+      if error_msg.include? "Reference does not exist"
+        create_ref(client: client, repo_name: repo_name, ref: ref, sha: new_sha)
+      else
+        raise
+      end
+    end
+  end
+end

--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -8,6 +8,7 @@ module Shipit
       after_transition to: :success, do: :schedule_continuous_delivery
       after_transition to: :success, do: :schedule_merges
       after_transition to: :success, do: :update_undeployed_commits_count
+      after_transition to: :success, do: :update_latest_deployed_ref
       after_transition to: :aborted, do: :trigger_revert_if_required
       after_transition any => any, do: :update_release_status
       after_transition any => any, do: :update_commit_deployments
@@ -279,6 +280,10 @@ module Shipit
 
     def update_last_deploy_time
       stack.update(last_deployed_at: ended_at)
+    end
+
+    def update_latest_deployed_ref
+      stack.update_latest_deployed_ref
     end
   end
 end

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -458,6 +458,10 @@ module Shipit
       update(undeployed_commits_count: undeployed_commits)
     end
 
+    def update_latest_deployed_ref
+      UpdateGithubLastDeployedRefJob.perform_later(self)
+    end
+
     def broadcast_update
       Pubsubstub.publish(
         "stack.#{id}",

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -288,6 +288,10 @@ module Shipit
       deploys_and_rollbacks.last_completed
     end
 
+    def last_successful_deploy_commit
+      deploys_and_rollbacks.last_successful&.until_commit
+    end
+
     def previous_successful_deploy(deploy_id)
       deploys_and_rollbacks.success.where("id < ?", deploy_id).last
     end

--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -47,6 +47,10 @@ module Shipit
         completed.last
       end
 
+      def last_successful
+        success.last
+      end
+
       def current
         active.exclusive.last
       end

--- a/test/jobs/update_github_last_deployed_ref_job_test.rb
+++ b/test/jobs/update_github_last_deployed_ref_job_test.rb
@@ -1,0 +1,88 @@
+require 'test_helper'
+
+module Shipit
+  class UpdateGithubLastDeployedRefJobTest < ActiveSupport::TestCase
+    setup do
+      @stack = shipit_stacks(:shipit)
+      @job = UpdateGithubLastDeployedRefJob.new
+      @deploy = @stack.deploys.last
+      @commit = @deploy.until_commit
+      @api_client = Shipit.github.api
+      @expected_ref_prefix = "shipit-deploy/#{@stack.environment}"
+      @expected_name = @stack.github_repo_name
+      @expected_sha = @commit.sha
+
+      expected_ref = ["refs", @expected_ref_prefix].join('/')
+      ref_url = "http://api.github.test.com/shopify/shipit-engine/git/#{expected_ref}"
+      commit_url = "https://api.github.test.com/repos/shopify/shipit-engine/git/commits/#{@commit.sha}"
+      response_inner_obj = OpenStruct.new(sha: @commit.sha, type: "commit", url: commit_url)
+      @response = OpenStruct.new(ref: expected_ref, node_id: "blah", url: ref_url, object: response_inner_obj)
+    end
+
+    test "#perform will create a ref when one is not present" do
+      Octokit::UnprocessableEntity.any_instance.stubs(:build_error_message).returns("Reference does not exist")
+
+      @api_client.expects(:update_ref).with(@expected_name, @expected_ref_prefix, @expected_sha).raises(Octokit::UnprocessableEntity)
+      @api_client.expects(:create_ref).with(@expected_name, @expected_ref_prefix, @expected_sha).returns(@response)
+
+      result = @job.perform(@stack)
+
+      assert_equal @response, result
+    end
+
+    test "#perform will update a ref when one is present" do
+      prior_response = @response.dup
+      prior_response.object = prior_response.object.dup
+      new_sha = "some_new_sha"
+      @response.object.sha = new_sha
+      @commit.sha = new_sha
+      @commit.save
+
+      @api_client.expects(:update_ref).with(@expected_name, @expected_ref_prefix, new_sha).returns(@response)
+
+      result = @job.perform(@stack)
+
+      assert_equal @response, result
+    end
+
+    test '#perform will raise an exception for non ref existence errors' do
+      Octokit::UnprocessableEntity.any_instance.stubs(:build_error_message).returns("Some other error.")
+
+      @api_client.expects(:update_ref).with(@expected_name, @expected_ref_prefix, @expected_sha).raises(Octokit::UnprocessableEntity)
+      @api_client.expects(:create_ref).with(@expected_name, @expected_ref_prefix, @expected_sha).never
+
+      assert_raises Octokit::UnprocessableEntity do
+        @job.perform(@stack)
+      end
+    end
+
+    test '#perform skips unsuccessful deploys when finding sha to use' do
+      prior_response = @response.dup
+      prior_response.object = prior_response.object.dup
+      new_sha = "some_new_sha"
+      @response.object.sha = new_sha
+      @commit.sha = new_sha
+      @commit.save
+
+      new_deploy = @stack.deploys.last.dup
+      new_commit = new_deploy.until_commit.dup
+      new_commit.sha = "some fake sha"
+      new_deploy.until_commit = new_commit
+      new_deploy.id = nil
+      new_deploy.status = "faulty"
+      new_deploy.save
+
+      @api_client.expects(:update_ref).with(@expected_name, @expected_ref_prefix, new_sha).returns(@response)
+      result = @job.perform(@stack)
+
+      assert_equal @response, result
+
+      new_deploy.reload
+      new_deploy.status = "success"
+      new_deploy.save
+
+      @api_client.expects(:update_ref).with(@expected_name, @expected_ref_prefix, new_commit.sha).returns(@response)
+      @job.perform(@stack)
+    end
+  end
+end

--- a/test/models/deploys_test.rb
+++ b/test/models/deploys_test.rb
@@ -245,6 +245,13 @@ module Shipit
       end
     end
 
+    test "transitioning to success enqueues a last-deployed git reference update" do
+      @deploy = shipit_deploys(:shipit_running)
+      assert_enqueued_with(job: UpdateGithubLastDeployedRefJob, args: [@deploy.stack]) do
+        @deploy.complete!
+      end
+    end
+
     test "transitions to any state updates last deploy time to stack record" do
       @deploy = shipit_deploys(:shipit_running)
       @deploy.complete!


### PR DESCRIPTION
To support future features, we want to add a per-environment per-project git reference that will allow new tools and features to know which commit is currently deployed by making a Github `refs` api call.

See https://github.com/Shopify/shipit/issues/743 for more context.

The basic gist of these changes is that when a deploy finishes, its `-> success` state transition will trigger a call to its owning Stack, which will enqueue a job that will update or create a ref in github pointing to whatever the Stack thinks is its latest deployed commit.

For now, we've assumed that it is sufficient to abide by a ref set at the end of a deploy, and not add things like startup checks by the stacks the ensure the currently set ref is correct (and so on). The idea being that it is fine to let an assumedly-rare edge case of stale or incorrect last deployed refs self-correct via deploys or manual intervention for now.

This should serve to resolve https://github.com/Shopify/shipit/issues/743.