### PR TITLE
Render shipit.yml links as a menu-list in the nav

### DIFF
--- a/app/views/shipit/stacks/_header.html.erb
+++ b/app/views/shipit/stacks/_header.html.erb
@@ -47,11 +47,18 @@
 
   <ul class="nav__list nav__list--secondary">
     <% if stack.links.present? %>
-      <% stack.links.each do |name, url| %>
-        <li class="nav__list__item">
-          <%= link_to name.humanize, url, :target => '_blank', :class => "#{name.dasherize}-url" %>
-        </li>
-      <% end %>
+      <li class="nav__list__item nav__list__item--has-children">
+
+        <%=  t('stack.nav.links') %>
+
+        <ul class="nav__sub__list">
+          <% stack.links.each do |name, url| %>
+            <li class="nav__list__sub__item">
+              <%= link_to name.humanize, url, :target => '_blank', :class => "#{name.dasherize}-url" %>
+            </li>
+          <% end %>
+        </ul>
+      </li>
     <% end %>
     <li class="nav__list__item">
       <%= link_to t('stack.nav.view_on_github'), github_repo_url(stack.repo_owner, stack.repo_name) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,7 @@ en:
       statistics: Stats
       merge_queue: "Merge Queue (%{count})"
       view_on_github: View on GitHub
+      links: More
       deploy_link: View website
   commit:
     lock: This commit is safe to deploy. Click to mark it as unsafe.


### PR DESCRIPTION
For stacks with more than one or two links the navigation bar starts
to wrap links. We _might_ prevent this by rendering the links as a
sub-list instead.