### PR TITLE
More job timeout tweaks

### DIFF
--- a/app/jobs/shipit/create_on_github_job.rb
+++ b/app/jobs/shipit/create_on_github_job.rb
@@ -5,7 +5,8 @@ module Shipit
     queue_as :default
 
     # We observe that some objects regularly take longer than the default 10 seconds to create, e.g. deployments
-    self.timeout = 20
+    self.timeout = 40
+    self.lock_timeout = 20
 
     def perform(record)
       record.create_on_github!

--- a/app/jobs/shipit/deferred_touch_job.rb
+++ b/app/jobs/shipit/deferred_touch_job.rb
@@ -4,6 +4,9 @@ module Shipit
 
     queue_as :default
 
+    self.timeout = 30
+    self.lock_timeout = 15
+
     def perform
       DeferredTouch.touch_now!
     end


### PR DESCRIPTION
I took a closer look through our exception reports and StatsD metrics over the last 24 hours, the aim with these changes is to further reduce the `ConcurrentJobError` exceptions. The timeout values are based on the max observed runtime for these jobs in the last 24 hours, and the lock timeout is intended to add a bit of a buffer for outliers.