### PR TITLE
Guard against missing token refresh field.

### DIFF
--- a/lib/shipit/github_app.rb
+++ b/lib/shipit/github_app.rb
@@ -24,6 +24,9 @@ module Shipit
       end
 
       def blank?
+        # Old tokens missing @refresh_at may be used upon deploy, so we should auto-correct for now.
+        # TODO: Remove this assignment at a later date.
+        @refresh_at ||= @expires_at - GITHUB_TOKEN_REFRESH_WINDOW
         @refresh_at.past?
       end
     end
@@ -102,7 +105,7 @@ module Shipit
         token = Token.from_github(response)
         raise AuthenticationFailed if token.blank?
         Rails.logger.info("Created GitHub access token ending #{token.to_s[-5..-1]}, expires at #{token.expires_at}"\
-          " and will be refreshed at #{token.refresh_at}")
+          " and will be refreshed at #{token&.refresh_at}")
         token
       end
     end


### PR DESCRIPTION
The token changes deployed earlier today (https://github.com/Shopify/shipit-engine/pull/951) broke deploys, as the shipit app pulled down the cached Token object, which was missing a field that the updated method was trying to use.

From: https://shipit.shopify.io/shopify/shopify/canaries/deploys/873103
```s
NoMethodError: undefined method `past?' for nil:NilClass
	/artifacts/ruby/2.6.0/bundler/gems/shipit-engine-21fc3eae8681/lib/shipit/github_app.rb:27:in `blank?'
	/artifacts/ruby/2.6.0/gems/activesupport-6.0.0/lib/active_support/core_ext/object/blank.rb:26:in `present?'
	/artifacts/ruby/2.6.0/gems/activesupport-6.0.0/lib/active_support/core_ext/object/blank.rb:46:in `presence'
	/artifacts/ruby/2.6.0/bundler/gems/shipit-engine-21fc3eae8681/lib/shipit/github_app.rb:86:in `token'
	/artifacts/ruby/2.6.0/bundler/gems/shipit-engine-21fc3eae8681/lib/shipit/commands.rb:24:in `env'
```

This PR fixes that by using a conditional assignment before using the token.

I've also added a regression test for this case (if you remove the updated business logic, it will fail.)