### PR TITLE
Fix GitHub tokens not being updated before expiry.

### DIFF
--- a/lib/shipit/github_app.rb
+++ b/lib/shipit/github_app.rb
@@ -9,7 +9,9 @@ module Shipit
         end
       end
 
-      attr_reader :expires_at
+      GITHUB_TOKEN_REFRESH_WINDOW = 10.minutes
+
+      attr_reader :expires_at, :refresh_at
 
       def to_s
         @token
@@ -18,10 +20,11 @@ module Shipit
       def initialize(token, expires_at)
         @token = token
         @expires_at = expires_at
+        @refresh_at = expires_at - GITHUB_TOKEN_REFRESH_WINDOW
       end
 
       def blank?
-        @expires_at.past?
+        @refresh_at.past?
       end
     end
 
@@ -88,7 +91,8 @@ module Shipit
         )
         token = Token.from_github(response)
         raise AuthenticationFailed if token.blank?
-        Rails.logger.info("Created GitHub access token ending #{token.to_s[-5..-1]}, expires at #{token.expires_at}")
+        Rails.logger.info("Created GitHub access token ending #{token.to_s[-5..-1]}, expires at #{token.expires_at}"\
+          " and will be refreshed at #{token.refreshes_at}")
         token
       end
     end

--- a/lib/shipit/github_app.rb
+++ b/lib/shipit/github_app.rb
@@ -9,8 +9,6 @@ module Shipit
         end
       end
 
-      GITHUB_TOKEN_REFRESH_WINDOW = 10.minutes
-
       attr_reader :expires_at, :refresh_at
 
       def to_s
@@ -20,6 +18,8 @@ module Shipit
       def initialize(token, expires_at)
         @token = token
         @expires_at = expires_at
+
+        # This needs to be lower than the token's lifetime, but higher than the cache expiry setting.
         @refresh_at = expires_at - GITHUB_TOKEN_REFRESH_WINDOW
       end
 
@@ -31,6 +31,10 @@ module Shipit
     DOMAIN = 'github.com'.freeze
     AuthenticationFailed = Class.new(StandardError)
     API_STATUS_ID = 'brv1bkgrwx7q'.freeze
+
+    GITHUB_EXPECTED_TOKEN_LIFETIME = 60.minutes
+    GITHUB_TOKEN_RAILS_CACHE_LIFETIME = 50.minutes
+    GITHUB_TOKEN_REFRESH_WINDOW = GITHUB_EXPECTED_TOKEN_LIFETIME - GITHUB_TOKEN_RAILS_CACHE_LIFETIME - 2.minutes
 
     attr_reader :oauth_teams, :domain, :bot_login
 
@@ -84,7 +88,13 @@ module Shipit
     end
 
     def fetch_new_token
-      Rails.cache.fetch('github:integration:access-token', expires_in: 50.minutes, race_condition_ttl: 10.minutes) do
+      # Rails can add 5 minutes to the cache entry expiration time when any TTL is provided,
+      # so our TTL setting can be lower, and TTL + expires_in should be lower than the GitHub token expiration.
+      Rails.cache.fetch(
+        'github:integration:access-token',
+        expires_in: GITHUB_TOKEN_RAILS_CACHE_LIFETIME,
+        race_condition_ttl: 4.minutes,
+      ) do
         response = new_client(bearer_token: authentication_payload).create_app_installation_access_token(
           installation_id,
           accept: 'application/vnd.github.machine-man-preview+json',
@@ -92,7 +102,7 @@ module Shipit
         token = Token.from_github(response)
         raise AuthenticationFailed if token.blank?
         Rails.logger.info("Created GitHub access token ending #{token.to_s[-5..-1]}, expires at #{token.expires_at}"\
-          " and will be refreshed at #{token.refreshes_at}")
+          " and will be refreshed at #{token.refresh_at}")
         token
       end
     end

--- a/test/unit/github_app_test.rb
+++ b/test/unit/github_app_test.rb
@@ -5,6 +5,14 @@ module Shipit
     setup do
       @github = app
       @enterprise = app(domain: 'github.example.com')
+      @rails_env = Rails.env
+      @token_cache_key = 'github:integration:access-token'
+      Rails.cache.delete(@token_cache_key)
+    end
+
+    teardown do
+      Rails.env = @rails_env
+      Rails.cache.delete(@token_cache_key)
     end
 
     test "#initialize doesn't raise if given an empty config" do
@@ -62,6 +70,88 @@ module Shipit
 
     test "#oauth_config.last[:client_options] returns Enterprise endpoint if domain is overriden" do
       assert_equal 'https://github.example.com/api/v3/', @enterprise.oauth_config.last[:client_options][:site]
