### PR TITLE
Set a GitHub deployment status for the running state

### DIFF
--- a/app/models/shipit/commit_deployment.rb
+++ b/app/models/shipit/commit_deployment.rb
@@ -10,7 +10,8 @@ module Shipit
     def create_on_github!
       create_deployment_on_github!
       statuses.order(id: :asc).each(&:create_on_github!)
-    rescue Octokit::NotFound, Octokit::Forbidden
+    rescue Octokit::NotFound, Octokit::Forbidden => error
+      Rails.logger.warn("Got #{error.class.name} creating deployment or statuses: #{error.message}")
       # If no one can create the deployment we can only give up
     end
 

--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -18,7 +18,8 @@ module Shipit
     belongs_to :since_commit, class_name: 'Commit', required: true, inverse_of: :deploys
     has_many :commit_deployments, dependent: :destroy, inverse_of: :task, foreign_key: :task_id do
       GITHUB_STATUSES = {
-        'pending' => 'in_progress',
+        'pending' => 'pending',
+        'running' => 'in_progress',
         'failed' => 'failure',
         'success' => 'success',
         'error' => 'error',
@@ -30,6 +31,8 @@ module Shipit
           each do |deployment|
             deployment.statuses.create!(status: github_status)
           end
+        else
+          Rails.logger.warn("No GitHub status for task status #{task_status}")
         end
       end
     end


### PR DESCRIPTION
We intend to create a deployment status immediately after creating the deployment, however when #982 moved the deployment creation to a job a delay was created. Now the initial status may be created when the job is already running, and we did not have a corresponding status for that state.

I have tophatted locally:

<img width="623" alt="Screenshot 2020-01-10 at 13 31 56" src="https://user-images.githubusercontent.com/398706/72156487-96c3e200-33ad-11ea-9627-fd6035374b31.png">