### PR TITLE
Revert "Adjusted regex to work for macos and to account for parenthesis instead of space."

### DIFF
--- a/app/models/shipit/deploy_spec/bundler_discovery.rb
+++ b/app/models/shipit/deploy_spec/bundler_discovery.rb
@@ -33,9 +33,9 @@ module Shipit
         # Heroku apps often specify a ruby version.
         if /darwin/i.match?(RUBY_PLATFORM)
           # OSX is nitpicky about the -i.
-          %q(/usr/bin/sed -i '' -E '/^ruby([[:space:]]|\()/d' Gemfile)
+          %q(/usr/bin/sed -i '' '/^ruby\s/d' Gemfile)
         else
-          %q(sed -i -r '/^ruby(\s|\()/d' Gemfile)
+          %q(sed -i '/^ruby\s/d' Gemfile)
         end
       end
 


### PR DESCRIPTION
Reverts Shopify/shipit-engine#998

It looks like Shipit uses a version of sed that isn't compatible with the suspected gnu flags.