### PR TITLE
Truncate commit messages if they are to big to fit the database column

### DIFF
--- a/app/models/shipit/commit.rb
+++ b/app/models/shipit/commit.rb
@@ -104,6 +104,14 @@ module Shipit
       )
     end
 
+    def message=(message)
+      limit = self.class.columns_hash['message'].limit
+      if limit && message && message.size > limit
+        message = message.slice(0, limit)
+      end
+      super(message)
+    end
+
     def reload(*)
       @status = nil
       super

--- a/test/models/commits_test.rb
+++ b/test/models/commits_test.rb
@@ -96,6 +96,14 @@ module Shipit
       assert_equal shipit_users(:walrus), commit.author
     end
 
+    test "#message= truncates the message" do
+      skip unless Shipit::Commit.columns_hash['message'].limit
+      limit = Shipit::Commit.columns_hash['message'].limit
+
+      @commit.update!(message: 'a' * limit * 2)
+      assert_equal limit, @commit.message.size
+    end
+
     test "#pull_request? detect pull request based on message format" do
       assert @pr.pull_request?
       refute @commit.pull_request?


### PR DESCRIPTION
If the commit message is ridiculously long, the insertion might fail, and it breaks GItHub syncrhonization.

We could increase the storage, but the value would be low as we never really use more than the first few lines of the message.