+    end
+
+    test "#github token is refreshed after expiration" do
+      Rails.env = 'not_test'
+      config = {
+        app_id: "test_id",
+        installation_id: "test_installation_id",
+        private_key: "test_private_key",
+      }
+      initial_token = OpenStruct.new(
+        token: "some_initial_github_token",
+        expires_at: Time.now.utc + 60.minutes,
+      )
+      second_token = OpenStruct.new(
+        token: "some_new_github_token",
+        expires_at: initial_token.expires_at + 60.minutes,
+      )
+      auth_payload = "test_auth_payload"
+
+      GitHubApp.any_instance.expects(:authentication_payload).twice.returns(auth_payload)
+      valid_app = app(config)
+
+      freeze_time do
+        Octokit::Client
+          .any_instance
+          .expects(:create_app_installation_access_token).twice.with(config[:installation_id], anything)
+          .returns(initial_token, second_token)
+
+        initial_token = valid_app.token
+        initial_cached_token = Rails.cache.fetch(@token_cache_key)
+        assert_equal initial_token, initial_cached_token.to_s
+
+        travel 5.minutes
+        assert_equal initial_token, valid_app.token
+
+        travel_to initial_cached_token.expires_at + 5.minutes
+        assert_equal second_token.token, valid_app.token
+      end
+    end
+
+    test "#github token is refreshed in refresh window before expiry" do
+      Rails.env = 'not_test'
+      config = {
+        app_id: "test_id",
+        installation_id: "test_installation_id",
+        private_key: "test_private_key",
+      }
+      initial_token = OpenStruct.new(
+        token: "some_initial_github_token",
+        expires_at: Time.now.utc + 60.minutes,
+      )
+      second_token = OpenStruct.new(
+        token: "some_new_github_token",
+        expires_at: initial_token.expires_at + 60.minutes,
+      )
+      auth_payload = "test_auth_payload"
+
+      GitHubApp.any_instance.expects(:authentication_payload).twice.returns(auth_payload)
+      valid_app = app(config)
+
+      freeze_time do
+        Octokit::Client
+          .any_instance
+          .expects(:create_app_installation_access_token).twice.with(config[:installation_id], anything)
+          .returns(initial_token, second_token)
+
+        initial_token = valid_app.token
+        initial_cached_token = Rails.cache.fetch(@token_cache_key)
+        assert_equal initial_token, initial_cached_token.to_s
+
+        # Travel forward, but before the token is refreshed, so the cached value should be the same.
+        travel 40.minutes
+        assert_equal initial_token, valid_app.token
+
+        # Travel to when the token should refresh, but is not expired, which should result in our cache.fetch update block.
+        travel 15.minutes
+        updated_token = valid_app.token
+        assert_not_equal initial_token, updated_token
+
+        cached_token = Rails.cache.fetch(@token_cache_key)
+        assert_operator cached_token.expires_at, :>, initial_cached_token.expires_at
+      end
     end
 
     private


### PR DESCRIPTION
[_GitHub Token means Github App Installation Token_]

We want to update GitHub tokens roughly ~10 minutes before they expire.

This is accomplished by setting a cache expiry of 50 minutes (GitHub tokens expire in 60 minutes) with a `race_condition_ttl` of 10 minutes, which should allow racing Shipit threads to continue using the old, valid token while the request for a new one is flying.

However, it turns out that we're gating this cache logic behind a check on whether the GitHub token itself has expired:

```ruby
class Token
...
  def blank?
    @expires_at.past?
  end
...
end
...
# Presence uses `blank?`
@token = @token.presence || synchronize { @token.presence || fetch_new_token }
```

So the GitHub token will expire, then the Shipit threads/nodes will race to update it; our cache ttl logic will ensure that the expired token object is re-inserted into the rails cache while the race winner is calling for a new token.
The losers then receive the expired token from the cache, try to use it (causing a 401), and then on the next call into GitHubApp, will try to update it themselves (if the initial winner hasn't written a new token to the cache by that time).

The quick solution of this PR is to ensure that we check whether we need a new token _before_ the current token has expired.

This should help with https://github.com/Shopify/shipit-engine/issues/924, if not resolve it outright.

---

I've retained the debug logging for now, along with the existing GitHub expired_at details in the Token object. It's possible I've missed something, so having the logging will help to debug further if errors continue to surface for a short period after deploying.

I've also adjusted the race condition TTL to be lower, as having this set at all with redis or memcached in the loop will add 5 minutes to the (cache entry) expiration inside the [Rails cache code](https://github.com/rails/rails/blob/master/activesupport/lib/active_support/cache/mem_cache_store.rb#L156).