### PR TITLE
Stack Statistics Page

### DIFF
--- a/app/assets/stylesheets/_pages/_stacks.scss
+++ b/app/assets/stylesheets/_pages/_stacks.scss
@@ -161,3 +161,71 @@
 .pagination {
   text-align: center;
 }
+
+.box {
+  border-radius: 5px;
+  width: 32%;
+  float: left;
+  padding: 5px;
+}
+
+.box__header {
+  padding: 15px 25px;
+  position: relative;
+}
+
+.box__header-title {
+  color: #333;
+  font-size: 18px;
+}
+
+.box__body {
+  padding: 0 25px;
+}
+
+.row {
+  @include clearfix;
+}
+
+/* STATS */
+
+.stats {
+  color: #333;
+  position: relative;
+  padding-bottom: 25px;
+}
+
+.stats__amount {
+  font-size: 54px;
+  line-height: 1.2;
+}
+
+.stats__caption {
+  font-size: 18px;
+
+}
+
+.stats__change {
+  position: absolute;
+  top: 10px;
+  right: 0;
+  text-align: right;
+  color: #B1B7C8;
+}
+
+.stats__value {
+  font-size: 18px;
+}
+
+.stats__period {
+  font-size: 14px;
+}
+
+.stats__value--positive {
+  color: #AEDC6F;
+}
+
+.stats__value--negative {
+  color: #FB5055;
+}
+

--- a/app/controllers/shipit/stacks_controller.rb
+++ b/app/controllers/shipit/stacks_controller.rb
@@ -1,6 +1,6 @@
 module Shipit
   class StacksController < ShipitController
-    before_action :load_stack, only: %i(update destroy settings clear_git_cache refresh)
+    before_action :load_stack, only: %i(update destroy settings statistics clear_git_cache refresh)
 
     def new
       @stack = Stack.new
@@ -60,6 +60,12 @@ module Shipit
     end
 
     def settings
+    end
+
+    def statistics
+      previous_deploy_stats = Shipit::DeployStats.new(@stack.deploys.not_active.previous_seven_days)
+      @deploy_stats = Shipit::DeployStats.new(@stack.deploys.not_active.last_seven_days)
+      @diffs = @deploy_stats.compare(previous_deploy_stats)
     end
 
     def refresh

--- a/app/helpers/shipit/stacks_helper.rb
+++ b/app/helpers/shipit/stacks_helper.rb
@@ -86,5 +86,9 @@ module Shipit
         t('commit.unlock')
       end
     end
+
+    def positive_negative_class(value)
+      value.to_f >= 0 ? 'positive' : 'negative'
+    end
   end
 end

--- a/app/models/shipit/deploy_stats.rb
+++ b/app/models/shipit/deploy_stats.rb
@@ -1,0 +1,55 @@
+module Shipit
+  class DeployStats
+    def initialize(deploys)
+      @deploys = deploys
+      @durations = @deploys.map { |d| d.duration.value }.compact
+    end
+
+    def count
+      @deploys.length
+    end
+
+    def average_duration
+      return if @durations.empty?
+      @durations.sum / @durations.length.to_f
+    end
+
+    def max_duration
+      @durations.max
+    end
+
+    def min_duration
+      @durations.min
+    end
+
+    def median_duration
+      return if @durations.empty?
+      (sorted_durations[(@durations.length - 1) / 2] + sorted_durations[@durations.length / 2]) / 2.0
+    end
+
+    def success_rate
+      return if @deploys.empty?
+      (@deploys.count(&:success?) / @deploys.length.to_f) * 100
+    end
+
+    def compare(compare_stats)
+      {
+        count: percent_change(compare_stats.count, count),
+        average_duration: percent_change(compare_stats.average_duration, average_duration),
+        median_duration: percent_change(compare_stats.median_duration, median_duration),
+      }
+    end
+
+    protected
+
+    def sorted_durations
+      @sorted ||= @durations.sort
+    end
+
+    def percent_change(from, to)
+      return if to.nil? || from.nil?
+      return to * 100 if from.zero?
+      ((to - from) / from.to_f) * 100
+    end
+  end
+end

--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -29,8 +29,11 @@ module Shipit
     scope :success, -> { where(status: 'success') }
     scope :completed, -> { where(status: COMPLETED_STATUSES) }
     scope :active, -> { where(status: ACTIVE_STATUSES) }
+    scope :not_active, -> { where(status: COMPLETED_STATUSES + UNSUCCESSFUL_STATUSES) }
     scope :exclusive, -> { where(allow_concurrency: false) }
     scope :unsuccessful, -> { where(status: UNSUCCESSFUL_STATUSES) }
