### PR TITLE
Allow registering additional webhook handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Allow applications to register extra handlers for Github webhooks. (#961)
+
 # 0.29.0
 
 * Upgraded to Rails 6.0.

--- a/README.md
+++ b/README.md
@@ -35,7 +35,11 @@ This guide aims to help you [set up](#installation-and-setup), [use](#using-ship
 * [Configuring providers](#configuring-providers)
 * [Free samples](/examples/shipit.yml)
 
-**IV. CONTRIBUTING**
+**IV. INTERGRATING**
+
+* [Registering webhooks](#integrating-webhooks)
+
+**V. CONTRIBUTING**
 
 * [Instructions](#contributing-instructions)
 * [Local development](#contributing-local-dev)
@@ -634,7 +638,24 @@ For Kubernetes, you have to provision Shipit environment with the following tool
 * `kubectl`
 * `kubernetes-deploy` [gem](https://github.com/Shopify/kubernetes-deploy)
 
-<h2 id="contributing">IV. CONTRIBUTING</h2>
+<h2 id="integrating">IV. INTERGRATING</h2>
+
+<h3 id="integrating-webhooks">Registering webhooks</h3>
+
+Shipit handles several webhook types by default, listed in `Shipit::WebhooksController::HANDLERS`, in order to implement default behaviours. Extra handler blocks can be registered via `Shipit::WebhooksController.register_handler`, eg:
+
+```ruby
+Shipit::WebhooksController.register_handler do |type, params|
+  case type
+  when 'pull_request'
+    Rails.logger.info "Received PR #{params['action']} webhook for PR #{params[['number']}"
+  end
+end
+```
+
+Multiple handler blocks can be registered. If any raise errors, execution will be halted and the request will be reported failed to github.
+
+<h2 id="contributing">V. CONTRIBUTING</h2>
 
 <h3 id="contributing-instructions">Instructions</h3>
 

--- a/app/controllers/shipit/webhooks_controller.rb
+++ b/app/controllers/shipit/webhooks_controller.rb
@@ -132,9 +132,25 @@ module Shipit
       'check_suite' => CheckSuiteHandler,
     }.freeze
 
+    class << self
+      attr_accessor :extra_handlers
+    end
+
+    self.extra_handlers = []
+
+    def self.register_handler(&block)
+      extra_handlers << block
+    end
+
     def create
+      params = JSON.parse(request.raw_post)
+
       if handler = HANDLERS[event]
-        handler.new(JSON.parse(request.raw_post)).process
+        handler.new(params).process
+      end
+
+      self.class.extra_handlers.each do |extra_handler|
+        extra_handler.call(event, params)
       end
 
       head :ok

--- a/test/controllers/webhooks_controller_test.rb
+++ b/test/controllers/webhooks_controller_test.rb
@@ -142,7 +142,24 @@ module Shipit
       end
     end
 
+    test "other events trigger custom handlers" do
+      received_webhooks = []
+      Shipit::WebhooksController.register_handler do |type, params|
+        received_webhooks << [type, params]
+      end
+
+      @request.headers['X-Github-Event'] = 'pull_request'
+      post :create, body: pull_request_params.to_json, as: :json
+      assert_response :ok
+
+      assert_equal [['pull_request', pull_request_params.stringify_keys]], received_webhooks
+    end
+
     private
+
+    def pull_request_params
+      {action: 'opened', number: 2, pull_request: 'foobar'}
+    end
 
     def membership_params
       {action: 'added', team: team_params, organization: {login: 'shopify'}, member: {login: 'walrus'}}


### PR DESCRIPTION
Allows wrapping applications to extend Shipit functionality based on triggers from Github.