### PR TITLE
Bump timeout on CreateOnGithubJob

### DIFF
--- a/app/jobs/shipit/create_on_github_job.rb
+++ b/app/jobs/shipit/create_on_github_job.rb
@@ -4,6 +4,9 @@ module Shipit
 
     queue_as :default
 
+    # We observe that some objects regularly take longer than the default 10 seconds to create, e.g. deployments
+    self.timeout = 20
+
     def perform(record)
       record.create_on_github!
     end


### PR DESCRIPTION
We are seeing this in the wild often:

```
bundler/gems/shipit-engine-9ba3c13818c9jobs/shipit/background_job/unique.rb:24:in `rescue in acquire_lock': Shipit::BackgroundJob::Unique::ConcurrentJobError (Shipit::BackgroundJob::Unique::ConcurrentJobError)
    from bundler/gems/shipit-engine-9ba3c13818c9jobs/shipit/background_job/unique.rb:15:in `acquire_lock'
    from bundler/gems/shipit-engine-9ba3c13818c9jobs/shipit/background_job/unique.rb:10:in `block (2 levels) in <module:Unique>'
```

... and the job arg is almost exclusively a `Shipit::CommitDeployment`. From my own experience I know these are surprisingly slow to create, I ran some experiments and they were all in the 11-13 second range.