### PR TITLE
Add concept of extra variables to stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -625,6 +625,8 @@ These variables are accessible only during deploys and rollback:
 * `REVISION`: the git SHA of the revision that must be deployed in production
 * `SHA`: alias for REVISION
 
+On top of that, any other extra variable defined in the stack configuration page will also be made available during your deploy and rollback script execution.
+
 <h2 id="configuring-providers">Configuring providers</h2>
 
 ### Heroku

--- a/app/assets/javascripts/shipit/stacks.js.coffee
+++ b/app/assets/javascripts/shipit/stacks.js.coffee
@@ -22,6 +22,49 @@ $document.on 'click', '.action-set-release-status', (event) ->
     $deploy.attr('data-release-status', last_status.state)
   )
 
+$document.on 'click', '#add-new-variable', (event) ->
+  event.preventDefault()
+  formFields = $(event.target).closest('form').find('.field-list')[0]
+  template = document.querySelector("template[id='stack-variable-form-input']")
+
+  formFields.appendChild(document.importNode(template.content, true))
+
+$document.on 'change', '#stack_extra_variables__key', (event) ->
+  validateExtraVariables()
+
+$document.on 'click', '#remove-variable', (event) ->
+  event.preventDefault()
+  formField = $(event.target).closest('div')[0]
+  formField.parentNode.removeChild(formField)
+  validateExtraVariables()
+
+validateExtraVariables = () ->
+  $keysInputs = document.querySelectorAll('input#stack_extra_variables__key')
+
+  allKeys = []
+  $keysInputs.forEach (item) ->
+    allKeys.push(item.value)
+
+  $keysInputs.forEach (item) ->
+    $submit = $(item).closest('form').find("input[type='submit']")
+    if (allOcurrences(allKeys, item.value).length > 1)
+      $submit.addClass('btn--disabled')
+      $submit.prop('disabled', true)
+      $(item).addClass('field-invalid')
+    else
+      $submit.removeClass('btn--disabled')
+      $submit.prop('disabled', false)
+      $(item).removeClass('field-invalid')
+
+allOcurrences = (items, element) ->
+    indexes = []
+    idx = items.indexOf(element)
+    while (idx != -1)
+      indexes.push(idx)
+      idx = items.indexOf(element, idx + 1)
+
+    indexes
+
 jQuery ($) ->
   displayIgnoreCiMessage = ->
     ignoreCiMessage = $(".ignoring-ci")

--- a/app/assets/stylesheets/_pages/_settings.scss
+++ b/app/assets/stylesheets/_pages/_settings.scss
@@ -21,4 +21,16 @@
   .hidden {
     display: none;
   }
+
+  .field-list {
+    margin-bottom: 1.5rem;
+
+    input[type=text] {
+      display: inline;
+      width: 200px;
+    }
+  }
+  .field-invalid {
+    border: 2px solid red;
+  }
 }

--- a/app/controllers/shipit/stacks_controller.rb
+++ b/app/controllers/shipit/stacks_controller.rb
@@ -107,6 +107,12 @@ module Shipit
         end
       end
 
+      updated_extra_variables = extra_variables.map { |ev| ExtraVariable.new(key: ev[:key], value: ev[:value]) }
+
+      unless @stack.extra_variables.replace(updated_extra_variables)
+        options = {flash: {warning: @stack.errors.full_messages.to_sentence}}
+      end
+
       redirect_to(params[:return_to].presence || stack_settings_path(@stack), options)
     end
 
@@ -141,6 +147,16 @@ module Shipit
         :ignore_ci,
         :merge_queue_enabled,
       )
+    end
+
+    def extra_variables_params
+      params.require(:stack).permit(
+        extra_variables: [:key, :value]
+      )
+    end
+
+    def extra_variables
+      extra_variables_params[:extra_variables] || []
     end
 
     def repository

