### PR TITLE
Various optimizations to reduce git lock contention

### DIFF
--- a/app/jobs/shipit/perform_task_job.rb
+++ b/app/jobs/shipit/perform_task_job.rb
@@ -63,7 +63,9 @@ module Shipit
     def checkout_repository
       unless @commands.fetched?(@task.until_commit).tap(&:run).success?
         @task.acquire_git_cache_lock do
-          capture! @commands.fetch
+          unless @commands.fetched?(@task.until_commit).tap(&:run).success?
+            capture! @commands.fetch
+          end
         end
       end
       capture_all! @commands.clone

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -354,8 +354,8 @@ module Shipit
 
     def clear_git_cache!
       tmp_path = "#{git_path}-#{SecureRandom.hex}"
+      return unless File.exist?(git_path)
       acquire_git_cache_lock do
-        return unless File.exist?(git_path)
         File.rename(git_path, tmp_path)
       end
       FileUtils.rm_rf(tmp_path)

--- a/lib/shipit/stack_commands.rb
+++ b/lib/shipit/stack_commands.rb
@@ -46,7 +46,9 @@ module Shipit
 
       if !commit || !fetched?(commit).tap(&:run).success?
         @stack.acquire_git_cache_lock do
-          fetch.run!
+          unless fetched?(commit).tap(&:run).success?
+            fetch.run!
+          end
         end
       end
 


### PR DESCRIPTION
- When fetching the repo, we [double check](https://en.wikipedia.org/wiki/Double-checked_locking) the commit presence, because it's likely that the lock we were waiting onto was already fetching that same commit.

- `clear_git_cache!` can directly bail out before locking if the repo doesn't exist.