### PR TITLE
More explicit tooltip content for the lock button

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,9 +32,9 @@ en:
       links: More
       deploy_link: View website
   commit:
-    lock: Click to mark this commit as UNSAFE to deploy.
-    unlock: Click to mark this commit as SAFE to deploy.
-    unlock_with_author: "%{author} marked this commit as unsafe to deploy. Click to mark it as safe."
+    lock: Click to mark this commit as unsafe to deploy.
+    unlock: Click to mark this commit as safe to deploy.
+    unlock_with_author: "%{author} marked this commit as unsafe to deploy. Click to mark this commit as safe to deploy."
     confirm_unlock: Mark this commit as safe to deploy?
   release:
     validate: Mark the release as healthy

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -32,8 +32,8 @@ en:
       links: More
       deploy_link: View website
   commit:
-    lock: This commit is safe to deploy. Click to mark it as unsafe.
-    unlock: This commit was marked as unsafe to deploy. Click to mark it as safe.
+    lock: Click to mark this commit as UNSAFE to deploy.
+    unlock: Click to mark this commit as SAFE to deploy.
     unlock_with_author: "%{author} marked this commit as unsafe to deploy. Click to mark it as safe."
     confirm_unlock: Mark this commit as safe to deploy?
   release:


### PR DESCRIPTION
I just had to lock some changes, but in the heat of the moment, was not reading the full sentences of these tooltips and was confused how to lock the change. I feel tooltips like this that are used in critical moments should be very explicit about what they do, that's all I care about when scanning the UI trying to find what I need.

The color of the lock 🔒 icon already indicates the status of the commit so I don't feel it's needed in the tooltip as well. But maybe there was an accessibility reason for this?