--- a/app/models/shipit/extra_variable.rb
+++ b/app/models/shipit/extra_variable.rb
@@ -1,0 +1,11 @@
+module Shipit
+  class ExtraVariable < ActiveRecord::Base
+    belongs_to :stack
+    validates :key, :value, presence: true
+    validates :key, uniqueness: {
+      scope: :stack_id,
+      message: "key can only be defined once per stack",
+      case_sensitive: false,
+    }
+  end
+end

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -37,6 +37,7 @@ module Shipit
     has_many :github_hooks, dependent: :destroy, class_name: 'Shipit::GithubHook::Repo'
     has_many :hooks, dependent: :destroy
     has_many :api_clients, dependent: :destroy
+    has_many :extra_variables, dependent: :destroy
     belongs_to :lock_author, class_name: :User, optional: true
     belongs_to :repository
     validates_associated :repository

--- a/app/views/shipit/stacks/_extra_variables_form.html.erb
+++ b/app/views/shipit/stacks/_extra_variables_form.html.erb
@@ -1,0 +1,22 @@
+<div class="field-list">
+  <div class="field-wrapper">
+    <%= label_tag :extra_variables, 'Extra variables (your deploy scripts will have access to the following extra environment variables)' %>
+  </div>
+  <div class="field-wrapper">
+    <a href="javascript:;" id="add-new-variable" class="btn">Add Variable</a>
+  </div>
+  <% @stack.extra_variables.each do |extra_var| %>
+    <div class="field-wrapper">
+        <%= text_field_tag "stack[extra_variables[][key]]", extra_var.key, placeholder: "KEY", required: true %>
+        <%= text_field_tag "stack[extra_variables[][value]]", extra_var.value, placeholder: "VALUE", required: true %>
+        <a href="javascript:;" id="remove-variable" class="btn">Remove Variable</a>
+    </div>
+  <% end %>
+</div>
+<template id="stack-variable-form-input">
+  <div class="field-wrapper">
+    <%= text_field_tag "stack[extra_variables[][key]]", "", placeholder: "KEY", required: true %>
+    <%= text_field_tag "stack[extra_variables[][value]]", "", placeholder: "VALUE", required: true %>
+    <a href="javascript:;" id="remove-variable" class="btn">Remove Variable</a>
+  </div>
+</template>

--- a/app/views/shipit/stacks/new.html.erb
+++ b/app/views/shipit/stacks/new.html.erb
@@ -32,6 +32,9 @@
           <%= f.check_box :ignore_ci %>
           <%= f.label :ignore_ci, "Allow deploys regardless of CI status" %>
         </div>
+
+        <%= render 'extra_variables_form' %>
+
         <div class="field-wrapper"><%= f.submit class: 'btn' %></div>
       <% end %>
     </div>

--- a/app/views/shipit/stacks/settings.html.erb
+++ b/app/views/shipit/stacks/settings.html.erb
@@ -37,6 +37,8 @@
           <%= f.label :ignore_ci, "Don't require CI to deploy" %>
         </div>
 
+        <%= render 'extra_variables_form'%>
+
         <%= f.submit class: "btn", value: "Save" %>
       <% end %>
     </div>

--- a/db/migrate/20200102191658_create_shipit_extra_variables.rb
+++ b/db/migrate/20200102191658_create_shipit_extra_variables.rb
@@ -1,0 +1,11 @@
+class CreateShipitExtraVariables < ActiveRecord::Migration[6.0]
+  def change
+    create_table :extra_variables do |t|
+      t.string :key, null: false
+      t.string :value, null: false
+      t.references :stack, null: false, foreign_key: true, type: :integer
+
+      t.timestamps
+    end
+  end
+end

--- a/test/controllers/stacks_controller_test.rb
+++ b/test/controllers/stacks_controller_test.rb
@@ -164,6 +164,23 @@ module Shipit
       assert_instance_of AnonymousUser, @stack.lock_author
     end
 