+    scope :last_seven_days, -> { where("created_at > ?", 7.days.ago) }
+    scope :previous_seven_days, -> { where(created_at: 14.days.ago..7.days.ago) }
 
     scope :due_for_rollup, -> { completed.where(rolled_up: false).where('created_at <= ?', 1.hour.ago) }
 

--- a/app/views/shipit/stacks/_header.html.erb
+++ b/app/views/shipit/stacks/_header.html.erb
@@ -19,6 +19,9 @@
     <li class="nav__list__item">
       <%= link_to 'Timeline', index_stack_tasks_path(stack) %>
     </li>
+    <li class="nav__list__item">
+      <%= link_to 'Stats', stack_statistics_path(stack) %>
+    </li>
     <% if stack.merge_queue_enabled? %>
       <li class="nav__list__item">
         <%= link_to "Merge Queue (#{stack.pull_requests.queued.count})", stack_pull_requests_path(stack) %>

--- a/app/views/shipit/stacks/statistics.html.erb
+++ b/app/views/shipit/stacks/statistics.html.erb
@@ -1,0 +1,82 @@
+<%= render partial: 'shipit/stacks/header', locals: {stack: @stack} %>
+<%= render partial: 'shipit/stacks/banners', locals: {stack: @stack} %>
+
+<div class="wrapper">
+  <section>
+    <header class="section-header">
+      <h2>Statistics &ndash; Past 7 Days</h2>
+    </header>
+
+    <div class="row">
+      <div class="box">
+        <div class="box__body">
+          <div class="stats">
+            <div class="stats__amount"><%= @deploy_stats.count %></div>
+            <div class="stats__caption">Deploys</div>
+            <div class="stats__change">
+              <div class="stats__value stats__value--<%=positive_negative_class(@diffs[:count])%>"><%= number_to_percentage(@diffs[:count], precision: 1) %></div>
+              <div class="stats__period">this week</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="box">
+        <div class="box__body">
+          <div class="stats">
+            <div class="stats__amount"><%= number_to_percentage(@deploy_stats.success_rate, precision: 1) %></div>
+            <div class="stats__caption">Deploys success rate</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="box">
+        <div class="box__body">
+          <div class="stats">
+            <div class="stats__amount"><%= Shipit::Duration.new @deploy_stats.average_duration %></div>
+            <div class="stats__caption">Average deploy time</div>
+            <div class="stats__change">
+              <div class="stats__value stats__value--<%=positive_negative_class(@diffs[:average_duration])%>"><%= number_to_percentage(@diffs[:average_duration], precision: 1) %></div>
+              <div class="stats__period">this week</div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+    <div class="row">
+      <div class="box">
+        <div class="box__body">
+          <div class="stats">
+            <div class="stats__amount"><%= Shipit::Duration.new @deploy_stats.min_duration %></div>
+            <div class="stats__caption">Min deploy time</div>
+          </div>
+        </div>
+      </div>
+
+      <div class="box">
+        <div class="box__body">
+          <div class="stats">
+            <div class="stats__amount"><%= Shipit::Duration.new @deploy_stats.median_duration %></div>
+            <div class="stats__caption">Median deploy time</div>
+            <div class="stats__change">
+              <div class="stats__value stats__value--<%=positive_negative_class(@diffs[:median_duration])%>"><%= number_to_percentage(@diffs[:median_duration], precision: 1) %></div>
+              <div class="stats__period">this week</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="box">
+        <div class="box__body">
+          <div class="stats">
+            <div class="stats__amount"><%= Shipit::Duration.new @deploy_stats.max_duration %></div>
+            <div class="stats__caption">Max deploy time</div>
+          </div>
+        </div>
+      </div>
+    </div>
+
+  </section>
+
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -61,6 +61,7 @@ Shipit::Engine.routes.draw do
     patch '/' => 'stacks#update'
     delete '/' => 'stacks#destroy'
     get :settings, controller: :stacks
+    get :statistics, controller: :stacks
     post :refresh, controller: :stacks
     get :refresh, controller: :stacks # For easier design, sorry :/
     post :clear_git_cache, controller: :stacks
@@ -73,6 +74,8 @@ Shipit::Engine.routes.draw do
   scope '/*stack_id', stack_id: stack_id_format, as: :stack do
     get '/commit/:sha/checks' => 'commit_checks#show', as: :commit_checks
     get '/commit/:sha/checks/tail' => 'commit_checks#tail', as: :tail_commit_checks, defaults: {format: :json}
+
+    get '/stats' => 'stats#show', as: :stats
 
     resources :rollbacks, only: %i(create)
     resources :commits, only: %i(update)

--- a/test/controllers/stacks_controller_test.rb
+++ b/test/controllers/stacks_controller_test.rb
@@ -110,6 +110,11 @@ module Shipit
       assert_response :success
     end
 
