### PR TITLE
Adjusted regex to work for macos and to account for parenthesis instead of space.

### DIFF
--- a/app/models/shipit/deploy_spec/bundler_discovery.rb
+++ b/app/models/shipit/deploy_spec/bundler_discovery.rb
@@ -33,9 +33,9 @@ module Shipit
         # Heroku apps often specify a ruby version.
         if /darwin/i.match?(RUBY_PLATFORM)
           # OSX is nitpicky about the -i.
-          %q(/usr/bin/sed -i '' '/^ruby\s/d' Gemfile)
+          %q(/usr/bin/sed -i '' -E '/^ruby([[:space:]]|\()/d' Gemfile)
         else
-          %q(sed -i '/^ruby\s/d' Gemfile)
+          %q(sed -i -r '/^ruby(\s|\()/d' Gemfile)
         end
       end
 


### PR DESCRIPTION
The current MacOS ruby version stripping regex doesn't work because `\s` is not supported by the older bsd version of `sed` used on macs.

This PR fixes that by using the `[[:space:]]` character class on macos.

This PR also adds support for stripping `ruby('x.y.z')` versions by matching the parenthesis.
The [previous PR](https://github.com/Shopify/shipit-engine/pull/995) didn't work because the Extended regex flag is needed to do so. In this case, we're accomplishing that with `-E` on Linux and `-r` on MacOS.

Tested using a Gemfile on macos with coreutils gsed for Linux sed, and default Catalina sed for MacOS sed testing.
