### PR TITLE
Reload records to be created on Github

### DIFF
--- a/app/jobs/shipit/create_on_github_job.rb
+++ b/app/jobs/shipit/create_on_github_job.rb
@@ -9,7 +9,7 @@ module Shipit
     self.lock_timeout = 20
 
     def perform(record)
-      record.create_on_github!
+      record.reload.create_on_github!
     end
   end
 end


### PR DESCRIPTION
This prevents us from duplicating data on Github.

This is a temporary solution until the lock can be moved from the `around_perform` to `around_execute` callback in order to operate prior to database queries, which is blocked on [support in Rails core](https://discuss.rubyonrails.org/t/activejob-before-perform-callback/74137). See https://github.com/Shopify/shipit-engine/pull/1042#issuecomment-608118022

Fixes #1049 