### PR TITLE
Prevent immediately marking newly started deployments as dead

### DIFF
--- a/app/jobs/shipit/reap_dead_tasks_job.rb
+++ b/app/jobs/shipit/reap_dead_tasks_job.rb
@@ -1,19 +1,20 @@
 module Shipit
   class ReapDeadTasksJob < BackgroundJob
     include BackgroundJob::Unique
-
-    ZOMBIE_STATES = %w(running aborting).freeze
-
     queue_as :default
 
     def perform
-      zombie_tasks = Task.where(status: ZOMBIE_STATES).reject(&:alive?)
-
       Rails.logger.info("Reaping #{zombie_tasks.size} running tasks.")
       zombie_tasks.each do |task|
         Rails.logger.info("Reaping task #{task.id}: #{task.title}")
         task.report_dead!
       end
+    end
+
+    private
+
+    def zombie_tasks
+      @zombie_tasks ||= Task.zombies
     end
   end
 end

--- a/test/jobs/reap_dead_tasks_job_test.rb
+++ b/test/jobs/reap_dead_tasks_job_test.rb
@@ -5,16 +5,20 @@ module Shipit
     setup do
       Task.where(status: Task::ACTIVE_STATUSES).update_all(status: 'success')
 
+      not_recently = Shipit::Task.recently_created_at - 1.minute
       @deploy = shipit_deploys(:shipit)
       @deploy.status = 'success'
+      @deploy.created_at = not_recently
       @deploy.save!
 
       @rollback = @deploy.build_rollback
       @rollback.status = 'running'
+      @rollback.created_at = not_recently
       @rollback.save!
 
       @zombie_deploy = shipit_deploys(:shipit2)
       @zombie_deploy.status = 'running'
+      @zombie_deploy.created_at = not_recently
       @zombie_deploy.save!
     end
 
@@ -33,6 +37,21 @@ module Shipit
 
       @rollback.reload
       assert_predicate @rollback, :running?
+    end
+
+    test "does reap recently created tasks" do
+      Task.where(status: Task::ACTIVE_STATUSES).update_all(status: 'success')
+      recently = Time.current
+      @deploy = shipit_deploys(:shipit)
+      @deploy.created_at = recently
+      @deploy.status = 'running'
+      @deploy.save!
+      Shipit::Deploy.any_instance.expects(:alive?).never
+
+      ReapDeadTasksJob.perform_now
+
+      @deploy.reload
+      assert_predicate @deploy, :running?
     end
 
     test 'reaps zombie aborting tasks' do


### PR DESCRIPTION
There appears to be a race condition between the time when the
PerformTaskJob marks a task as "running" and when the newly added
RemoveDeadTasks job attempts to reap dead tasks.

In some cases a deployment is almost immediately marked as dead after
it starts. We believe this is because there critical section in which
PerformTaskJob marks a task as running and ReapDeadTaskJob is run in
which newly a task can be transitioned to a "running" status, but not
yet marked alive in which a newly created task will be considered a
"dead task" by the ReapDeaTasks job.

This changeset aims a two pronged approach at preventing this
race. First it makes the ReapDeadTasksJob less aggressive in its
consideration of tasks as "dead" - it will now only consider tasks in
a "running" or "aborted" state which are missing an "alive" monitor
AND are 5 at least minutes old.

Second, when PerformTaskJob starts working a task the task will ping
the "alive" monitor as soon as the task is marked as running. The
implementation of reporting that tasks are "alive" is somewhat
imperfect, in that it it doesn't happen until we attempt to capture
command output. There are therefore several things which happen
between starting the task and the first command happening, namely one
or two checks that the git repo is already checked out and a wait on a
cache lock, whose timeout is also 15 seconds. This means a large
opportunity for the "alive" status to expire. We should probably
ensure that the task is considered alive for a period long enough to
span this (maybe 30 seconds rather than 15), as well as ping after
each check of `fetched?`.

References
----------

- [Task marked as running, but not yet alive](https://github.com/Shopify/shipit-engine/blob/d48ceb4ffc21afbdf2701ce8c3a8936268afc3d5/app/jobs/shipit/perform_task_job.rb#L18)
- [Task first marked as alive](https://github.com/Shopify/shipit-engine/blob/d48ceb4ffc21afbdf2701ce8c3a8936268afc3d5/app/jobs/shipit/perform_task_job.rb#L81)