### PR TITLE
Retry intermittent GitHub exceptions in background jobs

### DIFF
--- a/app/jobs/shipit/background_job.rb
+++ b/app/jobs/shipit/background_job.rb
@@ -4,6 +4,9 @@ module Shipit
       attr_accessor :timeout
     end
 
+    # Write actions can sometimes fail intermittently, particulary for large and/or busy repositories
+    retry_on(Octokit::BadGateway, Octokit::InternalServerError)
+
     def perform(*)
       with_timeout do
         super


### PR DESCRIPTION
I see no harm adding this to the base class, but would be happy to add this to jobs individually if you prefer.