### PR TITLE
Log deployment status creation

### DIFF
--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -29,6 +29,7 @@ module Shipit
       def append_status(task_status)
         if github_status = GITHUB_STATUSES[task_status]
           each do |deployment|
+            Rails.logger.info("Creating #{github_status} deploy status for deployment #{deployment.id}")
             deployment.statuses.create!(status: github_status)
           end
         else


### PR DESCRIPTION
#982 moved deployment and status creation async, and has created some racey issues. I'm trying to debug some instances where the final status is not created and reported, and need some more clues.