### PR TITLE
Change the latest deployed ref job to create a proper refs/heads/ branch.

### DIFF
--- a/app/jobs/shipit/update_github_last_deployed_ref_job.rb
+++ b/app/jobs/shipit/update_github_last_deployed_ref_job.rb
@@ -2,6 +2,7 @@ module Shipit
   class UpdateGithubLastDeployedRefJob < BackgroundJob
     queue_as :default
 
+    BRANCH_REF_PREFIX = 'refs/heads'.freeze
     DEPLOY_PREFIX = 'shipit-deploy'.freeze
 
     def perform(stack)
@@ -20,7 +21,7 @@ module Shipit
     private
 
     def create_full_ref(stack_environment)
-      [DEPLOY_PREFIX, stack_environment].join("/")
+      [BRANCH_REF_PREFIX, DEPLOY_PREFIX, stack_environment].join("/")
     end
 
     def create_ref(client:, repo_name:, ref:, sha:)


### PR DESCRIPTION
We were creating the ref for the latest-deployed-commit under `refs/shipit-deploy/stack_env_name`.
However, this turned out to be unusable for Github's branch-based APIs, as Github only treats refs under `refs/heads/` as branches for those purposes.

As such, this PR changes the created refs to be under `refs/heads/shipit-deploy/stack_env_name`, and thus they show up as branches (`git fetch ; git branch -a`, the Branches view in Github, etc).

I 🎩locally with a test repo of mine:

The created ref `refs/heads/shipit-deploy/myenvironment` can be fetched, and will create the mapping `shipit-deploy/myenvironment -> origin/shipit-deploy/myenvironment` representing the remote `remotes/origin/shipit-deploy/devvy-myenvironment`.

Not sure how we want to handle cleanup of the existing refs.