### PR TITLE
Disable statistics view if no deploys are present

### DIFF
--- a/app/controllers/shipit/stacks_controller.rb
+++ b/app/controllers/shipit/stacks_controller.rb
@@ -71,6 +71,10 @@ module Shipit
     def statistics
       previous_deploy_stats = Shipit::DeployStats.new(@stack.deploys.not_active.previous_seven_days)
       @deploy_stats = Shipit::DeployStats.new(@stack.deploys.not_active.last_seven_days)
+      if @deploy_stats.empty?
+        flash[:warning] = 'Statistics not available without previous deploys'
+        return redirect_to stack_path(@stack)
+      end
       @diffs = @deploy_stats.compare(previous_deploy_stats)
     end
 

--- a/app/models/shipit/deploy_stats.rb
+++ b/app/models/shipit/deploy_stats.rb
@@ -1,5 +1,7 @@
 module Shipit
   class DeployStats
+    delegate :empty?, to: :@deploys
+
     def initialize(deploys)
       @deploys = deploys
       @durations = @deploys.map { |d| d.duration.value }.compact
@@ -10,7 +12,7 @@ module Shipit
     end
 
     def average_duration
-      return if @durations.empty?
+      return if empty?
       @durations.sum / @durations.length.to_f
     end
 
@@ -28,7 +30,7 @@ module Shipit
     end
 
     def success_rate
-      return if @deploys.empty?
+      return if empty?
       (@deploys.count(&:success?) / @deploys.length.to_f) * 100
     end
 

--- a/test/controllers/stacks_controller_test.rb
+++ b/test/controllers/stacks_controller_test.rb
@@ -115,6 +115,12 @@ module Shipit
       assert_response :success
     end
 
+    test "#statistics redirects to #show if no deploys are present" do
+      @stack.deploys.destroy_all
+      get :statistics, params: {id: @stack.to_param}
+      assert_redirected_to stack_path(@stack)
+    end
+
     test "#update allows to lock the stack" do
       refute @stack.locked?
 


### PR DESCRIPTION
Fixes: `undefined method zero? for nil:NilClass`

```
gems/activesupport-6.0.2.1/lib/active_support/duration.rb:212:in `block in initialize': undefined method `zero?' for nil:NilClass (ActionView::Template::Error)
    from gems/activesupport-6.0.2.1/lib/active_support/duration.rb:212:in `reject!'
    from gems/activesupport-6.0.2.1/lib/active_support/duration.rb:212:in `initialize'
    from bundler/gems/shipit-engine-767318bc03a5models/shipit/duration.rb:38:in `initialize'
    from bundler/gems/shipit-engine-767318bc03a5views/shipit/stacks/statistics.html.erb:36:in `new'
```