### PR TITLE
Added status mappings for faulty and timedout shipit statuses.

### DIFF
--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -21,7 +21,9 @@ module Shipit
         'pending' => 'pending',
         'running' => 'in_progress',
         'failed' => 'failure',
+        'timedout' => 'failure',
         'success' => 'success',
+        'faulty' => 'error',
         'error' => 'error',
         'aborted' => 'error',
       }.freeze

--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -35,7 +35,8 @@ module Shipit
             Rails.logger.info(
               "Creating #{github_status} deploy status for deployment #{deployment.id}. "\
               "Commit: #{deployment.sha}, Github id: #{deployment.github_id}, "\
-              "Repo: #{deployment.stack.repo_name}, Environment: #{deployment.stack.environment}",
+              "Repo: #{deployment.stack.repo_name}, Environment: #{deployment.stack.environment}, "\
+              "API Url: #{deployment.api_url}.",
             )
             deployment.statuses.create!(status: github_status)
           end
@@ -44,7 +45,8 @@ module Shipit
             Rails.logger.warn(
               "No GitHub status for task status #{task_status}. "\
               "Commit: #{deployment.sha}, Github id: #{deployment.github_id}, "\
-              "Repo: #{deployment.stack.repo_name}, Environment: #{deployment.stack.environment}",
+              "Repo: #{deployment.stack.repo_name}, Environment: #{deployment.stack.environment}, "\
+              "API Url: #{deployment.api_url}.",
             )
           end
         end


### PR DESCRIPTION
I think these statuses should both count as "finisher" statuses, e.g. ones that result in a deployment status being created in a 'done' state such as failure or error.

This will also let us rule out skipping these statuses as one potential source of the current missing deploy completion statuses.