### PR TITLE
Adjust deploy description

### DIFF
--- a/app/models/shipit/commit_deployment_status.rb
+++ b/app/models/shipit/commit_deployment_status.rb
@@ -6,6 +6,8 @@ module Shipit
 
     delegate :stack, :task, :author, to: :commit_deployment
 
+    DESCRIPTION_MAX_LENGTH = 140
+
     def create_on_github!
       return if github_id?
       response = begin
@@ -25,7 +27,7 @@ module Shipit
     def description
       I18n.t(
         "deployment_description.#{task_type}.#{status}",
-        sha: task.until_commit.sha,
+        sha: task.until_commit.short_sha,
         author: task.author.login,
         stack: stack.to_param,
       )
@@ -47,8 +49,12 @@ module Shipit
         status,
         accept: 'application/vnd.github.flash-preview+json',
         target_url: url_helpers.stack_deploy_url(stack, task),
-        description: description,
+        description: trim_description(description),
       )
+    end
+
+    def trim_description(description)
+      description&.squish&.truncate(DESCRIPTION_MAX_LENGTH, separator: ' ')
     end
 
     def url_helpers

--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -21,6 +21,7 @@ module Shipit
         'pending' => 'pending',
         'running' => 'in_progress',
         'failed' => 'failure',
+        'timedout' => 'failure',
         'success' => 'success',
         'error' => 'error',
         'aborted' => 'error',

--- a/test/models/commit_deployment_status_test.rb
+++ b/test/models/commit_deployment_status_test.rb
@@ -16,8 +16,19 @@ module Shipit
         'in_progress',
         accept: "application/vnd.github.flash-preview+json",
         target_url: "http://shipit.com/shopify/shipit-engine/production/deploys/#{@task.id}",
-        description: "walrus triggered the deploy of shopify/shipit-engine/production to #{@deployment.sha}",
+        description: "walrus triggered the deploy of shopify/shipit-engine/production to #{@task.until_commit.short_sha}",
       ).returns(response)
+
+      @status.create_on_github!
+      assert_equal response.id, @status.github_id
+      assert_equal response.url, @status.api_url
+    end
+
+    test 'creation on Github with long description' do
+      response = stub(id: 44, url: 'https://example.com')
+      @author.github_api.expects(:create_deployment_status).with do |_, _, body|
+        assert_operator body[:description].length, :<=, 140
+      end.returns(response)
 
       @status.create_on_github!
       assert_equal response.id, @status.github_id


### PR DESCRIPTION
Truncates the deploy description, uses short sha and adjusts the state used for deploy timeouts.

This should resolve https://github.com/Shopify/shipit-engine/issues/1004