### PR TITLE
Relax gemfile ruby version detection regex.

### DIFF
--- a/app/models/shipit/deploy_spec/bundler_discovery.rb
+++ b/app/models/shipit/deploy_spec/bundler_discovery.rb
@@ -33,9 +33,9 @@ module Shipit
         # Heroku apps often specify a ruby version.
         if /darwin/i.match?(RUBY_PLATFORM)
           # OSX is nitpicky about the -i.
-          %q(/usr/bin/sed -i '' '/^ruby\s/d' Gemfile)
+          %q(/usr/bin/sed -i '' '/^ruby(\s|\()/d' Gemfile)
         else
-          %q(sed -i '/^ruby\s/d' Gemfile)
+          %q(sed -i '/^ruby(\s|\()/d' Gemfile)
         end
       end
 


### PR DESCRIPTION
We try to detect a ruby version in Gemfiles and delete the line.

This was working for, say, `ruby '2.5.3'`, but not for lines with parenthesis like `ruby('2.5.3')` or `ruby ('2.5.3')`.

This results in deploys failing for those builds:
https://shipit.shopify.io/shopify/identity_client/production/deploys/914537

This PR changes the regex to match those cases as well.