### PR TITLE
Set email field using private emails if public ones are not found

### DIFF
--- a/app/models/shipit/user.rb
+++ b/app/models/shipit/user.rb
@@ -131,18 +131,18 @@ module Shipit
     end
 
     def org_email?(email_address)
-      email_address.present? && email_address.split("@").last&.include?(org_domain)
+      return false if email_address.blank?
+
+      org_domains = Shipit.preferred_org_emails
+      return true if org_domains.blank?
+
+      org_domains.any? { |domain| email_address.end_with?("@#{domain}") }
     end
 
-    def filter_org_emails(emails)
-      emails
-        .select { |email| org_email?(email.email) }
-        .map(&:email)
-    end
-
-    # Domain to filter email addresses by. Override in integration application.
-    def org_domain
-      ""
+    def filter_org_emails(github_email_records)
+      org_email_records = github_email_records.select { |email_record| org_email?(email_record.email) }
+      email_record = org_email_records.find(-> { org_email_records.first }, &:primary)
+      email_record&.email
     end
   end
 end

--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -60,7 +60,7 @@ module Shipit
   delegate :table_name_prefix, to: :secrets
 
   attr_accessor :disable_api_authentication, :timeout_exit_codes
-  attr_writer :internal_hook_receivers, :task_logger
+  attr_writer :internal_hook_receivers, :task_logger, :preferred_org_emails
 
   self.timeout_exit_codes = [].freeze
 
@@ -194,6 +194,10 @@ module Shipit
 
   def internal_hook_receivers
     @internal_hook_receivers ||= []
+  end
+
+  def preferred_org_emails
+    @preferred_org_emails ||= []
   end
 
   def task_logger

--- a/test/models/commits_test.rb
+++ b/test/models/commits_test.rb
@@ -8,6 +8,8 @@ module Shipit
       @pr.message = "Merge pull request #31 from Shopify/improve-polling\n\nSeveral improvements to polling"
       @stack.reload
       @commit = shipit_commits(:first)
+
+      FakeWeb.register_uri(:get, "https://api.github.com/user/emails", status: %w(200 OK), body: {}.to_json, content_type: 'application/json')
     end
 
     test '.create_from_github handle unknown users' do

--- a/test/models/commits_test.rb
+++ b/test/models/commits_test.rb
@@ -9,7 +9,11 @@ module Shipit
       @stack.reload
       @commit = shipit_commits(:first)
 
-      FakeWeb.register_uri(:get, "https://api.github.com/user/emails", status: %w(200 OK), body: {}.to_json, content_type: 'application/json')
+      stub_request(:get, "https://api.github.com/user/emails").to_return(
+        status: %w(200 OK),
+        body: {}.to_json,
+        headers: {"Content-Type" => "application/json"},
+      )
     end
 
     test '.create_from_github handle unknown users' do

--- a/test/models/users_test.rb
+++ b/test/models/users_test.rb
@@ -58,6 +58,7 @@ module Shipit
     end
 
     test "find_or_create_from_github accepts minimal users without name nor email" do
+      FakeWeb.register_uri(:get, "https://api.github.com/user/emails", status: %w(200 OK), body: [].to_json, content_type: "application/json")
       user = User.find_or_create_from_github(@minimal_github_user)
       assert_equal @minimal_github_user.login, user.login
     end


### PR DESCRIPTION
This PR looks to address https://github.com/Shopify/shipit/issues/775, wherein the EMAIL variable is not filled if the Github user has no public email addresses. We'd also like the ability to filter the emails selected by a specific org (as some users may be using a personal public email, or may have multiple emails including personal ones).

This is accomplished, in the case where they have no public email, by retrieving their emails from `/emails` and filtering it by a provided org domain, if any.

Some more specific tests are needed for this before merging, as well as (possibly) selection of the Primary email in the case where the user has multiple valid candidate emails.

I also need to :tophat: from a local running Shipit application itself, but I wanted to get some eyes on this approach first and whether it belongs here or if more things should be moved to the app integration side of things.