### PR TITLE
avoid crash on null duration

### DIFF
--- a/app/models/shipit/deploy_stats.rb
+++ b/app/models/shipit/deploy_stats.rb
@@ -4,7 +4,7 @@ module Shipit
 
     def initialize(deploys)
       @deploys = deploys
-      @durations = @deploys.map { |d| d.duration.value }.compact
+      @durations = @deploys.map { |d| d.duration&.value }.compact
     end
 
     def count


### PR DESCRIPTION
Encountered a hard crash on the stats page due to a null reference.