### PR TITLE
Drops duplicate Continuous Delivery jobs

### DIFF
--- a/app/jobs/shipit/continuous_delivery_job.rb
+++ b/app/jobs/shipit/continuous_delivery_job.rb
@@ -3,6 +3,7 @@ module Shipit
     include BackgroundJob::Unique
 
     queue_as :default
+    on_duplicate :drop
 
     def perform(stack)
       return unless stack.continuous_deployment?


### PR DESCRIPTION
This job does not explicitly set the lock timeout, and so uses the default of `0`. It also defaults to `on_duplicate :retry`, despite being executed every minute by the cron job. It is highly likely that many of these jobs are duplicates that are being retried, though this is entirely unnecessary because the job runs every minute to catch up anyway, causing a very high job load and many reported exceptions to exception tracking services.

In our instance of Shipit, we're seeing thousands of this exception occurring every week.