### PR TITLE
Improve 'Commits not include in this deploy' presentation

### DIFF
--- a/app/assets/stylesheets/_structure/_main.scss
+++ b/app/assets/stylesheets/_structure/_main.scss
@@ -142,8 +142,9 @@ pre {
 .less-important {
     color: $grey;
     margin-bottom: 0em;
-    margin-top: 1em;
+    margin-top: 5em;
     p {
+        margin-top: 1.5rem;
         margin-bottom: 0.5em;
     }
 }

--- a/app/views/shipit/deploys/new.html.erb
+++ b/app/views/shipit/deploys/new.html.erb
@@ -9,18 +9,6 @@
     <%= render 'shipit/deploys/summary', commits: @deploy.commits %>
   </section>
 
-  <% unless @deploy.commits_since.empty?  %>
-    <section class="less-important">
-
-      <p>The following commits are <strong>not</strong> included in this deploy.
-      Please ensure that none of these commits are needed for what
-      <strong>is</strong> being deployed (for example, if they contain the revert
-      of a broken change).</p>
-
-      <%= render 'shipit/deploys/summary', commits: @deploy.commits_since %>
-    </section>
-  <% end %>
-
   <%= render_monitoring @stack %>
 
   <%= render_checks @commit %>
@@ -35,6 +23,23 @@
     <section class="submit-section">
       <%= f.hidden_field :until_commit_id %>
       <%= f.submit class: 'btn btn--primary btn--large trigger-deploy' %>
+    </section>
+  <% end %>
+
+  <% unless @deploy.commits_since.empty?  %>
+    <section class="less-important">
+      <header class="section-header">
+        <h2>Commits not included in this deploy</h2>
+      </header>
+
+      <div>
+        <p>The following commits are <strong>not</strong> included in this deploy.
+        Please ensure that none of these commits are needed for what
+        <strong>is</strong> being deployed (for example, if they contain the revert
+        of a broken change).</p>
+
+        <%= render 'shipit/deploys/summary', commits: @deploy.commits_since %>
+      </div>
     </section>
   <% end %>
 </div>


### PR DESCRIPTION
## Problem

In the current state, commits not included in the deploy are presented inside a section with the header that says `Commits included in this deploy`, which creates the wrong impression on the user.

Moreover, these not-included commits are listed above the `Create Deploy` button, giving the impression that they are a part of the commits that will be included in the action.

## Solution

This PR moves the `Commits not included in this deploy` section outside and below the `Create Deploy` button so that it is visually separate from where the action is expected to happen. The information is still being displayed in a de-emphasized manner, and the title of the new section is very clear, so it should not create extra user confusion.

### Before

<img width="1066" alt="Screenshot 2019-08-16 at 18 51 06" src="https://user-images.githubusercontent.com/224488/63202561-3cba2d00-c058-11e9-8bd8-2b66b43ae821.png">

### After

<img width="1066" alt="Screenshot 2019-08-16 at 18 49 08" src="https://user-images.githubusercontent.com/224488/63202567-4348a480-c058-11e9-9044-0bc0360a2cfd.png">
