### PR TITLE
Remove 'refs/' prefix from latest deployed commit refs.

### DIFF
--- a/app/jobs/shipit/update_github_last_deployed_ref_job.rb
+++ b/app/jobs/shipit/update_github_last_deployed_ref_job.rb
@@ -2,7 +2,8 @@ module Shipit
   class UpdateGithubLastDeployedRefJob < BackgroundJob
     queue_as :default
 
-    BRANCH_REF_PREFIX = 'refs/heads'.freeze
+    # We do not prefix 'refs/' because Octokit methods will do this automatically.
+    BRANCH_REF_PREFIX = 'heads'.freeze
     DEPLOY_PREFIX = 'shipit-deploy'.freeze
 
     def perform(stack)

--- a/test/jobs/update_github_last_deployed_ref_job_test.rb
+++ b/test/jobs/update_github_last_deployed_ref_job_test.rb
@@ -12,7 +12,7 @@ module Shipit
       @expected_sha = @commit.sha
 
       expected_ref_suffix = "shipit-deploy/#{@stack.environment}"
-      @expected_ref = ["refs/heads", expected_ref_suffix].join('/')
+      @expected_ref = ["heads", expected_ref_suffix].join('/')
 
       ref_url = "http://api.github.test.com/shopify/shipit-engine/git/#{@expected_ref}"
       commit_url = "https://api.github.test.com/repos/shopify/shipit-engine/git/commits/#{@commit.sha}"


### PR DESCRIPTION
This PR removes the 'refs/' prefix from the refs we are creating for the last-deployed-commit.

It turns out that Octokit's `[update_ref](https://github.com/octokit/octokit.rb/blob/master/lib/octokit/client/refs.rb#L68)` method will always add a `refs/` prefix, whereas `[create_ref](https://github.com/octokit/octokit.rb/blob/master/lib/octokit/client/refs.rb#L48)` does not.

So create_ref would pass, but then the update_ref on the next deploys would always fail. 