### PR TITLE
Fix GitHubApp for Enterprise installations

### DIFF
--- a/lib/shipit/github_app.rb
+++ b/lib/shipit/github_app.rb
@@ -132,7 +132,7 @@ module Shipit
       if enterprise?
         options = options.reverse_merge(
           api_endpoint: api_endpoint,
-          web_endpoint: web_endpoint
+          web_endpoint: web_endpoint,
         )
       end
       client = Octokit::Client.new(options)

--- a/lib/shipit/github_app.rb
+++ b/lib/shipit/github_app.rb
@@ -125,7 +125,7 @@ module Shipit
     end
 
     def new_client(options = {})
-      options.reverse_merge(api_endpoint: api_endpoint) if api_endpoint
+      options.reverse_merge!(api_endpoint: api_endpoint) if api_endpoint
       client = Octokit::Client.new(options)
       client.middleware = faraday_stack
       client

--- a/lib/shipit/github_app.rb
+++ b/lib/shipit/github_app.rb
@@ -120,12 +120,21 @@ module Shipit
       url('/api/v3/') if enterprise?
     end
 
+    def web_endpoint
+      url if enterprise?
+    end
+
     def enterprise?
       domain != DOMAIN
     end
 
     def new_client(options = {})
-      options = options.reverse_merge(api_endpoint: api_endpoint) if api_endpoint
+      if enterprise?
+        options = options.reverse_merge(
+          api_endpoint: api_endpoint,
+          web_endpoint: web_endpoint
+        )
+      end
       client = Octokit::Client.new(options)
       client.middleware = faraday_stack
       client

--- a/lib/shipit/github_app.rb
+++ b/lib/shipit/github_app.rb
@@ -125,7 +125,7 @@ module Shipit
     end
 
     def new_client(options = {})
-      options.reverse_merge!(api_endpoint: api_endpoint) if api_endpoint
+      options = options.reverse_merge(api_endpoint: api_endpoint) if api_endpoint
       client = Octokit::Client.new(options)
       client.middleware = faraday_stack
       client

--- a/test/unit/github_app_test.rb
+++ b/test/unit/github_app_test.rb
@@ -52,7 +52,8 @@ module Shipit
     end
 
     test "#new_client retruns an Octokit::Client configure to use the github installation" do
-      assert_equal 'https://github.example.com', @enterprise.new_client.web_endpoint
+      assert_equal 'https://github.example.com/', @enterprise.new_client.web_endpoint
+      assert_equal 'https://github.example.com/api/v3/', @enterprise.new_client.api_endpoint
     end
 
     test "#oauth_config.last[:client_options] is nil if domain is not overriden" do

--- a/test/unit/github_app_test.rb
+++ b/test/unit/github_app_test.rb
@@ -51,6 +51,10 @@ module Shipit
       assert_equal 'https://github.example.com/foo/bar/baz', @enterprise.url('foo/bar', 'baz')
     end
 
+    test "#new_client retruns an Octokit::Client configure to use the github installation" do
+      assert_equal 'https://github.example.com', @enterprise.new_client.web_endpoint
+    end
+
     test "#oauth_config.last[:client_options] is nil if domain is not overriden" do
       assert_nil @github.oauth_config.last[:client_options][:site]
     end

--- a/test/unit/github_app_test.rb
+++ b/test/unit/github_app_test.rb
@@ -51,7 +51,7 @@ module Shipit
       assert_equal 'https://github.example.com/foo/bar/baz', @enterprise.url('foo/bar', 'baz')
     end
 
-    test "#new_client retruns an Octokit::Client configure to use the github installation" do
+    test "#new_client retruns an Octokit::Client configured to use the github installation" do
       assert_equal 'https://github.example.com/', @enterprise.new_client.web_endpoint
       assert_equal 'https://github.example.com/api/v3/', @enterprise.new_client.api_endpoint
     end


### PR DESCRIPTION
Fix GitHubApp for Enterprise installations.  Options hash was not actually being modified to add in the `api_endpoint`.