### PR TITLE
Emits status update hook when deploy is triggered

### DIFF
--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -39,7 +39,8 @@ module Shipit
 
     after_save :record_status_change
     after_create :prevent_concurrency, unless: :allow_concurrency?
-    after_commit :emit_hooks
+    after_commit :emit_hooks, on: :create
+    after_commit :emit_hooks_if_status_changed, on: :update
 
     class << self
       def durations
@@ -306,9 +307,13 @@ module Shipit
       end
     end
 
-    def emit_hooks
+    def emit_hooks_if_status_changed
       return unless @status_changed
       @status_changed = nil
+      emit_hooks
+    end
+
+    def emit_hooks
       Hook.emit(hook_event, stack, hook_event => self, status: status, stack: stack)
     end
 


### PR DESCRIPTION
Prior to this change, a hook was only being emitted when a task changed status, which was not considered to be the case when the task was created (status nil -> pending). This change simply causes the hook to be emitted on task creation, as this is effectively a status change. We're using this downstream to modify a deployment (manipulate its environment) in between it being triggered and executing.