### PR TITLE
Capture exit code of rubygems push commands and fail shipit stack on …

### DIFF
--- a/lib/snippets/release-gem
+++ b/lib/snippets/release-gem
@@ -51,7 +51,8 @@ if RubygemsAPI.published?(spec.name, spec.version)
   puts "#{spec.name} version #{spec.version} is already published."
   exit 0
 else
-  Git.tag_and_push(spec.version) do
+  is_successful = Git.tag_and_push(spec.version) do
     system(*release_command)
   end
+  is_successful ? exit(0) : exit(1)
 end


### PR DESCRIPTION
While deploying Krane v1.1.2 via ShipIt ([see bottom](https://shipit.shopify.io/shopify/krane/rubygems/deploys/934803)), a subcommand failed due to GitHub suffering from an outage. However, Shipit didn't register this and the deploy was marked successful. This PR will fail the deploy if any of the `tag_and_push` sub-commands fail.'

cc @Shopify/krane 