### PR TITLE
Bumps nokogiri for CVE-2019-5477

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -160,7 +160,7 @@ GEM
     multipart-post (2.1.1)
     mysql2 (0.4.6)
     nio4r (2.4.0)
-    nokogiri (1.10.3)
+    nokogiri (1.10.4)
       mini_portile2 (~> 2.4.0)
     oauth2 (1.4.1)
       faraday (>= 0.8, < 0.16.0)


### PR DESCRIPTION
As per https://github.com/sparklemotion/nokogiri/issues/1915, bumps nokogiri to protect against said vulnerability

@casperisfine @EiNSTeiN- 