### PR TITLE
Set initial status when GH deploy is created

### DIFF
--- a/app/models/shipit/commit_deployment_status.rb
+++ b/app/models/shipit/commit_deployment_status.rb
@@ -45,6 +45,7 @@ module Shipit
       client.create_deployment_status(
         commit_deployment.api_url,
         status,
+        accept: 'application/vnd.github.flash-preview+json',
         target_url: url_helpers.stack_deploy_url(stack, task),
         description: description,
       )

--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -16,7 +16,7 @@ module Shipit
 
     has_many :commit_deployments, dependent: :destroy, inverse_of: :task, foreign_key: :task_id do
       GITHUB_STATUSES = {
-        'pending' => 'pending',
+        'pending' => 'in_progress',
         'failed' => 'failure',
         'success' => 'success',
         'error' => 'error',

--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -221,6 +221,9 @@ module Shipit
       commits.each do |commit|
         commit_deployments.create!(commit: commit)
       end
+
+      # Immediately update to publish the status to the commit deployments
+      update_commit_deployments
     end
 
     def update_release_status

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -72,12 +72,14 @@ en:
       ascii: "contains non-ASCII characters"
   deployment_description:
     deploy:
-      pending: "%{author} triggered the deploy of %{stack} to %{sha}"
+      in_progress: "%{author} triggered the deploy of %{stack} to %{sha}"
+      pending: "%{author} created the deploy of %{stack} to %{sha}"
       success: "%{author} deployed %{stack} to %{sha}"
       failure: "Deploy of %{stack} to %{sha} by %{author} failed"
       error: "Deploy of %{stack} to %{sha} by %{author} failed"
     rollback:
-      pending: "%{author} triggered the rollback of %{stack} to %{sha}"
+      in_progress: "%{author} triggered the deploy of %{stack} to %{sha}"
+      pending: "%{author} created the rollback of %{stack} to %{sha}"
       success: "%{author} rolled back %{stack} to %{sha}"
       failure: "Rollback of %{stack} to %{sha} by %{author} failed"
       error: "Rollback of %{stack} to %{sha} by %{author} failed"

--- a/test/fixtures/shipit/commit_deployment_statuses.yml
+++ b/test/fixtures/shipit/commit_deployment_statuses.yml
@@ -1,6 +1,6 @@
-shipit_deploy_second_pending:
+shipit_deploy_second_in_progress:
   commit_deployment: shipit_deploy_second
-  status: pending
+  status: in_progress
   github_id: 42
   api_url: https://api.github.com/repos/shopify/shipit-engine/deployments/1/statuses/42
 
@@ -10,9 +10,9 @@ shipit_deploy_second_success:
   github_id: 43
   api_url: https://api.github.com/repos/shopify/shipit-engine/deployments/1/statuses/43
 
-shipit2_deploy_third_pending:
+shipit2_deploy_third_in_progress:
   commit_deployment: shipit2_deploy_third
-  status: pending
+  status: in_progress
 
 shipit2_deploy_third_failure:
   commit_deployment: shipit2_deploy_third

--- a/test/models/commit_deployment_status_test.rb
+++ b/test/models/commit_deployment_status_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 module Shipit
   class CommitDeploymentStatusTest < ActiveSupport::TestCase
     setup do
-      @status = shipit_commit_deployment_statuses(:shipit2_deploy_third_pending)
+      @status = shipit_commit_deployment_statuses(:shipit2_deploy_third_in_progress)
       @deployment = @status.commit_deployment
       @task = @deployment.task
       @commit = @deployment.commit
@@ -14,7 +14,8 @@ module Shipit
       response = stub(id: 44, url: 'https://example.com')
       @author.github_api.expects(:create_deployment_status).with(
         @deployment.api_url,
-        'pending',
+        'in_progress',
+        accept: "application/vnd.github.flash-preview+json",
         target_url: "http://shipit.com/shopify/shipit-engine/production/deploys/#{@task.id}",
         description: "walrus triggered the deploy of shopify/shipit-engine/production to #{@commit.sha}",
       ).returns(response)

--- a/test/models/deploys_test.rb
+++ b/test/models/deploys_test.rb
@@ -300,7 +300,7 @@ module Shipit
       end
     end
 
-    test "creating a deploy creates one CommitDeployment per commit" do
+    test "creating a deploy creates one CommitDeployment and status per commit" do
       shipit = shipit_stacks(:shipit)
       deploy = shipit.deploys.build(
         since_commit: shipit.commits.first,
@@ -308,7 +308,9 @@ module Shipit
       )
 
       assert_difference -> { CommitDeployment.count }, deploy.commits.size do
-        deploy.save!
+        assert_difference -> { CommitDeploymentStatus.count }, deploy.commits.size do
+          deploy.save!
+        end
       end
     end
 


### PR DESCRIPTION
Right now, when we create a CommitDeployment, we don't set an initial status so the first status that gets pushed to GitHub is the _next_ status that the commit deployment receives after creation. This is a small tweak that will immediately push the current status when the commit deployment is created.