### PR TITLE
Browser tab disambiguation

### DIFF
--- a/app/views/layouts/shipit.html.erb
+++ b/app/views/layouts/shipit.html.erb
@@ -2,7 +2,7 @@
 <html lang="<%= I18n.locale %>" data-controller="<%= controller_name %>" data-action="<%= action_name %>">
 <head>
   <% if @stack %>
-    <title><%= Shipit.app_name %> - <%= @stack.repo_name %>/<%= @stack.environment %></title>
+    <title><%= @stack.repo_name %>/<%= @stack.environment %> - <%= Shipit.app_name %></title>
   <% else %>
   <title><%= Shipit.app_name %></title>
   <% end %>


### PR DESCRIPTION
Favicons tell you it's shipit. Browser tabs that all say "Shipit" are kinda useless.