### PR TITLE
Use --recursive option when cloning repo from cache

### DIFF
--- a/lib/shipit/stack_commands.rb
+++ b/lib/shipit/stack_commands.rb
@@ -53,7 +53,7 @@ module Shipit
       Dir.mktmpdir do |dir|
         git(
           'clone', @stack.git_path, @stack.repo_name,
-          '--origin', 'cache',
+          '--recursive', '--origin', 'cache',
           chdir: dir
         ).run!
 


### PR DESCRIPTION
Addition of the `--recursive` flag enables deployment of repositories with git submodules.

Further discussion welcome.