### PR TITLE
Update seeds and fix travis errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,11 @@
-dist: precise # https://github.com/travis-ci/travis-ci/issues/8331
-addons:
-  apt:
-    packages:
-      - sqlite3 # https://github.com/rails/rails/issues/24288#issuecomment-206011385
 language: ruby
 sudo: false
 script: 'script/cibuild'
 cache: bundler
+
+before_install:
+  - gem install bundler -v 1.17.3
+
 env:
   matrix:
     - SUITE=mysql
@@ -14,11 +13,25 @@ env:
     - SUITE=sqlite3
     - SUITE=rubocop
     - SUITE=setup
+
 rvm:
   - 2.5.3
+  - 2.6.3
+
+matrix:
+  fast_finish: true
+  exclude:
+    - rvm: 2.6.3
+  include:
+    - rvm: 2.6.3
+      env: SUITE=sqlite3
 
 notifications:
   email: false
+
 services:
   - redis
+  - mysql
+  - postgresql
+
 bundler_args: --without deploy production debug --jobs 3 --retry 3

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -2,11 +2,11 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# Note that this schema.rb definition is the authoritative source for your
-# database schema. If you need to create the application database on another
-# system, you should be using db:schema:load, not running all the migrations
-# from scratch. The latter is a flawed and unsustainable approach (the more migrations
-# you'll amass, the slower it'll run and the greater likelihood for issues).
+# This file is the source Rails uses to define your schema when running `rails
+# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# be faster and is potentially less error prone than running all of your
+# migrations from scratch. Old migrations may fail to apply correctly if those
+# migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 

--- a/test/dummy/db/seeds.rb
+++ b/test/dummy/db/seeds.rb
@@ -112,8 +112,8 @@ module Shipit
         message:      Faker::Company.catch_phrase,
         authored_at:  Time.now,
         committed_at: Time.now,
-        additions: Faker::Number.number(3),
-        deletions: Faker::Number.number(3),
+        additions: Faker::Number.number(digits: 3),
+        deletions: Faker::Number.number(digits: 3),
       )
 
       if (i % 4) != 0
@@ -144,19 +144,19 @@ module Shipit
     end
 
     stack.pull_requests.create!(
-      number: Faker::Number.number(3),
+      number: Faker::Number.number(digits: 3),
       title: Faker::Company.catch_phrase,
       merge_status: 'pending',
       merge_requested_at: 5.minute.ago,
       merge_requested_by: users.sample,
-      github_id: Faker::Number.number(8),
+      github_id: Faker::Number.number(digits: 8),
       api_url: 'https://api.github.com/repos/shopify/shipit-engine/pulls/62',
       state: 'open',
-      branch: "feature-#{Faker::Number.number(3)}",
+      branch: "feature-#{Faker::Number.number(digits: 3)}",
       head_id: nil,
       mergeable: true,
-      additions: Faker::Number.number(3),
-      deletions: Faker::Number.number(3),
+      additions: Faker::Number.number(digits: 3),
+      deletions: Faker::Number.number(digits: 3),
     )
   end
 
@@ -173,8 +173,8 @@ module Shipit
         since_commit_id: commits.first.id,
         until_commit_id: commits.last.id,
         status:          "success",
-        additions: Faker::Number.number(3),
-        deletions: Faker::Number.number(3),
+        additions: Faker::Number.number(digits: 3),
+        deletions: Faker::Number.number(digits: 3),
         started_at: Random.rand(15.minutes.to_i).seconds.ago,
         ended_at: Time.now.utc,
         user: users.sample,


### PR DESCRIPTION
Update seeds to follow a new Faker version
After upgrade gems, seeds task returns:

```
shipit-engine/test/dummy/db/seeds.rb:115: Passing `digits` with the 1st argument of `number` is deprecated. Use keyword argument like `number(digits: ...)` instead.
```

In Travis there is exception for ruby 2.3.8:

```
zeitwerk-2.1.10 requires ruby version >= 2.4.4, which is incompatible with the
```

For ruby 2.4.5:

```
activesupport-6.0.0 requires ruby version >= 2.5.0, which is incompatible with
```

For ruby 2.5.3:

```
Your version of SQLite (3.7.9) is too old. Active Record supports SQLite >= 3.8.
```

Base on those exceptions, minimum required ruby is 2.5.0.
Update Travis OS dist to current default `xenial`. (I have tested dist: bionic, it has issue to setup postgresql).
List of TravisCI's dist: https://docs.travis-ci.com/user/reference/linux/