### PR TITLE
Create deployment payload with commit range info

### DIFF
--- a/app/models/shipit/commit_deployment.rb
+++ b/app/models/shipit/commit_deployment.rb
@@ -53,6 +53,13 @@ module Shipit
         required_contexts: [],
         description: "Via Shipit",
         environment: stack.environment,
+        payload: {
+          shipit: {
+            task_id: task.id,
+            from_sha: task.since_commit.sha,
+            to_sha: task.until_commit.sha,
+          },
+        },
       )
     end
   end

--- a/test/models/commit_deployment_test.rb
+++ b/test/models/commit_deployment_test.rb
@@ -28,6 +28,13 @@ module Shipit
         required_contexts: [],
         description: "Via Shipit",
         environment: @stack.environment,
+        payload: {
+          shipit: {
+            task_id: 4,
+            from_sha: 'f890fd8b5f2be05d1fedb763a3605ee461c39074',
+            to_sha: '467578b362bf2b4df5903e1c7960929361c3435a',
+          },
+        },
       ).returns(deployment_response)
 
       @deployment.create_on_github!


### PR DESCRIPTION
Deployments are not batch aware, and as Shipit will create a deployment for every pull request included in a deploy, it can be difficult for other apps to introspect GitHub and find the unique deployments - and what they contain.

Deployments support an arbitrary payload, we can use that to define a minimal schema and pass around more detail about a deploy between our tools. This change adds that with info on the task ID, and the range of commits being deployed. 🎩'd locally.