### PR TITLE
Added guard against 401 and log message when a user email cannot be retrieved

### DIFF
--- a/app/models/shipit/user.rb
+++ b/app/models/shipit/user.rb
@@ -140,8 +140,9 @@ module Shipit
                   .sort_by { |e| e.primary ? 0 : 1 }
                   .map(&:email)
                   .find { |e| email_valid_and_preferred?(e) }
-      rescue Octokit::NotFound, Octokit::Forbidden
+      rescue Octokit::NotFound, Octokit::Forbidden, Octokit::Unauthorized
         # If the user hasn't agreed to the necessary permission, we can't access their private emails.
+        Rails.logger.warn("Failed to retrieve emails for user '#{name}'")
         nil
       end
     end

--- a/app/models/shipit/user.rb
+++ b/app/models/shipit/user.rb
@@ -142,7 +142,7 @@ module Shipit
                   .find { |e| email_valid_and_preferred?(e) }
       rescue Octokit::NotFound, Octokit::Forbidden, Octokit::Unauthorized
         # If the user hasn't agreed to the necessary permission, we can't access their private emails.
-        Rails.logger.warn("Failed to retrieve emails for user '#{name}'")
+        Rails.logger.warn("Failed to retrieve emails for user '#{github_user.name || github_user.login}'")
         nil
       end
     end

--- a/test/models/users_test.rb
+++ b/test/models/users_test.rb
@@ -162,6 +162,13 @@ module Shipit
       assert_nil user.email
     end
 
+    test "find_or_create_from_github handles user 401" do
+      Shipit.preferred_org_emails = [@org_domain]
+      Octokit::Client.any_instance.expects(:emails).raises(Octokit::Unauthorized)
+      user = User.find_or_create_from_github(@minimal_github_user)
+      assert_nil user.email
+    end
+
     test "#identifiers_for_ping returns a hash with the user's github_id, name, email and github_login" do
       user = shipit_users(:bob)
       expected_ouput = {github_id: user.github_id, name: user.name, email: user.email, github_login: user.login}


### PR DESCRIPTION
We are already guarding against 403s and 404s, but apparently the credentials can be in a state where 401s are returned when trying to retrieve emails at all. This didn't show up in testing at the time.

This adds 401s to the rescue clause, as well as a log message so users with problematic app permission and email API settings can be more easily tracked down.