### PR TITLE
Remove openssl from dev.yml

### DIFF
--- a/dev.yml
+++ b/dev.yml
@@ -6,7 +6,6 @@ type: rails
 
 up:
   - homebrew:
-    - openssl
     - sqlite
   - ruby:
       version: 2.5.6


### PR DESCRIPTION
Fixes:

```
┃ ✗ Specifying openssl in dev.yml's homebrew section is deprecated:
┃ ✗ OpenSSL 1.1 is always installed.  Please remove it from dev.yml.
┃ ✗ You will then need to re-run dev up.
```