### PR TITLE
Monkeypatch deprecated omniauth-github behaviour

### DIFF
--- a/config/initializers/omniauth_github.rb
+++ b/config/initializers/omniauth_github.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+# The gem in unmaintained but using a deprecated API, this monkeypatches a fix:
+# https://github.com/omniauth/omniauth-github/pull/84
+
+module OmniAuthGitHubHeaderAuth
+  def raw_info
+    access_token.options[:mode] = :header
+    @raw_info ||= access_token.get('user').parsed
+  end
+
+  def emails
+    return [] unless email_access_allowed?
+    access_token.options[:mode] = :header
+    @emails ||= access_token.get('user/emails', headers: {'Accept' => 'application/vnd.github.v3'}).parsed
+  end
+end
+
+OmniAuth::Strategies::GitHub.prepend(OmniAuthGitHubHeaderAuth)


### PR DESCRIPTION
Fixes #1011 

The issue is in omniauth-github but it is currently [unmaintained](https://github.com/omniauth/omniauth-github/blob/2e77639f32c35598e398c0c591ffab37691cdee7/README.md#omniauth-is-looking-for-a-new-home--if-you-are-interested-in-taking-over-this-project-please-contact-jasonmobomocom), so this patches in the [fix](https://github.com/omniauth/omniauth-github/pull/84) which is unlikely to be merged any time soon.

This patch has been installed successfully on other apps at Shopify.