### PR TITLE
Fetch 100 commit statuses at a time

### DIFF
--- a/app/models/shipit/commit.rb
+++ b/app/models/shipit/commit.rb
@@ -128,7 +128,9 @@ module Shipit
     end
 
     def refresh_statuses!
-      github_statuses = stack.handle_github_redirections { Shipit.github.api.statuses(github_repo_name, sha) }
+      github_statuses = stack.handle_github_redirections do
+        Shipit.github.api.statuses(github_repo_name, sha, per_page: 100)
+      end
       github_statuses.each do |status|
         create_status_from_github!(status)
       end

--- a/test/models/commits_test.rb
+++ b/test/models/commits_test.rb
@@ -248,7 +248,7 @@ module Shipit
         target_url: 'http://example.com',
         created_at: 1.day.ago,
       )
-      Shipit.github.api.expects(:statuses).with(@stack.github_repo_name, @commit.sha).returns([status])
+      Shipit.github.api.expects(:statuses).with(@stack.github_repo_name, @commit.sha, per_page: 100).returns([status])
       assert_difference '@commit.statuses.count', 1 do
         @commit.refresh_statuses!
       end

--- a/test/models/pull_request_test.rb
+++ b/test/models/pull_request_test.rb
@@ -116,7 +116,7 @@ module Shipit
         )
       end
 
-      Shipit.github.api.expects(:statuses).with(@stack.github_repo_name, head_sha).returns([stub(
+      Shipit.github.api.expects(:statuses).with(@stack.github_repo_name, head_sha, per_page: 100).returns([stub(
         state: 'success',
         description: nil,
         context: 'default',


### PR DESCRIPTION
Core deploys are getting stuck because Shipit thinks some statuses are missing, despite the statuses on GitHub being present and passing. After some debugging it seems that this is a [lack of] pagination problem - a core commit has something like ~50 status records now, and the default fetch size is 30. This is a hotfix to unblock deploys, pending some actual pagination support.