### PR TITLE
Revert "Relax gemfile ruby version detection regex"

### DIFF
--- a/app/models/shipit/deploy_spec/bundler_discovery.rb
+++ b/app/models/shipit/deploy_spec/bundler_discovery.rb
@@ -33,9 +33,9 @@ module Shipit
         # Heroku apps often specify a ruby version.
         if /darwin/i.match?(RUBY_PLATFORM)
           # OSX is nitpicky about the -i.
-          %q(/usr/bin/sed -i '' '/^ruby(\s|\()/d' Gemfile)
+          %q(/usr/bin/sed -i '' '/^ruby\s/d' Gemfile)
         else
-          %q(sed -i '/^ruby(\s|\()/d' Gemfile)
+          %q(sed -i '/^ruby\s/d' Gemfile)
         end
       end
 


### PR DESCRIPTION
Not sure what went wrong here, but I'd rather revert this specific change, test and re-introduce later.