### PR TITLE
Handle stale check runs

### DIFF
--- a/app/models/shipit/check_run.rb
+++ b/app/models/shipit/check_run.rb
@@ -1,6 +1,6 @@
 module Shipit
   class CheckRun < ApplicationRecord
-    CONCLUSIONS = %w(success failure neutral cancelled timed_out action_required).freeze
+    CONCLUSIONS = %w(success failure neutral cancelled timed_out action_required stale).freeze
     include DeferredTouch
     include Status::Common
 
@@ -45,7 +45,7 @@ module Shipit
         'pending'
       when 'success', 'neutral'
         'success'
-      when 'failure', 'cancelled'
+      when 'failure', 'cancelled', 'stale'
         'failure'
       when 'timed_out'
         'error'


### PR DESCRIPTION
This was [added a few weeks ago](https://developer.github.com/changes/2020-02-03-stale-conclusion/) and is causing `ActiveRecord::RecordInvalid
Validation failed: Conclusion is not included in the list` exceptions.

> The new `stale` state ... behaves similarly to the `timed_out` and `canceled` conclusions.

^ so I grouped it with those here too.