### PR TITLE
Truncate rolled up chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 * Added a new job `ReapDeadTasksJob` to support cleanup of jobs that are stuck in running, but report as dead.
   * This job runs every minute via the cron rake task.
   * When running this job for the first time, it may transition old zombie tasks, causing any side-effects to fire, like notifications.
+* Limit the size of task output logs to 16 MB (#1041)
 
 # 0.31.0
 

--- a/Rakefile
+++ b/Rakefile
@@ -19,6 +19,7 @@ Rake::TestTask.new(:test) do |t|
   t.libs << 'test'
   t.test_files = FileList.new('test/**/*_test.rb').exclude('test/dummy/**/*')
   t.verbose = false
+  t.warning = false
 end
 
 task default: :test

--- a/app/jobs/shipit/chunk_rollup_job.rb
+++ b/app/jobs/shipit/chunk_rollup_job.rb
@@ -4,6 +4,9 @@ module Shipit
 
     queue_as :default
 
+    self.timeout = 60
+    self.lock_timeout = 30
+
     def perform(task)
       unless task.finished?
         logger.error("Task ##{task.id} is not finished (current state: #{task.status}). Aborting.")

--- a/test/models/tasks_test.rb
+++ b/test/models/tasks_test.rb
@@ -30,5 +30,21 @@ module Shipit
 
       task.write("hello\nworld")
     end
+
+    test "#chunk_output truncates output exceeding the storage limit" do
+      task = shipit_tasks(:shipit)
+      task.chunks.delete_all
+      # Dont persist the chunk to the DB, as it may exceed the MySQL max packet size on CI
+      task.chunks.build(text: 'a' * (Task::OUTPUT_SIZE_LIMIT * 1.1))
+
+      output = task.chunk_output
+
+      assert output.size <= Task::OUTPUT_SIZE_LIMIT, "Output was not truncated to the limit"
+      # We don't use assert_includes because it will print the whole message
+      assert(
+        output.include?(Task::OUTPUT_TRUNCATED_MESSAGE),
+        "'#{Task::OUTPUT_TRUNCATED_MESSAGE.chomp}' was not present in the output",
+      )
+    end
   end
 end


### PR DESCRIPTION
Fixes #1041 

We cannot support an unbounded output size, so this truncates task output to the last 16 MB - the size of a MySQL medium blob - on the basis that the end of the log is probably more useful than the start. I also decided to deal with whole characters using `last` rather than counting raw bytes, because even though this could theoretically exceed the size limit if we have multi-byte characters, the limits applies to the _decompressed_ output, and it's very unlikely that once compressed it will not exceed the limit. Optimising for readability.

This also bumps the timeout of the rollout job based on logic used in #1042, and disables Ruby warnings in CI because there are so many, the vast majority of which are not in our codebase.