### PR TITLE
Increase max fetch to 25

### DIFF
--- a/app/jobs/shipit/github_sync_job.rb
+++ b/app/jobs/shipit/github_sync_job.rb
@@ -2,7 +2,7 @@ module Shipit
   class GithubSyncJob < BackgroundJob
     include BackgroundJob::Unique
 
-    MAX_FETCHED_COMMITS = 10
+    MAX_FETCHED_COMMITS = 25
     queue_as :default
 
     self.timeout = 60


### PR DESCRIPTION
Our new merge-queue can fast-forward up to 24 commits at a time right now, so the github sync here should be increased to be able to process and sync more commits to ensure things are not dropped.