### PR TITLE
Defer continuous delivery if commit was recently pushed

### DIFF
--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -157,7 +157,8 @@ module Shipit
         return
       end
 
-      if commit.deploy_failed? || (checks? && !EphemeralCommitChecks.new(commit).run.success?)
+      if commit.deploy_failed? || (checks? && !EphemeralCommitChecks.new(commit).run.success?) ||
+         commit.recently_pushed?
         continuous_delivery_delayed!
         return
       end

--- a/test/fixtures/shipit/commits.yml
+++ b/test/fixtures/shipit/commits.yml
@@ -10,6 +10,7 @@ first:
   additions: 42
   deletions: 24
   updated_at: <%= 8.days.ago.to_s(:db) %>
+  created_at: <%= 1.day.ago.to_s(:db) %>
 
 second:
   id: 2
@@ -23,6 +24,7 @@ second:
   additions: 1
   deletions: 1
   updated_at: <%= 8.days.ago.to_s(:db) %>
+  created_at: <%= 1.day.ago.to_s(:db) %>
 
 third:
   id: 3
@@ -36,6 +38,7 @@ third:
   additions: 12
   deletions: 64
   updated_at: <%= 8.days.ago.to_s(:db) %>
+  created_at: <%= 1.day.ago.to_s(:db) %>
 
 fourth:
   id: 4
@@ -49,6 +52,7 @@ fourth:
   additions: 420
   deletions: 342
   updated_at: <%= 8.days.ago.to_s(:db) %>
+  created_at: <%= 1.day.ago.to_s(:db) %>
 
 fifth:
   id: 5
@@ -62,6 +66,7 @@ fifth:
   additions: 1
   deletions: 24
   updated_at: <%= 8.days.ago.to_s(:db) %>
+  created_at: <%= 1.day.ago.to_s(:db) %>
 
 cyclimse_first:
   id: 6
@@ -194,6 +199,7 @@ canaries_first:
   additions: 42
   deletions: 24
   updated_at: <%= 8.days.ago.to_s(:db) %>
+  created_at: <%= 1.day.ago.to_s(:db) %>
 
 canaries_second:
   id: 302
@@ -207,6 +213,7 @@ canaries_second:
   additions: 1
   deletions: 1
   updated_at: <%= 8.days.ago.to_s(:db) %>
+  created_at: <%= 1.day.ago.to_s(:db) %>
 
 canaries_third:
   id: 303
@@ -220,6 +227,7 @@ canaries_third:
   additions: 12
   deletions: 64
   updated_at: <%= 8.days.ago.to_s(:db) %>
+  created_at: <%= 1.day.ago.to_s(:db) %>
 
 canaries_fourth:
   id: 304
@@ -233,6 +241,7 @@ canaries_fourth:
   additions: 420
   deletions: 342
   updated_at: <%= 8.days.ago.to_s(:db) %>
+  created_at: <%= 1.day.ago.to_s(:db) %>
 
 canaries_fifth:
   id: 305
@@ -246,6 +255,7 @@ canaries_fifth:
   additions: 1
   deletions: 24
   updated_at: <%= 8.days.ago.to_s(:db) %>
+  created_at: <%= 1.day.ago.to_s(:db) %>
 
 undeployed_1:
   id: 401

--- a/test/models/commits_test.rb
+++ b/test/models/commits_test.rb
@@ -773,6 +773,16 @@ module Shipit
       assert_equal commit.deploy_requested_at, commit.created_at
     end
 
+    test "#recently_pushed?" do
+      freeze_time do
+        commit = Commit.new(message: "abcd", created_at: Time.now.utc)
+        assert_predicate commit, :recently_pushed?
+
+        commit = Commit.new(message: "abcd", created_at: 10.minutes.ago)
+        refute_predicate commit, :recently_pushed?
+      end
+    end
+
     private
 
     def expect_event(stack)

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -870,6 +870,21 @@ module Shipit
       )
     end
 
+    test "#trigger_continuous_delivery sets delay if commit was pushed recently" do
+      freeze_time do
+        @stack.tasks.delete_all
+
+        commit = @stack.next_commit_to_deploy
+        commit.touch(:created_at)
+
+        assert_no_enqueued_jobs(only: Shipit::PerformTaskJob) do
+          assert_no_difference -> { Deploy.count } do
+            @stack.trigger_continuous_delivery
+          end
+        end
+      end
+    end
+
     private
 
     def generate_revert_commit(stack:, reverted_commit:, author: reverted_commit.author)


### PR DESCRIPTION
For some high throughput repos at Shopify we are now fast-forwarding commits to the merge base rather than creating merge commits, and doing so in batches. These commits all have passing CI statuses when they are pushed, so the whole batch is ready to deploy immediately.

What we're seeing quite regularly is a batch of commits is fast-forwarded, but the whole batch is not deployed (e.g. 8 commits pushed, only 7 deployed). This looks to be because we schedule a `ContinuousDeliveryJob` when we create the `Commit` record, and doing so for each commit in the batch creates a race.

This PR attempts to fix that by adding a buffer between when a commit is pushed and when it is eligible for deploy:

* `Stack#trigger_continuous_delivery` will delay and bail early if the commit was pushed recently
* To mitigate the effect of that (deploys could start a bit later than you would expect, depending on when the job runs), delay the execution of `ContinuousDeliveryJob` by the recent commit threshold on create