### PR TITLE
Revert "Reload tasks when checking for concurrent execution"

### DIFF
--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -378,7 +378,7 @@ module Shipit
     private
 
     def prevent_concurrency
-      raise ConcurrentTaskRunning if stack.tasks.reload.active.exclusive.count > 1
+      raise ConcurrentTaskRunning if stack.tasks.active.exclusive.count > 1
     end
 
     def status_key

--- a/test/models/deploys_test.rb
+++ b/test/models/deploys_test.rb
@@ -509,7 +509,7 @@ module Shipit
       deploy1.save
 
       deploy2 = create_test_deploy(stack_id: stack_id, user_id: user_id, since_commit_id: commit_ids[1], until_commit_id: commit_ids[2])
-      deploy2.type = "Shipit::Task"
+      deploy2.type = "Shipit::Fake"
       deploy2.save
 
       deploy3 = create_test_deploy(stack_id: stack_id, user_id: user_id, since_commit_id: commit_ids[2], until_commit_id: commit_ids[3])


### PR DESCRIPTION
Reverts Shopify/shipit-engine#1061

We were wrong about the cause here, and the query is expensive so lets pull it out and try something else.