+    test "#update allows to update stack extra variables" do
+      assert @stack.extra_variables.any?
+
+      extra_vars = [
+        ExtraVariable.new(key: Faker::Alphanumeric.alpha(number: 10).upcase, value: Faker::Alphanumeric.alpha(number: 10).upcase),
+        ExtraVariable.new(key: Faker::Alphanumeric.alpha(number: 10).upcase, value: Faker::Alphanumeric.alpha(number: 10).upcase),
+        ExtraVariable.new(key: Faker::Alphanumeric.alpha(number: 10).upcase, value: Faker::Alphanumeric.alpha(number: 10).upcase),
+      ]
+      extra_vars_params = extra_vars.map { |element| element.attributes.extract!("key", "value") }
+
+      patch :update, params: { id: @stack.to_param, stack: { extra_variables: extra_vars_params } }
+
+      @stack.reload
+
+      assert_object_keys extra_vars, @stack.extra_variables, :key, :value
+    end
+
     test "#refresh queues a RefreshStatusesJob and a GithubSyncJob" do
       request.env['HTTP_REFERER'] = stack_settings_path(@stack)
 

--- a/test/controllers/stacks_controller_test.rb
+++ b/test/controllers/stacks_controller_test.rb
@@ -98,6 +98,29 @@ module Shipit
       assert_response :success
     end
 
+    test "#create adds stack extra variables" do
+      extra_vars = [
+        ExtraVariable.new(key: Faker::Alphanumeric.alpha(number: 10).upcase, value: Faker::Alphanumeric.alpha(number: 10).upcase),
+        ExtraVariable.new(key: Faker::Alphanumeric.alpha(number: 10).upcase, value: Faker::Alphanumeric.alpha(number: 10).upcase),
+        ExtraVariable.new(key: Faker::Alphanumeric.alpha(number: 10).upcase, value: Faker::Alphanumeric.alpha(number: 10).upcase),
+      ]
+      extra_vars_params = extra_vars.map { |element| element.attributes.extract!("key", "value") }
+
+      assert_difference "ExtraVariable.count", 3 do
+        post :create, params: {
+          stack: {
+            repo_name: 'rails',
+            repo_owner: 'rails',
+            environment: 'staging',
+            branch: 'staging',
+            extra_variables: extra_vars_params,
+          },
+        }
+      end
+
+      assert_redirected_to stack_path(Stack.last)
+    end
+
     test "#destroy enqueues a DestroyStackJob" do
       assert_enqueued_with(job: DestroyStackJob, args: [@stack]) do
         delete :destroy, params: {id: @stack.to_param}
@@ -174,7 +197,7 @@ module Shipit
       ]
       extra_vars_params = extra_vars.map { |element| element.attributes.extract!("key", "value") }
 
-      patch :update, params: { id: @stack.to_param, stack: { extra_variables: extra_vars_params } }
+      patch :update, params: {id: @stack.to_param, stack: {extra_variables: extra_vars_params}}
 
       @stack.reload
 

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_02_175621) do
+ActiveRecord::Schema.define(version: 2020_01_02_191658) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text "permissions", limit: 65535
@@ -99,6 +99,15 @@ ActiveRecord::Schema.define(version: 2020_01_02_175621) do
     t.datetime "updated_at", null: false
     t.index ["hook_id", "event", "status"], name: "index_deliveries_on_hook_id_and_event_and_status"
     t.index ["hook_id", "status"], name: "index_deliveries_on_hook_id_and_status"
+  end
+
+  create_table "extra_variables", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "value", null: false
+    t.integer "stack_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["stack_id"], name: "index_extra_variables_on_stack_id"
   end
 
   create_table "github_hooks", force: :cascade do |t|
@@ -295,5 +304,4 @@ ActiveRecord::Schema.define(version: 2020_01_02_175621) do
     t.index ["login"], name: "index_users_on_login"
     t.index ["updated_at"], name: "index_users_on_updated_at"
   end
-
 end

--- a/test/fixtures/shipit/extra_variables.yml
+++ b/test/fixtures/shipit/extra_variables.yml
@@ -1,0 +1,4 @@
+target:
+  key: TARGET
+  value: foo
+  stack: shipit

--- a/test/fixtures/shipit/extra_variables.yml
+++ b/test/fixtures/shipit/extra_variables.yml
@@ -2,3 +2,8 @@ target:
   key: TARGET
   value: foo
   stack: shipit
