### PR TITLE
Display the configured application name in UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # Unreleased
 
 * Allow applications to register extra handlers for Github webhooks. (#961)
+* Display the configured application name in UI
 
 # 0.29.0
 

--- a/app/models/shipit/commit_deployment.rb
+++ b/app/models/shipit/commit_deployment.rb
@@ -51,7 +51,7 @@ module Shipit
         pull_request_head,
         auto_merge: false,
         required_contexts: [],
-        description: "Via Shipit",
+        description: "Via #{Shipit.app_name}",
         environment: stack.environment,
         payload: {
           shipit: {

--- a/app/views/layouts/shipit.html.erb
+++ b/app/views/layouts/shipit.html.erb
@@ -54,11 +54,11 @@
     <% end %>
 
     <header class="header">
-      <%= link_to "Shipit v#{Shipit::VERSION}", "https://github.com/Shopify/shipit-engine/tree/v#{Shipit::VERSION}", class: 'powered-by' %>
+      <%= link_to "Powered by Shipit v#{Shipit::VERSION}", "https://github.com/Shopify/shipit-engine/tree/v#{Shipit::VERSION}", class: 'powered-by' %>
       <div class="wrapper">
         <div class="header__inner">
           <a href="/" class="logo">
-            <span class="visually-hidden">Shipit</span>
+            <span class="visually-hidden"><%= Shipit.app_name %></span>
           </a>
           <div class="header__page-title">
             <%= yield :page_title %>

--- a/app/views/shipit/merge_status/logged_out.erb
+++ b/app/views/shipit/merge_status/logged_out.erb
@@ -3,7 +3,7 @@
     <%= render 'anchor', color: '#bd2c00' %>
   </div>
   <h4 class="status-heading text-red">
-    Please log in to <%= link_to 'Shipit', '/', target: '_blank', rel: 'noopener' %>
+    Please log in to <%= link_to Shipit.app_name, '/', target: '_blank', rel: 'noopener' %>
   </h4>
   <span class="status-meta">
     Here Comes The Walrus is unable to check merge status.

--- a/app/views/shipit/stacks/index.html.erb
+++ b/app/views/shipit/stacks/index.html.erb
@@ -1,5 +1,5 @@
 <% content_for :page_title do %>
-  <h1>Shipit</h1>
+  <h1><%= Shipit.app_name %></h1>
 <% end %>
 <% content_for :primary_navigation do %>
   <%= link_to 'Add a stack', new_stack_path, class: 'btn secondary' %>

--- a/template.rb
+++ b/template.rb
@@ -55,6 +55,7 @@ CODE
 %w(config/secrets.yml config/secrets.example.yml).each do |path|
   create_file path, <<~CODE, force: true
     development:
+      app_name: My Shipit
       secret_key_base: #{SecureRandom.hex(64)}
       host: 'http://localhost:3000'
       redis_url: redis://localhost
@@ -71,6 +72,7 @@ CODE
           # team: MyOrg/developers # Enable this setting to restrict access to only the member of a team
 
     test:
+      app_name: My Shipit
       secret_key_base: #{SecureRandom.hex(64)}
       host: 'http://localhost:4000'
       redis_url: redis://localhost
@@ -87,6 +89,7 @@ CODE
           # teams: MyOrg/developers # Enable this setting to restrict access to only the member of a team
 
     production:
+      app_name: My Shipit
       secret_key_base: <%= ENV['SECRET_KEY_BASE'] %>
       host: <%= ENV['SHIPIT_HOST'] %>
       redis_url: <%= ENV['REDIS_URL'] %>


### PR DESCRIPTION
Instances of Shipit may be branded differently for their specific users.

Retain use of "Shipit" explicitly where this is a direct reference to Shipit internals, such as configuration or version number. Use configured name where this is directed as users of the application.