### PR TITLE
show absolute time of older tasks instead of "X days ago" relative time

### DIFF
--- a/app/views/shipit/tasks/_task.html.erb
+++ b/app/views/shipit/tasks/_task.html.erb
@@ -24,7 +24,7 @@
         <% if read_only %>
           <span class="utc-timecode">on <%= task.created_at.strftime('%Y-%m-%d %H:%M:%S') %> UTC</span>
         <% else %>
-          <%= timeago_tag(task.created_at, force: true) %>
+          <%= timeago_tag(task.created_at, force: false, date_only: false, limit: 12.hours.ago, format: '%Y-%m-%d %H:%M %Z') %>
         <% end %>
       </p>
     </div>


### PR DESCRIPTION
When debugging issues that were potentially caused by a deployment of code, it can be hard to determine which task/deploy happened within a given time range. The default time display can easily fold an entire day of deployments into the same "X days ago" window.

This PR updates the existing use of `timeago_tag` to have it print out the absolute time the task was created after `12.hours` have elapsed. For recent deployments, this will maintain current behaviour. If a user is looking at the timeline beyond 12 hours, the absolute time will be shown instead, which is probably more useful.

![image](https://user-images.githubusercontent.com/2074233/70811422-924ae000-1d93-11ea-96f7-990980dc2f00.png)

I thought about making this a configurable Stack settings option, but decided to put a smaller/simpler PR up for review first instead, to see how the community feels about this.

Local display example: 

