### PR TITLE
Allows deployment's branding to be used in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,8 @@ Also, if your repository is deployed different ways depending on the environment
 
 For example for a stack like: `my-org/my-repo/staging`, `shipit.staging.yml` will have priority over `shipit.yml`.
 
+Lastly, if you override the `app_name` configuration in your Shipit deployment, `yourapp.yml` and `yourapp.staging.yml` will work.
+
 * * *
 
 <h3 id="installing-dependencies">Installing dependencies</h3>

--- a/app/models/shipit/deploy_spec/file_system.rb
+++ b/app/models/shipit/deploy_spec/file_system.rb
@@ -84,8 +84,14 @@ module Shipit
       end
 
       def load_config
-        read_config(file("shipit.#{@env}.yml", root: true)) ||
+        read_config(file("#{app_name}.#{@env}.yml", root: true)) ||
+          read_config(file("#{app_name}.yml", root: true)) ||
+          read_config(file("shipit.#{@env}.yml", root: true)) ||
           read_config(file('shipit.yml', root: true))
+      end
+
+      def app_name
+        @app_name ||= Shipit.app_name.downcase
       end
 
       def read_config(path)


### PR DESCRIPTION
If the downstream application is branded `foobar`, then load `foobar.yml` to find a deployment spec.