### PR TITLE
Only unlock a stack when the unlock button is used

### DIFF
--- a/app/controllers/shipit/stacks_controller.rb
+++ b/app/controllers/shipit/stacks_controller.rb
@@ -92,11 +92,13 @@ module Shipit
         options = {flash: {warning: @stack.errors.full_messages.to_sentence}}
       end
 
-      reason = params[:stack][:lock_reason]
-      if reason.present?
-        @stack.lock(reason, current_user)
-      elsif @stack.locked?
-        @stack.unlock
+      if params[:stack].has_key?(:lock_reason)
+        reason = params[:stack][:lock_reason]
+        if reason.present?
+          @stack.lock(reason, current_user)
+        elsif @stack.locked?
+          @stack.unlock
+        end
       end
 
       if params[:stack][:archived].present?


### PR DESCRIPTION
Without this change, any modification to the configuration of a locked stack will implicitly unlock it.