### PR TITLE
release-gem: abort deploy if allowed_push_host property is not set

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 # Unreleased
 
+* Prevent gem released unless the `allowed_push_host` metadata is set in the gemspec (#1037).
 * Added a new job `ReapDeadDeploymentsJob` to support cleanup of jobs that are stuck in running, but report as dead.
   * This job runs every minute via the cron rake task.
   * When running this job for the first time, it may transition old zombie tasks, causing any side-effects to fire, like notifications.

--- a/lib/snippets/release-gem
+++ b/lib/snippets/release-gem
@@ -50,6 +50,9 @@ spec = Gem::Specification.load(spec_path)
 if RubygemsAPI.published?(spec.name, spec.version)
   puts "#{spec.name} version #{spec.version} is already published."
   exit 0
+elsif !spec.metadata['allowed_push_host']
+  puts "Can't release the gem: spec.metadata['allowed_push_host'] must be defined."
+  exit 1
 else
   is_successful = Git.tag_and_push(spec.version) do
     system(*release_command)


### PR DESCRIPTION
When you generate a gem with bundler `spec.metadata['allowed_push_host']` is set to `"TODO: Set to 'http://mygemserver.com'"` to prevent publishing private gems onto the public registry.

The problem is that if people remove that property entirely, or craft the gemspec entirely by hand, it then default to `https://rubygems.org`.

So this PR change the `release-gem` script, so that it requires explicit whitelisting of `https://rubygems`.

cc @lastgabs @EiNSTeiN- @wildmaples 