### PR TITLE
Disable DeferredTouch in development on auto-reload

### DIFF
--- a/test/dummy/config/environments/development.rb
+++ b/test/dummy/config/environments/development.rb
@@ -39,8 +39,11 @@ Rails.application.configure do
   # Raises error for missing translations
   # config.action_view.raise_on_missing_translations = true
   if Rails.application.config_for(:database)['adapter'] == 'sqlite3'
-    Shipit::DeferredTouch.enabled = false
+    config.to_prepare do
+      Shipit::DeferredTouch.enabled = false
+    end
   end
+
   config.active_job.queue_adapter = :async
 
   Pubsubstub.use_persistent_connections = false


### PR DESCRIPTION
When seeding the database via `bin/bootstrap` the script fails;
indicating that a Shipit::DeferredTouchJob failed to acquire the
run-lock in a timely manner:

```
Redis::Lock::LockTimeout: Timeout on lock Shipit::DeferredTouchJob exceeded 0 sec
```

This is strange because the script should be running in the
`development` environment AND deferred touching is supposed to be
disabled in both testing and development.

Here we add some diagnostic information to confirm a suspicion that
the assignment of `Shipit::DeferredTouch.enabled = false` is not doing
what we'd expect.

Running this diagnostic code, we can see that the object id of
`Shipit::DeferredTouch` changes between setting the `enabled`
attribute and when `db:seeds` interrogates this attribute.

```
$ bin/bootstrap
...
+ bundle exec rake db:seed
70263123644160 Disabling touches...
70263138902720 touching...
...
rake aborted!
Redis::Lock::LockTimeout: Timeout on lock Shipit::DeferredTouchJob exceeded 0 sec
...
```
When the autoreloader runs in development mode the initalization logic
in the `DeferredTouch` class overwrites the `enabled` attribute to be
`true`. This effectively turns on the `DeferredTouch` in development
even though it should be disabled per the environment configuration.

Here, we add instructions to the autoloader to disable `DeferredTouch`
when the class is reloaded in the development environment - this is
already configured correctly in test.

This fixes lock acquisition timeouts when running `bin/bootstrap`.

```
$ ./bin/bootstrap
...
+ bundle exec rake db:seed
70285677129620 Disabling touches...
Shipit::DeferredTouch<70285633447620 enabled=false> touching...
...
$
```

References
-----------
- [Deferred Touch class initialization logic](https://github.com/Shopify/shipit-engine/blob/88a0149de778cbcfdb513a3649e049fd54a1159b/app/models/concerns/shipit/deferred_touch.rb#L62)
- [Development environment config](https://github.com/Shopify/shipit-engine/blob/88a0149de778cbcfdb513a3649e049fd54a1159b/test/dummy/config/environments/development.rb#L41-L43)
- [Test environment config](https://github.com/Shopify/shipit-engine/blob/88a0149de778cbcfdb513a3649e049fd54a1159b/test/dummy/config/environments/test.rb#L43-L45)