+
+extra:
+  key: EXTRA
+  value: bar
+  stack: shipit

--- a/test/models/extra_variables_test.rb
+++ b/test/models/extra_variables_test.rb
@@ -1,0 +1,27 @@
+require 'test_helper'
+
+module Shipit
+  class ExtraVariablesTest < ActiveSupport::TestCase
+    def setup
+      @stack = shipit_stacks(:shipit)
+    end
+
+    test 'invalid without key' do
+      extra_var = ExtraVariable.new(stack: @stack, value: 'VALUE')
+      refute extra_var.valid?
+      assert_not_nil extra_var.errors[:key]
+    end
+
+    test 'invalid without value' do
+      extra_var = ExtraVariable.new(stack: @stack, key: 'KEY')
+      refute extra_var.valid?
+      assert_not_nil extra_var.errors[:value]
+    end
+
+    test 'invalid if key already defined' do
+      extra_var = ExtraVariable.new(shipit_extra_variables(:target).attributes)
+      refute extra_var.valid?
+      assert_not_nil extra_var.errors[:key]
+    end
+  end
+end

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -198,6 +198,12 @@ module Shipit
       end
     end
 
+    test "#destroy also destroy extra variables" do
+      assert_difference -> { ExtraVariable.count }, -shipit_stacks(:shipit).extra_variables.count do
+        shipit_stacks(:shipit).destroy
+      end
+    end
+
     test "#destroy delete all local files (git mirror and deploy clones)" do
       FileUtils.expects(:rm_rf).with(Rails.root.join('data', 'stacks', 'shopify', 'shipit-engine', 'production').to_s)
       shipit_stacks(:shipit).destroy

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -13,6 +13,7 @@ ActiveRecord::Migrator.migrations_paths = [
 require 'rails/test_help'
 require 'mocha/minitest'
 require 'spy/integration'
+require 'faker'
 
 # Load fixtures from the engine
 if ActiveSupport::TestCase.respond_to?(:fixture_path=)
@@ -65,5 +66,22 @@ class ActiveSupport::TestCase
 
   def resource(data)
     Sawyer::Resource.new(Sawyer::Agent.new('http://example.com'), data)
+  end
+
+  # assert if two list of objets are similar based on the keys you want to compare
+  def assert_object_keys(expected, actual, *attr)
+    expected_hash = expected.map do |item|
+       attributes = item.attributes.symbolize_keys
+       attributes = attributes.extract!(*attr) unless attr.nil?
+       attributes
+    end
+
+    actual_hash = actual.map do |item|
+      attributes = item.attributes.symbolize_keys
+      attributes = attributes.extract!(*attr) unless attr.nil?
+      attributes
+    end
+
+    assert_equal expected_hash, actual_hash
   end
 end

--- a/test/unit/deploy_commands_test.rb
+++ b/test/unit/deploy_commands_test.rb
@@ -172,6 +172,15 @@ module Shipit
       assert_equal '1', @commands.env['GLOBAL']
     end
 
+    test "#perform merges stack extra variables in ENVIRONMENT" do
+      commands = @commands.perform
+      assert_equal 1, commands.length
+      command = commands.first
+      @stack.extra_variables.each do |ev|
+        assert_equal ev.value, command.env[ev.key]
+      end
+    end
+
     test "#install_dependencies calls bundle install" do
       commands = @commands.install_dependencies
       assert_equal 1, commands.length


### PR DESCRIPTION
While implementing the dynamic provision of stacks we realized we would also need ways to dynamically assign variables to the stack in order to have those available during the execution of the deployment script. Since the stacks are dynamically provisioned based on pull requests, using a `shipit.yml` would not be possible.

What we are proposing here is the inclusion of the concept `ExtraVariable` to add another option in which we could define `environment` variables.

These `extra variables` can be managed using the stack settings page and the idea is that they take precedence over any other environment variable.

This is related to a few PRs that were opened recently. #979 and #967 are among them