### PR TITLE
Delay continuous delivery for stacks without a cached DeploySpec

### DIFF
--- a/app/models/shipit/deploy_spec.rb
+++ b/app/models/shipit/deploy_spec.rb
@@ -40,7 +40,7 @@ module Shipit
       end
     end
 
-    def config_empty?
+    def blank?
       config.empty?
     end
 

--- a/app/models/shipit/deploy_spec.rb
+++ b/app/models/shipit/deploy_spec.rb
@@ -40,6 +40,10 @@ module Shipit
       end
     end
 
+    def config_empty?
+      config.empty?
+    end
+
     def supports_fetch_deployed_revision?
       fetch_deployed_revision_steps.present?
     end

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -161,7 +161,7 @@ module Shipit
     end
 
     def trigger_continuous_delivery
-      return if empty_config?
+      return if cached_deploy_spec.config_empty?
 
       commit = next_commit_to_deploy
 
@@ -607,10 +607,6 @@ module Shipit
 
     def ci_enabled_cache_key
       "stacks:#{id}:ci_enabled"
-    end
-
-    def empty_config?
-      cached_deploy_spec.config.empty?
     end
 
     def should_resume_continuous_delivery?(commit)

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -161,7 +161,7 @@ module Shipit
     end
 
     def trigger_continuous_delivery
-      return if cached_deploy_spec.config_empty?
+      return if cached_deploy_spec.blank?
 
       commit = next_commit_to_deploy
 

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -43,6 +43,17 @@ module Shipit
 
     scope :not_archived, -> { where(archived_since: nil) }
 
+    def env
+      {
+        'ENVIRONMENT' => environment,
+        'LAST_DEPLOYED_SHA' => last_deployed_commit.sha,
+        'GITHUB_REPO_OWNER' => repository.owner,
+        'GITHUB_REPO_NAME' => repository.name,
+        'DEPLOY_URL' => deploy_url,
+        'BRANCH' => branch,
+      }
+    end
+
     def repository
       super || build_repository
     end

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -161,6 +161,8 @@ module Shipit
     end
 
     def trigger_continuous_delivery
+      return if empty_config?
+
       commit = next_commit_to_deploy
 
       if should_resume_continuous_delivery?(commit)
@@ -607,11 +609,8 @@ module Shipit
       "stacks:#{id}:ci_enabled"
     end
 
-    def should_delay_continuous_delivery?(commit)
-      commit.deploy_failed? ||
-        (checks? && !EphemeralCommitChecks.new(commit).run.success?) ||
-        commit.recently_pushed? ||
-        cached_deploy_spec.config.empty?
+    def empty_config?
+      cached_deploy_spec.config.empty?
     end
 
     def should_resume_continuous_delivery?(commit)
@@ -619,6 +618,12 @@ module Shipit
         deployed_too_recently? ||
         commit.nil? ||
         commit.deployed?
+    end
+
+    def should_delay_continuous_delivery?(commit)
+      commit.deploy_failed? ||
+        (checks? && !EphemeralCommitChecks.new(commit).run.success?) ||
+        commit.recently_pushed?
     end
   end
 end

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -152,8 +152,15 @@ module Shipit
     def trigger_continuous_delivery
       commit = next_commit_to_deploy
 
-      return continuous_delivery_resumed! if should_resume_continuous_delivery?(commit)
-      return continuous_delivery_delayed! if should_delay_continuous_delivery?(commit)
+      if should_resume_continuous_delivery?(commit)
+        continuous_delivery_resumed!
+        return
+      end
+
+      if should_delay_continuous_delivery?(commit)
+        continuous_delivery_delayed!
+        return
+      end
 
       begin
         trigger_deploy(commit, Shipit.user, env: cached_deploy_spec.default_deploy_env)

--- a/test/fixtures/shipit/commits.yml
+++ b/test/fixtures/shipit/commits.yml
@@ -373,3 +373,17 @@ task_no_commits:
   additions: 420
   deletions: 342
   updated_at: <%= 8.days.ago.to_s(:db) %>
