### PR TITLE
Reload tasks when checking for concurrent execution

### DIFF
--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -378,7 +378,7 @@ module Shipit
     private
 
     def prevent_concurrency
-      raise ConcurrentTaskRunning if stack.tasks.active.exclusive.count > 1
+      raise ConcurrentTaskRunning if stack.tasks.reload.active.exclusive.count > 1
     end
 
     def status_key

--- a/test/models/deploys_test.rb
+++ b/test/models/deploys_test.rb
@@ -509,7 +509,7 @@ module Shipit
       deploy1.save
 
       deploy2 = create_test_deploy(stack_id: stack_id, user_id: user_id, since_commit_id: commit_ids[1], until_commit_id: commit_ids[2])
-      deploy2.type = "Shipit::Fake"
+      deploy2.type = "Shipit::Task"
       deploy2.save
 
       deploy3 = create_test_deploy(stack_id: stack_id, user_id: user_id, since_commit_id: commit_ids[2], until_commit_id: commit_ids[3])


### PR DESCRIPTION
At Shopify we're observing duplicate deploy tasks on stacks with continuous delivery enabled. Doing some debugging it seems we have 2 running instances of `ContinuousDeliveryJob`, and our theory is - similar to https://github.com/Shopify/shipit-engine/pull/1042#issuecomment-608118022 - the later task has a stale association, and so the `prevent_concurrency` fails. If that is the cause then reloading the association should fix the duplicate tasks. It's very difficult to replicate the conditions and know for sure though, and given this is a relatively benign change I'd like to ship and see.