### PR TITLE
Permit locking stacks with machine-readable reason

### DIFF
--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -42,6 +42,7 @@ module Shipit
     validates_associated :repository
 
     scope :not_archived, -> { where(archived_since: nil) }
+    scope :locked_because, ->(reason_code) { where(lock_reason_code: reason_code) }
 
     def repository
       super || build_repository
@@ -397,13 +398,13 @@ module Shipit
       lock_reason.present?
     end
 
-    def lock(reason, user)
-      params = {lock_reason: reason, lock_author: user}
+    def lock(reason, user, code: nil)
+      params = {lock_reason: reason, lock_reason_code: code, lock_author: user}
       update!(params)
     end
 
     def unlock
-      update!(lock_reason: nil, lock_author: nil, locked_since: nil)
+      update!(lock_reason: nil, lock_reason_code: nil, lock_author: nil, locked_since: nil)
     end
 
     def archived?
@@ -411,11 +412,11 @@ module Shipit
     end
 
     def archive!(user)
-      update!(archived_since: Time.now, lock_reason: "Archived", lock_author: user)
+      update!(archived_since: Time.now, lock_reason: "Archived", lock_reason_code: "ARCHIVED", lock_author: user)
     end
 
     def unarchive!
-      update!(archived_since: nil, lock_reason: nil, lock_author: nil, locked_since: nil)
+      update!(archived_since: nil, lock_reason: nil, lock_reason_code: nil, lock_author: nil, locked_since: nil)
     end
 
     def to_param

--- a/app/serializers/shipit/stack_serializer.rb
+++ b/app/serializers/shipit/stack_serializer.rb
@@ -4,9 +4,9 @@ module Shipit
 
     has_one :lock_author
     attributes :id, :repo_owner, :repo_name, :environment, :html_url, :url, :tasks_url, :deploy_url, :pull_requests_url,
-               :deploy_spec, :undeployed_commits_count, :is_locked, :lock_reason, :continuous_deployment, :created_at,
-               :updated_at, :locked_since, :last_deployed_at, :branch, :merge_queue_enabled, :is_archived,
-               :archived_since
+               :deploy_spec, :undeployed_commits_count, :is_locked, :lock_reason, :lock_reason_code,
+               :continuous_deployment, :created_at, :updated_at, :locked_since, :last_deployed_at, :branch,
+               :merge_queue_enabled, :is_archived, :archived_since
 
     def url
       api_stack_url(object)

--- a/app/views/shipit/stacks/_banners.html.erb
+++ b/app/views/shipit/stacks/_banners.html.erb
@@ -44,6 +44,12 @@
         <p class="banner__text">
           <%= auto_link emojify(stack.lock_reason) %>
         </p>
+
+        <% if stack.lock_reason_code %>
+          <p class="banner__text">
+            Code: <%= stack.lock_reason_code %>
+          </p>
+        <% end %>
       </div>
     </div>
   </div>

--- a/db/migrate/20200115180018_add_lock_reason_code_to_stacks.rb
+++ b/db/migrate/20200115180018_add_lock_reason_code_to_stacks.rb
@@ -1,0 +1,6 @@
+class AddLockReasonCodeToStacks < ActiveRecord::Migration[6.0]
+  def change
+    add_column :stacks, :lock_reason_code, :string
+    add_index :stacks, :lock_reason_code
+  end
+end

--- a/test/controllers/stacks_controller_test.rb
+++ b/test/controllers/stacks_controller_test.rb
@@ -150,6 +150,7 @@ module Shipit
       assert @stack.locked?
       assert_equal shipit_users(:walrus), @stack.lock_author
       assert_equal "Archived", @stack.lock_reason
+      assert_equal "ARCHIVED", @stack.lock_reason_code
     end
 
     test "#update allows to dearchive the stack" do
@@ -161,6 +162,9 @@ module Shipit
       @stack.reload
       refute @stack.archived?
       refute @stack.locked?
+      assert_nil @stack.locked_since
+      assert_nil @stack.lock_reason
+      assert_nil @stack.lock_reason_code
       assert_instance_of AnonymousUser, @stack.lock_author
     end
 

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_09_132519) do
+ActiveRecord::Schema.define(version: 2020_01_15_180018) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text "permissions", limit: 65535
@@ -220,7 +220,9 @@ ActiveRecord::Schema.define(version: 2020_01_09_132519) do
     t.datetime "last_deployed_at"
     t.integer "repository_id", null: false
     t.datetime "archived_since"
+    t.string "lock_reason_code"
     t.index ["archived_since"], name: "index_stacks_on_archived_since"
+    t.index ["lock_reason_code"], name: "index_stacks_on_lock_reason_code"
     t.index ["repository_id", "environment"], name: "stack_unicity", unique: true
     t.index ["repository_id"], name: "index_stacks_on_repository_id"
   end

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -664,12 +664,23 @@ module Shipit
       assert_equal user, @stack.lock_author
     end
 
-    test "#unlock deletes reason and user" do
+    test "#lock can set a reason code" do
+      reason = "Here comes the walrus"
       user = shipit_users(:walrus)
-      @stack.lock("Here comes the walrus", user)
+      code = "STUFF"
+      @stack.lock(reason, user, code: code)
+      assert @stack.locked?
+      assert_equal code, @stack.lock_reason_code
+      assert_equal [@stack], Shipit::Stack.locked_because(code).all
+    end
+
+    test "#unlock deletes reason, user & reason code" do
+      user = shipit_users(:walrus)
+      @stack.lock("Here comes the walrus", user, code: "STUFF")
       @stack.unlock
       refute @stack.locked?
       assert_nil @stack.lock_reason
+      assert_nil @stack.lock_reason_code
       assert_not_equal user, @stack.lock_author
     end
 


### PR DESCRIPTION
This allows (efficiently) querying for stacks locked for this reason while retaining a user-friendly presentation.