### PR TITLE
Fix Postgres on GitHub Actions CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,8 @@ jobs:
       db:
         image: postgres:11
         ports: ['5432:5432']
+        env:
+          POSTGRES_HOST_AUTH_METHOD: 'trust'
         options: >-
           --health-cmd pg_isready
           --health-interval 10s


### PR DESCRIPTION
Looks like some config defaults were tightened up, without this the container fails to boot immediately with:

```
Error: Database is uninitialized and superuser password is not specified.
       You must specify POSTGRES_PASSWORD to a non-empty value for the
       superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".

       You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
       connections without a password. This is *not* recommended.

       See PostgreSQL documentation about "trust":
       https://www.postgresql.org/docs/current/auth-trust.html
```

> When trust authentication is specified, PostgreSQL assumes that anyone who can connect to the server is authorized to access the database with whatever database user name they specify (even superuser names).

This seems fine for CI.

cc @exterm you'll need to rebase on this once merged.