+    test "#statistics is success" do
+      get :statistics, params: {id: @stack.to_param}
+      assert_response :success
+    end
+
     test "#update allows to lock the stack" do
       refute @stack.locked?
 

--- a/test/fixtures/shipit/stacks.yml
+++ b/test/fixtures/shipit/stacks.yml
@@ -320,3 +320,41 @@ shipit_single:
     }
   updated_at: <%= 8.days.ago.to_s(:db) %>
   last_deployed_at: <%= 8.days.ago.to_s(:db) %>
+
+shipit_stats:
+  repo_owner: "shopify"
+  repo_name: "shipit-engine"
+  environment: "stats"
+  branch: master
+  ignore_ci: false
+  merge_queue_enabled: true
+  tasks_count: 4
+  undeployed_commits_count: 1
+  cached_deploy_spec: >
+    {
+      "machine": {"environment": {}},
+      "review": {
+        "checklist": ["foo", "bar", "baz"],
+        "monitoring": [
+          {"image": "https://example.com/monitor.png", "width": 200, "height": 300}
+        ]
+      },
+      "dependencies": {"override": []},
+      "deploy": {"override": null},
+      "rollback": {"override": ["echo 'Rollback!'"]},
+      "fetch": ["echo '42'"],
+      "tasks": {
+        "restart": {
+          "action": "Restart application",
+          "description": "Restart app and job servers",
+          "steps": [
+            "cap $ENVIRONMENT deploy:restart"
+          ]
+        }
+      },
+      "ci": {
+        "blocking": ["soc/compliance"]
+      }
+    }
+  updated_at: <%= 8.days.ago.to_s(:db) %>
+  last_deployed_at: <%= 8.days.ago.to_s(:db) %>

--- a/test/fixtures/shipit/tasks.yml
+++ b/test/fixtures/shipit/tasks.yml
@@ -10,7 +10,7 @@ shipit:
   deletions: 1
   created_at: <%= (60 - 1).minutes.ago.to_s(:db) %>
   started_at: <%= (60 - 1).minutes.ago.to_s(:db) %>
-  ended_at: <%= (60 - 3).minutes.ago.to_s(:db) %>
+  ended_at: <%= (60 - 6).minutes.ago.to_s(:db) %>
 
 shipit2:
   id: 2
@@ -278,3 +278,59 @@ shipit_single:
   created_at: <%= (60 - 2).minutes.ago.to_s(:db) %>
   started_at: <%= (60 - 2).minutes.ago.to_s(:db) %>
   ended_at: <%= (60 - 4).minutes.ago.to_s(:db) %>
+
+shipit_stats:
+  id: 401
+  user: walrus
+  since_commit_id: 601
+  until_commit_id: 601
+  type: Shipit::Deploy
+  stack: shipit_stats
+  status: success
+  additions: 12
+  deletions: 64
+  created_at: <%= 60.minutes.ago.to_s(:db) %>
+  started_at: <%= 60.minutes.ago.to_s(:db) %>
+  ended_at: <%= (60 - 4).minutes.ago.to_s(:db) %>
+
+shipit_stats_2:
+  id: 402
+  user: walrus
+  since_commit_id: 602
+  until_commit_id: 603
+  type: Shipit::Deploy
+  stack: shipit_stats
+  status: failed
+  additions: 12
+  deletions: 64
+  created_at: <%= (60 - 5).minutes.ago.to_s(:db) %>
+  started_at: <%= (60 - 5).minutes.ago.to_s(:db) %>
+  ended_at: <%= (60 - 11).minutes.ago.to_s(:db) %>
+
+shipit_stats_3:
+  id: 403
+  user: walrus
+  since_commit_id: 604
+  until_commit_id: 605
+  type: Shipit::Deploy
+  stack: shipit_stats
+  status: success
+  additions: 12
+  deletions: 64
+  created_at: <%= (60 - 10).minutes.ago.to_s(:db) %>
+  started_at: <%= (60 - 12).minutes.ago.to_s(:db) %>
+  ended_at: <%= (60 - 15).minutes.ago.to_s(:db) %>
+
+shipit_stats_4:
+  id: 404
+  user: walrus
+  since_commit_id: 606
+  until_commit_id: 608
+  type: Shipit::Deploy
+  stack: shipit_stats
+  status: success
+  additions: 12
+  deletions: 64
+  created_at: <%= (30 - 15).minutes.ago.to_s(:db) %>
+  started_at: <%= (30 - 15).minutes.ago.to_s(:db) %>
+  ended_at: <%= (30 - 17).minutes.ago.to_s(:db) %>

