### PR TITLE
Remove unused `repo` method on stack

### DIFF
--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -53,11 +53,6 @@ module Shipit
       super(user&.logged_in? ? user : nil)
     end
 
-    def self.repo(full_name)
-      repo_owner, repo_name = full_name.downcase.split('/')
-      Repository.find_by(owner: repo_owner, name: repo_name).stacks
-    end
-
     before_validation :update_defaults
     before_destroy :clear_local_files
     before_save :set_locked_since


### PR DESCRIPTION
I believe this was supposed to be removed in PR #963 - in favor of
using `Repository.from_github_repo_name` in the WebhooksController -
but was missed.

References
----------

- https://github.com/Shopify/shipit-engine/pull/963#discussion_r358212956