### PR TITLE
queue fetch deployed revision job under deploys queue

### DIFF
--- a/app/jobs/shipit/fetch_deployed_revision_job.rb
+++ b/app/jobs/shipit/fetch_deployed_revision_job.rb
@@ -1,6 +1,6 @@
 module Shipit
   class FetchDeployedRevisionJob < BackgroundJob
-    queue_as :default
+    queue_as :deploys
 
     def perform(stack)
       return if stack.active_task?


### PR DESCRIPTION
This job is quite expensive (doing a git clone as part of this) and may be better to run on deploy workers as they are expected to do clone workloads.