--- a/test/models/deploy_stats_test.rb
+++ b/test/models/deploy_stats_test.rb
@@ -1,0 +1,112 @@
+require 'test_helper'
+
+module Shipit
+  class DeployStatsTest < ActiveSupport::TestCase
+    def setup
+      @stack = shipit_stacks(:shipit_stats)
+      @stats = Shipit::DeployStats.new(@stack.deploys.not_active)
+      @old_deploys = @stack.deploys.not_active.where(created_at: 62.minutes.ago..32.minutes.ago)
+      @new_deploys = @stack.deploys.not_active.where("created_at > ?", 32.minutes.ago)
+    end
+
+    test "#average_duration is accurate" do
+      assert_equal 225.0, @stats.average_duration
+    end
+
+    test "#median_duration is accurate" do
+      assert_equal 210.0, @stats.median_duration
+    end
+
+    test "#max_duration is accurate" do
+      assert_equal 360.0, @stats.max_duration
+    end
+
+    test "#min_duration is accurate" do
+      assert_equal 120.0, @stats.min_duration
+    end
+
+    test "#success_rate is accurate" do
+      assert_equal 75.0, @stats.success_rate
+    end
+
+    test "#average_duration handles empty deploy data" do
+      stats = Shipit::DeployStats.new([])
+      assert_nil stats.average_duration
+    end
+
+    test "#median_duration handles empty deploy data" do
+      stats = Shipit::DeployStats.new([])
+      assert_nil stats.median_duration
+    end
+
+    test "#max_duration handles empty deploy data" do
+      stats = Shipit::DeployStats.new([])
+      assert_nil stats.max_duration
+    end
+
+    test "#min_duration handles empty deploy data" do
+      stats = Shipit::DeployStats.new([])
+      assert_nil stats.min_duration
+    end
+
+    test "#success_rate handles empty deploy data" do
+      stats = Shipit::DeployStats.new([])
+      assert_nil stats.success_rate
+    end
+
+    test "#compare count handles empty compare count" do
+      comparison = Shipit::DeployStats.new([])
+      results = @stats.compare(comparison)
+      assert_equal 400, results[:count]
+    end
+
+    test "#compare average and median handles empty array" do
+      comparison = Shipit::DeployStats.new([])
+      results = @stats.compare(comparison)
+      assert_nil results[:average_duration]
+      assert_nil results[:median_duration]
+    end
+
+    test "#compare average is accurate when negative" do
+      new_data = Shipit::DeployStats.new(@new_deploys)
+      old_data = Shipit::DeployStats.new(@old_deploys)
+      results = new_data.compare(old_data)
+      assert_equal(-53.84615384615385, results[:average_duration])
+    end
+
+    test "#compare median is accurate when negative" do
+      new_data = Shipit::DeployStats.new(@new_deploys)
+      old_data = Shipit::DeployStats.new(@old_deploys)
+      results = new_data.compare(old_data)
+      assert_equal(-50, results[:median_duration])
+    end
+
+    test "#compare count is accurate when negative" do
+      new_data = Shipit::DeployStats.new(@new_deploys)
+      old_data = Shipit::DeployStats.new(@old_deploys)
+      results = new_data.compare(old_data)
+      assert_equal(-66.66666666666666, results[:count])
+    end
+
+    test "#compare average is accurate" do
+      old_data = Shipit::DeployStats.new(@new_deploys)
+      new_data = Shipit::DeployStats.new(@old_deploys)
+      results = new_data.compare(old_data)
+      assert_equal(116.66666666666667, results[:average_duration])
+    end
+
+    test "#compare median is accurate" do
+      old_data = Shipit::DeployStats.new(@new_deploys)
+      new_data = Shipit::DeployStats.new(@old_deploys)
+      results = new_data.compare(old_data)
+      assert_equal(100, results[:median_duration])
+    end
+
+    test "#compare count is accurate" do
+      old_data = Shipit::DeployStats.new(@new_deploys)
+      new_data = Shipit::DeployStats.new(@old_deploys)
+      results = new_data.compare(old_data)
+      assert_equal(200, results[:count])
+    end
+  end
+end


### PR DESCRIPTION
I created this page under the assumption that not everyone will have or want to use a metrics platform to send their deploy data too. In that case they can use this basic statistic page that shows some stats over rolling 7 day period. This is hardcoded for now for simplicity. Ideally it could be expanded to a selector with "Last 24h", "Last Week", "Last Month" or (if you are really ambitious) a custom date range.

This is how the page looks with some dummy data after manipulating the seed data.

<img width="1190" alt="Screen Shot 2019-08-12 at 2 14 24 PM" src="https://user-images.githubusercontent.com/52968121/62891512-85e24800-bd0b-11e9-8ca2-2b86d332ae17.png">

This PR is most certainly WIP. However, i wanted to get some upstream eyes on it before putting a bunch more work into it.  

TODO:
- [ ] tests
- [ ] CSS cleanup, not all classes are being used right now
- [ ] DRY, lots of duplication in the controller right now
 