### PR TITLE
Changed UpdateGithubLastDeployedRef to be enqueued via after_commit instead of after_transition.

### DIFF
--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -8,7 +8,6 @@ module Shipit
       after_transition to: :success, do: :schedule_continuous_delivery
       after_transition to: :success, do: :schedule_merges
       after_transition to: :success, do: :update_undeployed_commits_count
-      after_transition to: :success, do: :update_latest_deployed_ref
       after_transition to: :aborted, do: :trigger_revert_if_required
       after_transition any => any, do: :update_release_status
       after_transition any => any, do: :update_commit_deployments
@@ -37,6 +36,7 @@ module Shipit
     after_create :create_commit_deployments
     after_create :update_release_status
     after_commit :broadcast_update
+    after_commit :update_latest_deployed_ref, on: :update
 
     delegate :broadcast_update, :filter_deploy_envs, to: :stack
 
@@ -283,7 +283,8 @@ module Shipit
     end
 
     def update_latest_deployed_ref
-      stack.update_latest_deployed_ref
+      return unless previous_changes.include?(:status)
+      stack.update_latest_deployed_ref if previous_changes[:status].last == 'success'
     end
   end
 end


### PR DESCRIPTION
UpdateGithubLastDeployedRef suffers from a potential race condition, wherein the job could execute before _or_ after the deploy that triggered it had committed the state that resulted in the trigger.

Since the accuracy of that state is necessary for the job to function correctly, the job could potentially keep the target ref out of date.

See https://github.com/Shopify/shipit/issues/765 for more details.

This was more common in production than I expected, so this PR resolves the issue in this case by using `after_transition to success` to mark a flag, and then after_commit for a deploy to trigger the job if and only if said flag was set (and therefore this was a deploy that succeeded, and was just committed).

### Testing

I have so far tested/ 🎩this solution by:

* Running the tests (which should fail if the after_commit callback did not fire; thus guaranteeing that the code paths do correctly lead to that outcome, at the very least).
* Running a shipit dummy app locally with a real github repo, deploying and rolling back various commits, and checking the remote sha (`git remote-ls | grep 'shipit-deploy'`) at each step for correctness.
  * This was with a Sidekiq process running, and it worked correctly.
* Doing the aforementioned process _without_ a sidekiq process running / by using the default async queue adapter.
  * This wasn't working correctly before, but with these changes, it now works every time.