### PR TITLE
Optionally tracks pull request information on stack

### DIFF
--- a/app/jobs/shipit/refresh_pull_request_job.rb
+++ b/app/jobs/shipit/refresh_pull_request_job.rb
@@ -3,6 +3,8 @@ module Shipit
     queue_as :default
 
     def perform(pull_request)
+      raise Stack::NotYetSynced if pull_request.stack.commits.blank?
+
       pull_request.refresh!
       MergePullRequestsJob.perform_later(pull_request.stack)
     end

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -2,6 +2,8 @@ require 'fileutils'
 
 module Shipit
   class Stack < ActiveRecord::Base
+    NotYetSynced = Class.new(StandardError)
+
     module NoDeployedCommit
       extend self
 

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -39,6 +39,7 @@ module Shipit
     has_many :api_clients, dependent: :destroy
     belongs_to :lock_author, class_name: :User, optional: true
     belongs_to :repository
+    has_one :review_request, -> { where(review_request: true) }, class_name: "PullRequest"
     validates_associated :repository
 
     scope :not_archived, -> { where(archived_since: nil) }

--- a/app/serializers/shipit/pull_request_serializer.rb
+++ b/app/serializers/shipit/pull_request_serializer.rb
@@ -5,6 +5,7 @@ module Shipit
 
     has_one :merge_requested_by
     has_one :head, serializer: ShortCommitSerializer
+    has_one :user
 
     attributes :id, :number, :title, :github_id, :additions, :deletions, :state, :merge_status, :mergeable,
                :merge_requested_at, :rejection_reason, :html_url, :branch, :base_ref

--- a/app/serializers/shipit/stack_serializer.rb
+++ b/app/serializers/shipit/stack_serializer.rb
@@ -3,10 +3,12 @@ module Shipit
     include ConditionalAttributes
 
     has_one :lock_author
+    has_one :review_request
+
     attributes :id, :repo_owner, :repo_name, :environment, :html_url, :url, :tasks_url, :deploy_url, :pull_requests_url,
-               :deploy_spec, :undeployed_commits_count, :is_locked, :lock_reason, :continuous_deployment, :created_at,
-               :updated_at, :locked_since, :last_deployed_at, :branch, :merge_queue_enabled, :is_archived,
-               :archived_since
+               :deploy_spec, :undeployed_commits_count, :is_locked, :lock_reason,
+               :continuous_deployment, :created_at, :updated_at, :locked_since, :last_deployed_at, :branch,
+               :merge_queue_enabled, :is_archived, :archived_since
 
     def url
       api_stack_url(object)

--- a/db/migrate/20200210200435_change_merge_request_at_to_nullable.rb
+++ b/db/migrate/20200210200435_change_merge_request_at_to_nullable.rb
@@ -1,0 +1,9 @@
+class ChangeMergeRequestAtToNullable < ActiveRecord::Migration[6.0]
+  def change
+    change_column_null(:pull_requests, :merge_requested_at, true)
+  end
+
+  def down
+    change_column_null(:pull_requests, :merge_requested_at, false)
+  end
+end

--- a/db/migrate/20200213175236_add_user_to_pull_requests_table.rb
+++ b/db/migrate/20200213175236_add_user_to_pull_requests_table.rb
@@ -1,0 +1,13 @@
+class AddUserToPullRequestsTable < ActiveRecord::Migration[6.0]
+  def change
+    change_table(:pull_requests) do |t|
+      t.references :user
+    end
+  end
+
+  def down
+    change_table(:pull_requests) do |t|
+      t.remove_references :user
+    end
+  end
+end

--- a/db/migrate/20200213190400_add_review_request_column_to_pull_requests_table.rb
+++ b/db/migrate/20200213190400_add_review_request_column_to_pull_requests_table.rb
@@ -1,0 +1,13 @@
+class AddReviewRequestColumnToPullRequestsTable < ActiveRecord::Migration[6.0]
+  def up
+    change_table(:pull_requests) do |t|
+      t.boolean :review_request, null: true, default: false
+    end
+  end
+
+  def down
+    change_table(:pull_requests) do |t|
+      t.remove :review_request
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_09_132519) do
+ActiveRecord::Schema.define(version: 2020_02_13_190400) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text "permissions", limit: 65535
@@ -158,7 +158,7 @@ ActiveRecord::Schema.define(version: 2020_01_09_132519) do
     t.integer "deletions", default: 0, null: false
     t.string "merge_status", limit: 30, null: false
     t.string "rejection_reason"
-    t.datetime "merge_requested_at", null: false
+    t.datetime "merge_requested_at"
     t.integer "merge_requested_by_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -167,6 +167,8 @@ ActiveRecord::Schema.define(version: 2020_01_09_132519) do
     t.datetime "merged_at"
     t.string "base_ref", limit: 1024
     t.integer "base_commit_id"
+    t.integer "user_id"
+    t.boolean "review_request", default: false
     t.index ["head_id"], name: "index_pull_requests_on_head_id"
     t.index ["merge_requested_by_id"], name: "index_pull_requests_on_merge_requested_by_id"
     t.index ["merge_status"], name: "index_pull_requests_on_merge_status"
@@ -174,6 +176,7 @@ ActiveRecord::Schema.define(version: 2020_01_09_132519) do
     t.index ["stack_id", "merge_status"], name: "index_pull_requests_on_stack_id_and_merge_status"
     t.index ["stack_id", "number"], name: "index_pull_requests_on_stack_id_and_number", unique: true
     t.index ["stack_id"], name: "index_pull_requests_on_stack_id"
+    t.index ["user_id"], name: "index_pull_requests_on_user_id"
   end
 
   create_table "release_statuses", force: :cascade do |t|

--- a/test/jobs/refresh_pull_request_job_test.rb
+++ b/test/jobs/refresh_pull_request_job_test.rb
@@ -1,0 +1,19 @@
+require 'test_helper'
+
+module Shipit
+  class RefreshPullRequestJobTest < ActiveSupport::TestCase
+    setup do
+      @job = RefreshPullRequestJob.new
+    end
+
+    test "#perform call #refresh! pull_request and schedule a merge when a merge request" do
+      pull_request = shipit_pull_requests(:shipit_pending)
+
+      PullRequest.any_instance.expects(:refresh!)
+
+      assert_enqueued_with(job: MergePullRequestsJob) do
+        @job.perform(pull_request)
+      end
+    end
+  end
+end

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -260,6 +260,23 @@ module Shipit
       Stack.run_deploy_in_foreground(stack: stack.to_param, revision: commit.sha)
     end
 
+    test ".review_request is nil by default" do
+      assert_nil @stack.review_request
+    end
+
+    test ".review_request returns nil when all pull requests are merge requests" do
+      @stack = shipit_stacks(:shipit)
+
+      assert_nil @stack.review_request
+    end
+
+    test ".review_request returns latest non merge request" do
+      @stack = shipit_stacks(:shipit)
+      @pull_request = PullRequest.create!(stack: @stack, number: "1", review_request: true)
+
+      assert @stack.review_request, @pull_request
+    end
+
     test "#active_task? is memoized" do
       assert_queries(1) do
         10.times { @stack.active_task? }


### PR DESCRIPTION
For stacks that are dynamically created we might want to assign the pull request that triggered the creation.

This PR is adding the concept of a review request that can be assign to a stack if needed. I'm using the existing `PullRequest` model in order to take advantage of the code that creates and refreshes the data pulling extra info from Github.