### PR TITLE
Allow host application to add system-wide links to stack header

### DIFF
--- a/app/views/shipit/stacks/_header.html.erb
+++ b/app/views/shipit/stacks/_header.html.erb
@@ -41,6 +41,8 @@
         </ul>
       </li>
     <% end %>
+
+    <%= render partial: 'links', locals: { stack: stack } %>
   </ul>
 
   <ul class="nav__list nav__list--secondary">

--- a/app/views/shipit/stacks/_links.html.erb
+++ b/app/views/shipit/stacks/_links.html.erb
@@ -1,0 +1,1 @@
+<%# Placeholder to be used by the host application %>


### PR DESCRIPTION
Give the mounting application a way to define additional links which
apply to stacks across the system rather than per stack.