### PR TITLE
Reload commit_deployments association before appending statuses

### DIFF
--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -28,7 +28,8 @@ module Shipit
 
       def append_status(task_status)
         if github_status = GITHUB_STATUSES[task_status]
-          each do |deployment|
+          # Deployments and statuses are created async, we reload the association to ensure we update all instances
+          reload.each do |deployment|
             Rails.logger.info("Creating #{github_status} deploy status for deployment #{deployment.id}")
             deployment.statuses.create!(status: github_status)
           end

--- a/test/models/deploys_test.rb
+++ b/test/models/deploys_test.rb
@@ -858,6 +858,17 @@ module Shipit
       end
     end
 
+    test "succeeding a deploy creates CommitDeploymentStatuses" do
+      @deploy = shipit_deploys(:shipit_running)
+      refute_empty @deploy.commit_deployments
+
+      assert_difference -> { CommitDeploymentStatus.count }, @deploy.commit_deployments.size do
+        @deploy.report_complete!
+      end
+
+      assert_equal 'success', CommitDeploymentStatus.last.status
+    end
+
     private
 
     def expect_event(deploy)


### PR DESCRIPTION
Fixes a race which prevents deployments from receiving status updates when a task completes. The issue exists because `CommitDeployments` are sometimes created *after* the task starts, something like:

* Task created (`pending` state), `PerformTaskJob` and `CreateDeploymentsForTaskJob` enqueued
* `PerformTaskJob` starts, transitions the job to `running`, which loads the `commit_deployments` association (in the `append_status` callback) but it is empty
* `CreateDeploymentsForTaskJob` completes while the task in in progress
* The task completes and `append_status` is called again, but with the stale association

I have tested this fix on our production instance and it looks good. NB that the additional test here does not reproduce the issue, but I spotted the missing coverage while investigating this issue and plugged the gap while I was here.