### PR TITLE
enable webhook consumers to detect anonymous user

### DIFF
--- a/app/serializers/shipit/user_serializer.rb
+++ b/app/serializers/shipit/user_serializer.rb
@@ -1,5 +1,9 @@
 module Shipit
   class UserSerializer < ActiveModel::Serializer
-    attributes :id, :name, :email, :login, :avatar_url, :created_at, :updated_at, :github_id
+    attributes :id, :name, :email, :login, :avatar_url, :created_at, :updated_at, :github_id, :anonymous
+
+    def anonymous
+      !object.logged_in?
+    end
   end
 end

--- a/test/models/hook_test.rb
+++ b/test/models/hook_test.rb
@@ -67,5 +67,12 @@ module Shipit
     ensure
         Shipit.internal_hook_receivers = original_receivers
     end
+
+    test ".coerce_payload coerces anonymous user correctly" do
+      locked_stack = Stack.first
+      locked_stack.lock("Some Reason", nil)
+      serialized = Hook.coerce_payload(stack: locked_stack)
+      assert_json("stack.lock_author.anonymous", true, document: serialized)
+    end
   end
 end

--- a/test/unit/anonymous_user_serializer_test.rb
+++ b/test/unit/anonymous_user_serializer_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+module Shipit
+  class AnonymousUserSerializerTest < ActiveSupport::TestCase
+    test 'sets anonymous to true' do
+      user = AnonymousUser.new
+      serializer = ActiveModel::Serializer.serializer_for(user)
+      assert_equal AnonymousUserSerializer, serializer
+      serialized = serializer.new(user).to_json
+      assert_json("anonymous", true, document: serialized)
+    end
+  end
+end

--- a/test/unit/user_serializer_test.rb
+++ b/test/unit/user_serializer_test.rb
@@ -1,0 +1,13 @@
+require 'test_helper'
+
+module Shipit
+  class UserSerializerTest < ActiveSupport::TestCase
+    test 'includes anonymous key' do
+      user = User.new
+      serializer = ActiveModel::Serializer.serializer_for(user)
+      assert_equal UserSerializer, serializer
+      serialized = serializer.new(user).to_json
+      assert_json("anonymous", false, document: serialized)
+    end
+  end
+end


### PR DESCRIPTION
Keep https://github.com/Shopify/spy/issues/6843 from happening again.

Also requires a change to spy though to handle this attribute.

Paired with @lastgabs on this