### PR TITLE
Add environment_url to deployment status events

### DIFF
--- a/app/models/shipit/commit_deployment_status.rb
+++ b/app/models/shipit/commit_deployment_status.rb
@@ -50,6 +50,7 @@ module Shipit
         accept: 'application/vnd.github.flash-preview+json',
         target_url: url_helpers.stack_deploy_url(stack, task),
         description: description.truncate(DESCRIPTION_CHARACTER_LIMIT_ON_GITHUB),
+        environment_url: stack.deploy_url,
       )
     end
 

--- a/test/models/commit_deployment_status_test.rb
+++ b/test/models/commit_deployment_status_test.rb
@@ -17,6 +17,7 @@ module Shipit
         accept: "application/vnd.github.flash-preview+json",
         target_url: "http://shipit.com/shopify/shipit-engine/production/deploys/#{@task.id}",
         description: "walrus triggered the deploy of shopify/shipit-engine/production to #{@deployment.short_sha}",
+        environment_url: "https://shipit.shopify.com",
       ).returns(response)
 
       @status.create_on_github!
@@ -33,6 +34,20 @@ module Shipit
       create_status_response = stub(id: 'abcd', url: 'https://github.com/status/abcd')
       status.author.github_api.expects(:create_deployment_status).with do |*_args, **kwargs|
         kwargs[:description].size <= limit
+      end.returns(create_status_response)
+
+      status.create_on_github!
+    end
+
+    test 'includes deployment url when the deployment succeeds' do
+      deployment = shipit_commit_deployments(:shipit_deploy_second)
+
+      status = deployment.statuses.create!(status: 'success')
+      stack = status.stack
+      stack.deploy_url = "stack-deploy-url"
+      create_status_response = stub(id: 'abcd', url: 'https://github.com/status/abcd')
+      status.author.github_api.expects(:create_deployment_status).with do |*_args, **kwargs|
+        kwargs[:environment_url] == 'stack-deploy-url'
       end.returns(create_status_response)
 
       status.create_on_github!


### PR DESCRIPTION
When creating a deployment status let's add the `environment_url` to
the payload we send to GitHub. The idea is that this gets us whatever
awesome features with which the GitHub API uses this value - automatic
linking to the deployment environment in the PR.

References
----------

- https://developer.github.com/changes/2016-04-06-deployment-and-deployment-status-enhancements/#link-to-a-live-deployment