### PR TITLE
[WIP] Set pending and deploying state refs.

### DIFF
--- a/app/jobs/shipit/update_github_currently_deploying_ref_job.rb
+++ b/app/jobs/shipit/update_github_currently_deploying_ref_job.rb
@@ -7,12 +7,12 @@ module Shipit
     private
 
     def select_target_commit(stack)
-      commits = @stack.undeployed_commits do |scope|
+      commits = stack.undeployed_commits do |scope|
         scope.preload(:author, :statuses, :check_runs, :lock_author)
       end
 
       # TODO: Need to sort?
-      @active_commits = commits.select { |commit| commit.active? }.last
+      @active_commits = commits.select(&:active?).last
     end
   end
 end

--- a/app/jobs/shipit/update_github_currently_deploying_ref_job.rb
+++ b/app/jobs/shipit/update_github_currently_deploying_ref_job.rb
@@ -1,0 +1,18 @@
+module Shipit
+  class UpdateGithubCurrentlyDeployingRefJob < UpdateGithubLastDeployedRefJob
+    queue_as :default
+
+    DEPLOY_PREFIX = 'shipit-deploy-deploying'.freeze
+
+    private
+
+    def select_target_commit(stack)
+      commits = @stack.undeployed_commits do |scope|
+        scope.preload(:author, :statuses, :check_runs, :lock_author)
+      end
+
+      # TODO: Need to sort?
+      @active_commits = commits.select { |commit| commit.active? }.last
+    end
+  end
+end

--- a/app/jobs/shipit/update_github_last_deployed_ref_job.rb
+++ b/app/jobs/shipit/update_github_last_deployed_ref_job.rb
@@ -19,6 +19,7 @@ module Shipit
       update_or_create_ref(client: client, repo_name: full_repo_name, ref: stack_ref, new_sha: stack_sha)
     end
 
+    # TODO: Make a common parent base class rather than inherit from this one.
     private
 
     def create_full_ref(stack_environment)

--- a/app/jobs/shipit/update_github_last_deployed_ref_job.rb
+++ b/app/jobs/shipit/update_github_last_deployed_ref_job.rb
@@ -7,7 +7,7 @@ module Shipit
     DEPLOY_PREFIX = 'shipit-deploy'.freeze
 
     def perform(stack)
-      stack_sha = stack.last_successful_deploy_commit&.sha
+      stack_sha = select_target_commit(stack)
       return unless stack_sha
 
       environment = stack.environment

--- a/app/jobs/shipit/update_github_last_deployed_ref_job.rb
+++ b/app/jobs/shipit/update_github_last_deployed_ref_job.rb
@@ -22,7 +22,7 @@ module Shipit
     private
 
     def create_full_ref(stack_environment)
-      [BRANCH_REF_PREFIX, DEPLOY_PREFIX, stack_environment].join("/")
+      [BRANCH_REF_PREFIX, self::DEPLOY_PREFIX, stack_environment].join("/")
     end
 
     def create_ref(client:, repo_name:, ref:, sha:)
@@ -38,6 +38,10 @@ module Shipit
       else
         raise
       end
+    end
+
+    def select_target_commit(stack)
+      stack.last_successful_deploy_commit&.sha
     end
   end
 end

--- a/app/jobs/shipit/update_github_last_deployed_ref_job.rb
+++ b/app/jobs/shipit/update_github_last_deployed_ref_job.rb
@@ -22,7 +22,7 @@ module Shipit
     private
 
     def create_full_ref(stack_environment)
-      [BRANCH_REF_PREFIX, self::DEPLOY_PREFIX, stack_environment].join("/")
+      [BRANCH_REF_PREFIX, self.class::DEPLOY_PREFIX, stack_environment].join("/")
     end
 
     def create_ref(client:, repo_name:, ref:, sha:)

--- a/app/jobs/shipit/update_github_pending_deploy_ref_job.rb
+++ b/app/jobs/shipit/update_github_pending_deploy_ref_job.rb
@@ -1,0 +1,13 @@
+module Shipit
+  class UpdateGithubPendingDeployRefJob < UpdateGithubLastDeployedRefJob
+    queue_as :default
+
+    DEPLOY_PREFIX = 'shipit-deploy-pending'.freeze
+
+    private
+
+    def select_target_commit(stack)
+      stack.next_expected_commit_to_deploy.sha
+    end
+  end
+end

--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -287,7 +287,7 @@ module Shipit
 
       if previous_changes[:status].last == 'success'
         stack.update_latest_deployed_ref
-        stack.update_deploy_marker_refs
+        stack.update_marker_refs
       end
     end
   end

--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -36,7 +36,7 @@ module Shipit
     after_create :create_commit_deployments
     after_create :update_release_status
     after_commit :broadcast_update
-    after_commit :update_latest_deployed_ref, on: :update
+    after_commit :update_deploy_marker_refs, on: :update
 
     delegate :broadcast_update, :filter_deploy_envs, to: :stack
 
@@ -282,9 +282,13 @@ module Shipit
       stack.update(last_deployed_at: ended_at)
     end
 
-    def update_latest_deployed_ref
+    def update_deploy_marker_refs
       return unless previous_changes.include?(:status)
-      stack.update_latest_deployed_ref if previous_changes[:status].last == 'success'
+
+      if previous_changes[:status].last == 'success'
+        stack.update_latest_deployed_ref
+        stack.update_deploy_marker_refs
+      end
     end
   end
 end

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -136,8 +136,7 @@ module Shipit
       run_now ? deploy.run_now! : deploy.enqueue
       continuous_delivery_resumed!
 
-      UpdateGithubCurrentlyDeployingRefJob.perform_later(self)
-      UpdateGithubPendingDeployRefJob.perform_later(self)
+      update_marker_refs
       deploy
     end
 
@@ -469,6 +468,11 @@ module Shipit
 
     def update_latest_deployed_ref
       UpdateGithubLastDeployedRefJob.perform_later(self)
+    end
+
+    def update_marker_refs
+      UpdateGithubCurrentlyDeployingRefJob.perform_later(self)
+      UpdateGithubPendingDeployRefJob.perform_later(self)
     end
 
     def broadcast_update

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -132,8 +132,12 @@ module Shipit
       run_now = kwargs.delete(:run_now)
       deploy = build_deploy(*args, **kwargs)
       deploy.save!
+
       run_now ? deploy.run_now! : deploy.enqueue
       continuous_delivery_resumed!
+
+      UpdateGithubCurrentlyDeployingRefJob.perform_later(self)
+      UpdateGithubPendingDeployRefJob.perform_later(self)
       deploy
     end
 


### PR DESCRIPTION
A bit of preliminary plumbing to set deploy state refs.

I subclassed the last-deployed-ref job as it was quicker, but ideally all three would inherit from a common base (or it would be one, customizable/composed job class).

Currently only doing the additional updating on `stack.trigger_deploy` and after a status change to 'success' for a deploy.

The refs would then be utilized by merge-queue / shipit-next: https://github.com/Shopify/shipit-next/pull/830

Still _very much_ WIP.