### PR TITLE
Quiet clones for less scrolling

### DIFF
--- a/lib/shipit/task_commands.rb
+++ b/lib/shipit/task_commands.rb
@@ -52,6 +52,7 @@ module Shipit
       [
         git(
           'clone',
+          '--quiet',
           '--local',
           '--origin', 'cache',
           @stack.git_path,

--- a/test/unit/deploy_commands_test.rb
+++ b/test/unit/deploy_commands_test.rb
@@ -62,8 +62,8 @@ module Shipit
       commands = @commands.clone
       assert_equal 2, commands.size
       clone_args = [
-        'git', 'clone', '--local',
-        '--origin', 'cache',
+        'git', 'clone', '--quiet',
+        '--local', '--origin', 'cache',
         @stack.git_path, @deploy.working_directory
       ]
       assert_equal clone_args, commands.first.args


### PR DESCRIPTION
A git clone's progress output can be very lengthy, resulting in hiding the interesting deployment output below much scrolling. This is not useful unless the clone encountered an error.