### PR TITLE
Wrap sql with Arel, to mark order params as safe

### DIFF
--- a/app/controllers/shipit/stacks_controller.rb
+++ b/app/controllers/shipit/stacks_controller.rb
@@ -9,7 +9,7 @@ module Shipit
     def index
       @user_stacks = current_user.stacks_contributed_to
 
-      @stacks = Stack.order(Arel.sql('(undeployed_commits_count > 0) desc, tasks_count desc')).to_a
+      @stacks = Stack.order(Arel.sql('(undeployed_commits_count > 0) desc'), tasks_count: :desc).to_a
     end
 
     def show


### PR DESCRIPTION
There is a deprecation warning:

```
DEPRECATION WARNING: Dangerous query method (method whose arguments are used as raw SQL) called with non-attribute argument(s): "(undeployed_commits_count > 0) desc". Non-attribute arguments will be disallowed in Rails 6.1. This method should not be called with user-provided values, such as request parameters or model attributes. Known-safe values can be passed by wrapping them in Arel.sql(). (called from index at app/controllers/shipit/stacks_controller.rb:12)
```

P.S.: The warning discussed: https://github.com/rails/rails/issues/32995

Wrap string with `Arel.sql`