### PR TITLE
Fix CommitDeploymentStatus GitHub creation job

### DIFF
--- a/app/models/shipit/commit_deployment.rb
+++ b/app/models/shipit/commit_deployment.rb
@@ -10,7 +10,8 @@ module Shipit
     def create_on_github!
       create_deployment_on_github!
       statuses.order(id: :asc).each(&:create_on_github!)
-    rescue Octokit::NotFound, Octokit::Forbidden
+    rescue Octokit::NotFound, Octokit::Forbidden => error
+      Rails.logger.warn("Got #{error.class.name} creating deployment or statuses: #{error.message}")
       # If no one can create the deployment we can only give up
     end
 

--- a/app/models/shipit/commit_deployment_status.rb
+++ b/app/models/shipit/commit_deployment_status.rb
@@ -36,7 +36,7 @@ module Shipit
     end
 
     def schedule_create_on_github
-      CreateOnGithubJob.perform_later(commit_deployment)
+      CreateOnGithubJob.perform_later(self)
     end
 
     private


### PR DESCRIPTION
I'm debugging a race where the initial status is not created on GitHub after the deployment is created. Using `commit_deployment` as the argument here looks like a typo to me, surely it should be itself. The warning log is for further debugging if I've got this wrong. 

Should I deploy our instance from this branch and 🎩 before merging?