+
+check_deploy_spec_first:
+  id: 701
+  sha: 547578b362bf2b4df5903e1c7960929361c3435a
+  message: "Removing deploy spec"
+  stack: check_deploy_spec
+  author: walrus
+  committer: walrus
+  authored_at: <%= 4.days.ago.to_s(:db) %>
+  committed_at: <%= 3.days.ago.to_s(:db) %>
+  additions: 420
+  deletions: 342
+  updated_at: <%= 8.days.ago.to_s(:db) %>
+  

--- a/test/fixtures/shipit/repositories.yml
+++ b/test/fixtures/shipit/repositories.yml
@@ -18,6 +18,10 @@ check_runs:
   owner: shopify
   name: check_runs
 
+check_deploy_spec:
+  owner: shopify
+  name: check_deploy_spec
+
 rails:
   owner: rails
   name: rails

--- a/test/fixtures/shipit/stacks.yml
+++ b/test/fixtures/shipit/stacks.yml
@@ -404,3 +404,16 @@ shipit_task_no_commits:
       }
     }
   updated_at: <%= 8.days.ago.to_s(:db) %>
+
+check_deploy_spec:
+  repository: check_deploy_spec
+  environment: production
+  branch: master
+  ignore_ci: true
+  merge_queue_enabled: true
+  tasks_count: 0
+  undeployed_commits_count: 1
+  continuous_deployment: true
+  cached_deploy_spec: "{}"
+  last_deployed_at: <%= 8.days.ago.to_s(:db) %>
+  updated_at: <%= 8.days.ago.to_s(:db) %>

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -555,11 +555,11 @@ module Shipit
 
     test "#trigger_continuous_delivery bails out if no DeploySpec has been cached" do
       @stack = shipit_stacks(:check_deploy_spec)
-      config = @stack.cached_deploy_spec.config
+      deploy_spec = @stack.cached_deploy_spec
 
       assert_predicate @stack, :deployable?
       refute_predicate @stack, :deployed_too_recently?
-      assert_empty(config, "DeploySpec was not empty")
+      assert(deploy_spec.config_empty?, "DeploySpec empty? returned false")
 
       assert_no_enqueued_jobs(only: Shipit::PerformTaskJob) do
         assert_no_difference -> { Deploy.count } do

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -559,7 +559,7 @@ module Shipit
 
       assert_predicate @stack, :deployable?
       refute_predicate @stack, :deployed_too_recently?
-      assert(deploy_spec.config_empty?, "DeploySpec empty? returned false")
+      assert(deploy_spec.blank?, "DeploySpec blank? returned false")
 
       assert_no_enqueued_jobs(only: Shipit::PerformTaskJob) do
         assert_no_difference -> { Deploy.count } do

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -483,7 +483,9 @@ module Shipit
 
       assert_no_enqueued_jobs do
         assert_no_difference -> { Deploy.count } do
-          @stack.trigger_continuous_delivery
+          value = @stack.trigger_continuous_delivery
+
+          assert_nil value
         end
       end
     end

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -551,6 +551,21 @@ module Shipit
       end
     end
 
+    test "#trigger_continuous_delivery bails out if no DeploySpec has been cached" do
+      @stack = shipit_stacks(:check_deploy_spec)
+      config = @stack.cached_deploy_spec.config
+
+      assert_predicate @stack, :deployable?
+      refute_predicate @stack, :deployed_too_recently?
+      assert_empty(config, "DeploySpec was not empty")
+
+      assert_no_enqueued_jobs(only: Shipit::PerformTaskJob) do
+        assert_no_difference -> { Deploy.count } do
+          @stack.trigger_continuous_delivery
+        end
+      end
+    end
+
     test "#trigger_continuous_delivery enqueues deployment ref update job" do
       @stack = shipit_stacks(:shipit_canaries)
       shipit_tasks(:canaries_running).delete


### PR DESCRIPTION
If a stack is provisioned with continuous delivery enabled, it's possible for the continuous delivery routine to run on the stack prior to the DeploySpec being cached. This occurs particularly when the git repo is large and slow to clone. This results in the _'max_commits'_ default value being used, and potentially the deployment of a very old commit being triggered. 

Here we have added a new pre-condition check to the _'trigger_continuous_delivery'_ method, along with some minor refactoring. We also added a nil check into _'test "#trigger_continuous_delivery bails out if the stack is deployable but was deployed too recently"'_ just to enforce the return type of  _'trigger_continuous_delivery'_, which was not tested before. 