### PR TITLE
Add ability to perform variable substitution to stack links in shipit.yml

### DIFF
--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -43,6 +43,17 @@ module Shipit
 
     scope :not_archived, -> { where(archived_since: nil) }
 
+    def env
+      {
+        'ENVIRONMENT' => environment,
+        'LAST_DEPLOYED_SHA' => last_deployed_commit.sha,
+        'GITHUB_REPO_OWNER' => repository.owner,
+        'GITHUB_REPO_NAME' => repository.name,
+        'DEPLOY_URL' => deploy_url,
+        'BRANCH' => branch,
+      }
+    end
+
     def repository
       super || build_repository
     end
@@ -77,7 +88,7 @@ module Shipit
     validates :lock_reason, length: {maximum: 4096}
 
     serialize :cached_deploy_spec, DeploySpec
-    delegate :find_task_definition, :supports_rollback?, :links, :release_status?, :release_status_delay,
+    delegate :find_task_definition, :supports_rollback?, :release_status?, :release_status_delay,
              :release_status_context, :supports_fetch_deployed_revision?, to: :cached_deploy_spec, allow_nil: true
 
     def self.refresh_deployed_revisions
@@ -526,6 +537,13 @@ module Shipit
 
     def sync_github
       GithubSyncJob.perform_later(stack_id: id)
+    end
+
+    def links
+      links_spec = cached_deploy_spec&.links || {}
+      context = EnvironmentVariables.with(env)
+
+      links_spec.transform_values { |url| context.interpolate(url) }
     end
 
     private

--- a/lib/shipit/command.rb
+++ b/lib/shipit/command.rb
@@ -48,10 +48,7 @@ module Shipit
     def interpolate_environment_variables(argument)
       return argument.map { |a| interpolate_environment_variables(a) } if argument.is_a?(Array)
 
-      argument.gsub(/(\$\w+)/) do |variable|
-        variable.sub!('$', '')
-        Shellwords.escape(@env.fetch(variable) { ENV[variable] })
-      end
+      EnvironmentVariables.with(env).interpolate(argument)
     end
 
     def success?

--- a/lib/shipit/environment_variables.rb
+++ b/lib/shipit/environment_variables.rb
@@ -14,6 +14,15 @@ module Shipit
       sanitize_env_vars(variable_definitions)
     end
 
+    def interpolate(argument)
+      return argument unless @env
+
+      argument.gsub(/(\$\w+)/) do |variable|
+        variable.sub!('$', '')
+        Shellwords.escape(@env.fetch(variable) { ENV[variable] })
+      end
+    end
+
     private
 
     def initialize(env)

--- a/lib/shipit/task_commands.rb
+++ b/lib/shipit/task_commands.rb
@@ -28,22 +28,20 @@ module Shipit
     end
 
     def env
