### PR TITLE
Don't attempt to checkout unreachable commits

### DIFF
--- a/lib/shipit/stack_commands.rb
+++ b/lib/shipit/stack_commands.rb
@@ -26,7 +26,7 @@ module Shipit
     end
 
     def fetch_deployed_revision
-      with_temporary_working_directory(commit: @stack.commits.last) do |dir|
+      with_temporary_working_directory(commit: @stack.commits.reachable.last) do |dir|
         spec = DeploySpec::FileSystem.new(dir, @stack.environment)
         outputs = spec.fetch_deployed_revision_steps!.map do |command_line|
           Command.new(command_line, env: env, chdir: dir).run
@@ -42,7 +42,7 @@ module Shipit
     end
 
     def with_temporary_working_directory(commit: nil)
-      commit ||= @stack.last_deployed_commit.presence || @stack.commits.last
+      commit ||= @stack.last_deployed_commit.presence || @stack.commits.reachable.last
 
       if !commit || !fetched?(commit).tap(&:run).success?
         @stack.acquire_git_cache_lock do


### PR DESCRIPTION
Where the last commit for a stack is unreachable (has been rebased off the branch, for example), we should not consider it for use when checking out the repo to, for example, fetch the deployed revision. We should only consider the last reachable commit.

I couldn't find any test coverage for this in a quick look.