### PR TITLE
docs: add new github related script variables to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -611,6 +611,8 @@ Your deploy scripts have access to the following environment variables:
 * `SHIPIT`: Set to `1` to allow your script to know it's executed by Shipit
 * `SHIPIT_LINK`: URL to the task output, useful to broadcast it in an IRC channel
 * `SHIPIT_USER`: Full name of the user that triggered the deploy/task
+* `GITHUB_REPO_NAME`: Name of the GitHub repository being used for the current deploy/task.
+* `GITHUB_REPO_OWNER`: The GitHub username of the repository owner for the current deploy/task.
 * `EMAIL`: Email of the user that triggered the deploy/task (if available)
 * `ENVIRONMENT`: The stack environment (e.g `production` / `staging`)
 * `BRANCH`: The stack branch (e.g `master`)


### PR DESCRIPTION
I reference this section of the docs often, would like this to be more visible for others as well.