-      super.merge(
-        'ENVIRONMENT' => @stack.environment,
-        'BRANCH' => @stack.branch,
-        'SHIPIT_USER' => "#{@task.author.login} (#{normalized_author_name}) via Shipit",
-        'EMAIL' => @task.author.email,
-        'BUNDLE_PATH' => Rails.root.join('data', 'bundler').to_s,
-        'SHIPIT_LINK' => @task.permalink,
-        'LAST_DEPLOYED_SHA' => @stack.last_deployed_commit.sha,
-        'TASK_ID' => @task.id.to_s,
-        'DEPLOY_URL' => @stack.deploy_url,
-        'IGNORED_SAFETIES' => @task.ignored_safeties? ? '1' : '0',
-        'GIT_COMMITTER_NAME' => @task.user&.name || Shipit.committer_name,
-        'GIT_COMMITTER_EMAIL' => @task.user&.email || Shipit.committer_email,
-        'GITHUB_REPO_OWNER' => @stack.repository.owner,
-        'GITHUB_REPO_NAME' => @stack.repository.name,
-      ).merge(deploy_spec.machine_env).merge(@task.env)
+      super
+        .merge(@stack.env)
+        .merge(
+          'SHIPIT_USER' => "#{@task.author.login} (#{normalized_author_name}) via Shipit",
+          'EMAIL' => @task.author.email,
+          'BUNDLE_PATH' => Rails.root.join('data', 'bundler').to_s,
+          'SHIPIT_LINK' => @task.permalink,
+          'TASK_ID' => @task.id.to_s,
+          'IGNORED_SAFETIES' => @task.ignored_safeties? ? '1' : '0',
+          'GIT_COMMITTER_NAME' => @task.user&.name || Shipit.committer_name,
+          'GIT_COMMITTER_EMAIL' => @task.user&.email || Shipit.committer_email,
+        )
+        .merge(deploy_spec.machine_env)
+        .merge(@task.env)
     end
 
     def checkout(commit)

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_09_132519) do
+ActiveRecord::Schema.define(version: 2020_02_11_145825) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text "permissions", limit: 65535
@@ -100,6 +100,16 @@ ActiveRecord::Schema.define(version: 2020_01_09_132519) do
     t.datetime "updated_at", null: false
     t.index ["hook_id", "event", "status"], name: "index_deliveries_on_hook_id_and_event_and_status"
     t.index ["hook_id", "status"], name: "index_deliveries_on_hook_id_and_status"
+  end
+
+  create_table "environment_variables", force: :cascade do |t|
+    t.string "name", null: false
+    t.string "value"
+    t.string "environmentable_type"
+    t.integer "environmentable_id"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["environmentable_type", "environmentable_id"], name: "idx_shipit_envvars_on_type_and_id"
   end
 
   create_table "github_hooks", force: :cascade do |t|

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -863,6 +863,41 @@ module Shipit
       end
     end
 
+    test "#links performs template substitutions" do
+      @stack.repo_name = "expected-repository-name"
+      @stack.environment = "expected-environment"
+      @stack.cached_deploy_spec = create_deploy_spec(
+        "links" => {
+          "logs" => "http://logs.$GITHUB_REPO_NAME.$ENVIRONMENT.domain.com",
+          "monitoring" => "https://graphs.$GITHUB_REPO_NAME.$ENVIRONMENT.domain.com",
+        },
+      )
+
+      assert_equal(
+        {
+          "logs" => "http://logs.expected-repository-name.expected-environment.domain.com",
+          "monitoring" => "https://graphs.expected-repository-name.expected-environment.domain.com",
+        },
+        @stack.links,
+      )
+    end
+
+    test "#env includes the stack's environment" do
+      expected_environment = {
+        'ENVIRONMENT' => @stack.environment,
+        'LAST_DEPLOYED_SHA' => @stack.last_deployed_commit.sha,
+        'GITHUB_REPO_OWNER' => @stack.repository.owner,
+        'GITHUB_REPO_NAME' => @stack.repository.name,
+        'DEPLOY_URL' => @stack.deploy_url,
+        'BRANCH' => @stack.branch,
+      }
+
+      assert_equal(
+        @stack.env,
+        expected_environment,
+      )
+    end
+
     private
 
     def generate_revert_commit(stack:, reverted_commit:, author: reverted_commit.author)
@@ -874,6 +909,10 @@ module Shipit
         authored_at: Time.zone.now,
         committed_at: Time.zone.now,
       )
+    end
+
+    def create_deploy_spec(spec)
+      Shipit::DeploySpec.new(spec.stringify_keys)
     end
   end
 end


### PR DESCRIPTION
...when at least one task has been performed on the stack - IE when
we have something we can use to grab the environment variables.

This maintains the previous functionality of the `shipit.yml` to
declare static links for stacks like:

```yml
links:
  logs: https://logs.application.com
```

but also affords consumers the ability to define template strings in
the `shipit.yaml` like:

```yml
links:
  logs: https://logs.$ENVIRONMENT.application.com
```

Which, if the stack's environment is set to `production` will render a
link to `https://logs.production.application.com` in the stack's header.