### PR TITLE
Fix rake CVE-2020-8130

### DIFF
--- a/shipit-engine.gemspec
+++ b/shipit-engine.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_dependency 'rails', '~> 6.0.0'
   s.add_dependency 'rails-timeago', '~> 2.13.0'
   s.add_dependency 'rails_autolink', '~> 1.1.6'
-  s.add_dependency 'rake', '~> 10.0'
+  s.add_dependency 'rake', '~> 12.0'
   s.add_dependency 'redis-namespace', '~> 1.6.0'
   s.add_dependency 'redis-objects', '~> 1.4.3'
   s.add_dependency 'responders', '~> 3.0'


### PR DESCRIPTION
I dunno if we should set something less restrictive or not or if `~> 12.0` will break in some scenarios.

Anyone with some input on this?