### PR TITLE
Fix commit deployment payload encoding

### DIFF
--- a/app/models/shipit/commit_deployment.rb
+++ b/app/models/shipit/commit_deployment.rb
@@ -56,7 +56,7 @@ module Shipit
             from_sha: task.since_commit.sha,
             to_sha: task.until_commit.sha,
           },
-        },
+        }.to_json,
       )
     end
   end

--- a/test/models/commit_deployment_test.rb
+++ b/test/models/commit_deployment_test.rb
@@ -24,7 +24,7 @@ module Shipit
             from_sha: 'f890fd8b5f2be05d1fedb763a3605ee461c39074',
             to_sha: '467578b362bf2b4df5903e1c7960929361c3435a',
           },
-        },
+        }.to_json,
       ).returns(deployment_response)
 
       @deployment.create_on_github!


### PR DESCRIPTION
As this is a [string field](https://github.com/octokit/octokit.rb/blob/14bb1a1d4fec8d2250dc6f6b9cb2d446a0332d58/lib/octokit/client/deployments.rb#L34) I intended this to be encoded JSON but forgot to actually do the encoding 🤦‍♂  In production octokit is silently casting the hash into a string of the hash literal, so this has gone unnoticed :embarrassed: