### PR TITLE
Removes mistaken entries from schema.rb

### DIFF
--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -195,9 +195,6 @@ ActiveRecord::Schema.define(version: 2020_01_02_175621) do
     t.string "name", limit: 100, null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.boolean "provision_pr_stacks", default: false
-    t.integer "provisioning_behavior", default: 0
-    t.string "provisioning_label_name"
     t.index ["owner", "name"], name: "repository_unicity", unique: true
   end
 


### PR DESCRIPTION
These leaked in by mistake in a prior PR. Will be submitted properly in the future.