### PR TITLE
Add job for reaping dead but running deploys.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+* Added a new job `ReapDeadDeploymentsJob` to support cleanup of jobs that are stuck in running, but report as dead.
+  * This job runs every minute via the cron rake task.
+  * When running this job for the first time, it may transition old zombie tasks, causing any side-effects to fire, like notifications.
+
 # 0.31.0
 
 * Update omniauth-github to stop using a deprecated authentication method.

--- a/app/jobs/shipit/reap_dead_deployments_job.rb
+++ b/app/jobs/shipit/reap_dead_deployments_job.rb
@@ -1,0 +1,17 @@
+module Shipit
+  class ReapDeadDeploymentsJob < BackgroundJob
+    include BackgroundJob::Unique
+
+    queue_as :default
+
+    def perform
+      zombie_tasks = Task.where(status: 'running').reject(&:alive?)
+
+      Rails.logger.info("Reaping #{zombie_tasks.size} running tasks.")
+      zombie_tasks.each do |task|
+        Rails.logger.info("Reaping task #{task.id}: #{task.title}")
+        task.report_dead!
+      end
+    end
+  end
+end

--- a/db/migrate/20200226211925_add_index_to_tasks_status.rb
+++ b/db/migrate/20200226211925_add_index_to_tasks_status.rb
@@ -1,0 +1,5 @@
+class AddIndexToTasksStatus < ActiveRecord::Migration[6.0]
+  def change
+    add_index :tasks, :status
+  end
+end

--- a/lib/tasks/cron.rake
+++ b/lib/tasks/cron.rake
@@ -5,6 +5,7 @@ namespace :cron do
     Shipit::Stack.schedule_continuous_delivery
     Shipit::GithubStatus.refresh_status
     Shipit::PullRequest.schedule_merges
+    Shipit::ReapDeadDeploymentsJob.perform_later
   end
 
   task hourly: %i(rollup refresh_users)

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_01_09_132519) do
+ActiveRecord::Schema.define(version: 2020_02_26_211925) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text "permissions", limit: 65535
@@ -265,6 +265,7 @@ ActiveRecord::Schema.define(version: 2020_01_09_132519) do
     t.index ["stack_id", "allow_concurrency", "status"], name: "index_active_tasks"
     t.index ["stack_id", "allow_concurrency"], name: "index_tasks_on_stack_id_and_allow_concurrency"
     t.index ["stack_id", "status", "type"], name: "index_tasks_by_stack_and_status"
+    t.index ["status"], name: "index_tasks_on_status"
     t.index ["type", "stack_id", "parent_id"], name: "index_tasks_by_stack_and_parent"
     t.index ["until_commit_id"], name: "index_tasks_on_until_commit_id"
     t.index ["user_id"], name: "index_tasks_on_user_id"

--- a/test/jobs/reap_dead_deployments_job_test.rb
+++ b/test/jobs/reap_dead_deployments_job_test.rb
@@ -1,0 +1,38 @@
+require 'test_helper'
+
+module Shipit
+  class ReapDeadDeploymentsJobTest < ActiveSupport::TestCase
+    setup do
+      Task.where(status: Task::ACTIVE_STATUSES).update_all(status: 'success')
+
+      @deploy = shipit_deploys(:shipit)
+      @deploy.status = 'success'
+      @deploy.save!
+
+      @rollback = @deploy.build_rollback
+      @rollback.status = 'running'
+      @rollback.save!
+
+      @zombie_deploy = shipit_deploys(:shipit2)
+      @zombie_deploy.status = 'running'
+      @zombie_deploy.save!
+    end
+
+    test 'reaps only zombie tasks' do
+      refute_predicate @zombie_deploy, :error?
+
+      Shipit::Deploy.any_instance.expects(:alive?).returns(false)
+      Shipit::Rollback.any_instance.expects(:alive?).returns(true)
+      ReapDeadDeploymentsJob.perform_now
+
+      @zombie_deploy.reload
+      assert_predicate @zombie_deploy, :error?
+
+      @deploy.reload
+      assert_predicate @deploy, :finished?
+
+      @rollback.reload
+      assert_predicate @rollback, :running?
+    end
+  end
+end


### PR DESCRIPTION
When infra disruptions occur (e.g. SQL) , tasks can get stuck in the Running state, but will return false when calling `alive?`. These deploys are then seemingly permanently stuck, requiring manual intervention.

This PR creates a job that will check for such stuck deploys and terminate them, while logging the information for further followup if necessary.

Scheduling of the job will be hooked up in a future PR, and can be done integration-side as well.