### PR TITLE
Update Service Status check to use statuspage.io

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -11,7 +11,7 @@ end
 
 group :development, :test do
   gem 'faker'
-  gem 'fakeweb'
+  gem 'webmock'
   gem 'rubocop', '~> 0.52.0'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,8 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.0.5)
+    crack (0.4.3)
+      safe_yaml (~> 1.0.0)
     crass (1.0.4)
     descendants_tracker (0.0.4)
       thread_safe (~> 0.3, >= 0.3.1)
@@ -117,7 +119,6 @@ GEM
       virtus (~> 1.0)
     faker (1.7.3)
       i18n (~> 0.5)
-    fakeweb (1.3.0)
     faraday (0.12.2)
       multipart-post (>= 1.2, < 3)
     faraday-http-cache (1.2.2)
@@ -126,6 +127,7 @@ GEM
     gemoji (2.1.0)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
+    hashdiff (1.0.0)
     hashie (3.6.0)
     i18n (0.9.5)
       concurrent-ruby (~> 1.0)
@@ -295,6 +297,10 @@ GEM
       coercible (~> 1.0)
       descendants_tracker (~> 0.0, >= 0.0.3)
       equalizer (~> 0.0, >= 0.0.9)
+    webmock (3.6.0)
+      addressable (>= 2.3.6)
+      crack (>= 0.3.2)
+      hashdiff (>= 0.4.0, < 2.0.0)
     websocket-driver (0.7.1)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.4)
@@ -305,7 +311,6 @@ PLATFORMS
 DEPENDENCIES
   byebug
   faker
-  fakeweb
   mocha
   mysql2
   pg
@@ -315,6 +320,7 @@ DEPENDENCIES
   simplecov
   spy
   sqlite3
+  webmock
 
 BUNDLED WITH
    1.17.3

--- a/app/models/shipit/github_status.rb
+++ b/app/models/shipit/github_status.rb
@@ -8,7 +8,7 @@ module Shipit
       end
 
       def refresh_status
-        Rails.cache.write(CACHE_KEY, Shipit.github.api.github_status)
+        Rails.cache.write(CACHE_KEY, Shipit.github.api_status)
       rescue Faraday::Error, Octokit::ServerError
       end
     end

--- a/app/views/layouts/shipit.html.erb
+++ b/app/views/layouts/shipit.html.erb
@@ -33,7 +33,7 @@
 
   <div id="layout-content">
     <% github_status = Shipit::GithubStatus.status
-       unless github_status.nil? || github_status[:status] == 'good' %>
+       unless github_status.nil? || github_status[:status] == 'operational' %>
       <div class="banner github-status banner--orange hidden">
         <div class="banner__inner wrapper">
           <div class="banner__content">

--- a/lib/shipit/github_app.rb
+++ b/lib/shipit/github_app.rb
@@ -25,6 +25,7 @@ module Shipit
 
     DOMAIN = 'github.com'.freeze
     AuthenticationFailed = Class.new(StandardError)
+    API_STATUS_ID = 'brv1bkgrwx7q'.freeze
 
     attr_reader :oauth_teams, :domain, :bot_login
 
@@ -51,6 +52,13 @@ module Shipit
         client.access_token = token
       end
       client
+    end
+
+    def api_status
+      conn = Faraday.new(url: 'https://www.githubstatus.com')
+      response = conn.get('/api/v2/components.json')
+      parsed = JSON.parse(response.body, symbolize_names: true)
+      parsed[:components].find{|c| c[:id] == API_STATUS_ID }
     end
 
     def verify_webhook_signature(signature, message)

--- a/lib/shipit/github_app.rb
+++ b/lib/shipit/github_app.rb
@@ -58,7 +58,7 @@ module Shipit
       conn = Faraday.new(url: 'https://www.githubstatus.com')
       response = conn.get('/api/v2/components.json')
       parsed = JSON.parse(response.body, symbolize_names: true)
-      parsed[:components].find{|c| c[:id] == API_STATUS_ID }
+      parsed[:components].find { |c| c[:id] == API_STATUS_ID }
     end
 
     def verify_webhook_signature(signature, message)

--- a/test/dummy/db/seeds.rb
+++ b/test/dummy/db/seeds.rb
@@ -1,8 +1,11 @@
 require 'faker'
-require 'fakeweb'
+require 'webmock'
+include WebMock::API
+WebMock.enable!
+WebMock.allow_net_connect!
 
 # Sometimes on Travis the background job runs immediately so provide a response to fake hooks
-FakeWeb.register_uri(:post, %r{https://example\.com/}, status: %w(200 OK))
+stub_request(:post, %r{https://example\.com/}).to_return(status: %w(200 OK))
 
 # Cheap hack to allow rake db:seed to work
 module Shipit

--- a/test/jobs/deliver_hook_job_test.rb
+++ b/test/jobs/deliver_hook_job_test.rb
@@ -8,7 +8,7 @@ module Shipit
     end
 
     test "#perform delivers a delivery" do
-      FakeWeb.register_uri(:post, @delivery.url, body: 'OK')
+      stub_request(:post, @delivery.url).to_return( body: 'OK')
       @job.perform(@delivery)
       assert_equal 'sent', @delivery.reload.status
     end

--- a/test/jobs/deliver_hook_job_test.rb
+++ b/test/jobs/deliver_hook_job_test.rb
@@ -8,7 +8,7 @@ module Shipit
     end
 
     test "#perform delivers a delivery" do
-      stub_request(:post, @delivery.url).to_return( body: 'OK')
+      stub_request(:post, @delivery.url).to_return(body: 'OK')
       @job.perform(@delivery)
       assert_equal 'sent', @delivery.reload.status
     end

--- a/test/jobs/merge_pull_requests_job_test.rb
+++ b/test/jobs/merge_pull_requests_job_test.rb
@@ -17,15 +17,15 @@ module Shipit
 
     test "#perform rejects unmergeable PRs and merge the others" do
       PullRequest.any_instance.stubs(:refresh!)
-      FakeWeb.register_uri(:put, "#{@pending_pr.api_url}/merge", status: %w(200 OK), body: {
+      stub_request(:put, "#{@pending_pr.api_url}/merge").to_return(status: %w(200 OK), body: {
         sha: "6dcb09b5b57875f334f61aebed695e2e4193db5e",
         merged: true,
         message: "Pull Request successfully merged",
       }.to_json)
       branch_url = "https://api.github.com/repos/shopify/shipit-engine/git/refs/heads/feature-62"
-      FakeWeb.register_uri(:delete, branch_url, status: %w(204 No content))
+      stub_request(:delete, branch_url).to_return(status: %w(204 No content))
       pulls_url = "https://api.github.com/repos/shopify/shipit-engine/pulls?base=feature-62"
-      FakeWeb.register_uri(:get, pulls_url, status: %w(200 OK), body: '[]')
+      stub_request(:get, pulls_url).to_return(status: %w(200 OK), body: '[]')
 
       @job.perform(@stack)
 
@@ -35,7 +35,7 @@ module Shipit
 
     test "#perform rejects PRs if the merge attempt fails" do
       PullRequest.any_instance.stubs(:refresh!)
-      FakeWeb.register_uri(:put, "#{@pending_pr.api_url}/merge", status: %w(405 Method not allowed), body: {
+      stub_request(:put, "#{@pending_pr.api_url}/merge").to_return(status: %w(405 Method not allowed), body: {
         message: "Pull Request is not mergeable",
         documentation_url: "https://developer.github.com/v3/pulls/#merge-a-pull-request-merge-button",
       }.to_json)

--- a/test/models/delivery_test.rb
+++ b/test/models/delivery_test.rb
@@ -24,7 +24,7 @@ module Shipit
 
     test "#send! post the payload and update the status to `sent`" do
       headers = {'content-type' => 'text/plain', 'content-length' => '2'}
-      FakeWeb.register_uri(:post, @delivery.url, headers.merge(body: 'OK'))
+      stub_request(:post, @delivery.url).to_return(headers: headers, body: 'OK')
 
       assert_equal 'scheduled', @delivery.status
       @delivery.send!

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,8 +3,7 @@ ENV["RAILS_ENV"] ||= "test"
 require 'simplecov'
 SimpleCov.start 'rails'
 
-require 'fakeweb'
-FakeWeb.allow_net_connect = false
+require 'webmock/minitest'
 
 require File.expand_path('../../test/dummy/config/environment.rb', __FILE__)
 ActiveRecord::Migrator.migrations_paths = [

--- a/test/unit/github_app_test.rb
+++ b/test/unit/github_app_test.rb
@@ -16,25 +16,27 @@ module Shipit
     test "#api_status" do
       stub_request(:get, "https://www.githubstatus.com/api/v2/components.json").to_return(
         status: 200,
-        body: %Q{{
-          "page":{},
-          "components":[
-            {
-              "id":"brv1bkgrwx7q",
-              "name":"API Requests",
-              "status":"operational",
-              "created_at":"2017-01-31T20:01:46.621Z",
-              "updated_at":"2019-07-23T18:41:18.197Z",
-              "position":2,
-              "description":"Requests for GitHub APIs",
-              "showcase":false,
-              "group_id":null,
-              "page_id":"kctbh9vrtdwd",
-              "group":false,
-              "only_show_if_degraded":false
-            }
-          ]
-        }}
+        body: %(
+          {
+            "page":{},
+            "components":[
+              {
+                "id":"brv1bkgrwx7q",
+                "name":"API Requests",
+                "status":"operational",
+                "created_at":"2017-01-31T20:01:46.621Z",
+                "updated_at":"2019-07-23T18:41:18.197Z",
+                "position":2,
+                "description":"Requests for GitHub APIs",
+                "showcase":false,
+                "group_id":null,
+                "page_id":"kctbh9vrtdwd",
+                "group":false,
+                "only_show_if_degraded":false
+              }
+            ]
+          }
+        ),
       )
       assert_equal "operational", app.api_status[:status]
     end

--- a/test/unit/github_app_test.rb
+++ b/test/unit/github_app_test.rb
@@ -13,6 +13,32 @@ module Shipit
       end
     end
 
+    test "#api_status" do
+      stub_request(:get, "https://www.githubstatus.com/api/v2/components.json").to_return(
+        status: 200,
+        body: %Q{{
+          "page":{},
+          "components":[
+            {
+              "id":"brv1bkgrwx7q",
+              "name":"API Requests",
+              "status":"operational",
+              "created_at":"2017-01-31T20:01:46.621Z",
+              "updated_at":"2019-07-23T18:41:18.197Z",
+              "position":2,
+              "description":"Requests for GitHub APIs",
+              "showcase":false,
+              "group_id":null,
+              "page_id":"kctbh9vrtdwd",
+              "group":false,
+              "only_show_if_degraded":false
+            }
+          ]
+        }}
+      )
+      assert_equal "operational", app.api_status[:status]
+    end
+
     test "#domain defaults to github.com" do
       assert_equal 'github.com', @github.domain
     end


### PR DESCRIPTION
This is meant to address https://github.com/Shopify/shipit-engine/issues/881.  As Octokit does not presently support updates Statuspage.io this adds an api call to it directly, parses out the response for the API component and updates the UI call for the new key.

I had some trouble with Fakeweb and newer Ruby so i replace it with Webmock

cc/ @stantona @charles-ferguson @rbroemeling