### PR TITLE
Store PR head ref sha when creating commits

### DIFF
--- a/app/models/shipit/commit.rb
+++ b/app/models/shipit/commit.rb
@@ -92,7 +92,7 @@ module Shipit
       committer = User.find_or_create_committer_from_github_commit(commit)
       committer ||= Anonymous.new
 
-      new(
+      record = new(
         sha: commit.sha,
         message: commit.commit.message,
         author:  author,
@@ -102,6 +102,12 @@ module Shipit
         additions: commit.stats&.additions,
         deletions: commit.stats&.deletions,
       )
+
+      if record.pull_request?
+        record.pull_request_head_sha = commit.parents.last.sha
+      end
+
+      record
     end
 
     def message=(message)

--- a/db/migrate/20200427135152_add_pull_request_head_sha_to_commit.rb
+++ b/db/migrate/20200427135152_add_pull_request_head_sha_to_commit.rb
@@ -1,0 +1,5 @@
+class AddPullRequestHeadShaToCommit < ActiveRecord::Migration[6.0]
+  def change
+    add_column :commits, :pull_request_head_sha, :string, limit: 40
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_02_26_211925) do
+ActiveRecord::Schema.define(version: 2020_04_27_135152) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text "permissions", limit: 65535
@@ -78,6 +78,7 @@ ActiveRecord::Schema.define(version: 2020_02_26_211925) do
     t.integer "pull_request_id"
     t.boolean "locked", default: false, null: false
     t.integer "lock_author_id", limit: 4
+    t.string "pull_request_head_sha", limit: 40
     t.index ["author_id"], name: "index_commits_on_author_id"
     t.index ["committer_id"], name: "index_commits_on_committer_id"
     t.index ["created_at"], name: "index_commits_on_created_at"

--- a/test/models/commits_test.rb
+++ b/test/models/commits_test.rb
@@ -96,6 +96,38 @@ module Shipit
       assert_equal shipit_users(:walrus), commit.author
     end
 
+    test '.create_from_github stores pull_request_head_sha' do
+      assert_difference -> { Commit.count }, +1 do
+        @stack.commits.create_from_github!(
+          resource(
+            sha: '2adaad1ad30c235d3a6e7981dfc1742f7ecb1e85',
+            author: {},
+            committer: {},
+            commit: {
+              author: {
+                name: 'Shipit',
+                email: '',
+                date: Time.now,
+              },
+              committer: {
+                name: 'Shipit',
+                email: '',
+                date: Time.now,
+              },
+              message: "Merge pull request #62 from shipit-engine/yoloshipit\n\nyoloshipit!",
+            },
+            parents: [
+              {sha: "1864542e3d2f8a41916a2dec0f2b4d3c1bf4899b", url: '', html_url: ''},
+              {sha: "63d7e03e517fd2ae1caeb1b7a9f21767f84d671a", url: '', html_url: ''},
+            ],
+          ),
+        )
+      end
+
+      commit = Commit.last
+      assert_equal '63d7e03e517fd2ae1caeb1b7a9f21767f84d671a', commit.pull_request_head_sha
+    end
+
     test "#message= truncates the message" do
       skip unless Shipit::Commit.columns_hash['message'].limit
       limit = Shipit::Commit.columns_hash['message'].limit


### PR DESCRIPTION
When creating `CommitDeployment`s we have to lookup the pull request head sha using the GitHub API:

https://github.com/Shopify/shipit-engine/blob/ae2ef38c72c6a88d952756b66da4746120ae5d10/app/models/shipit/deploy.rb#L250-L254

This means that, because this code is ran in an `after_create` callback, we are making these calls inside a database transaction, and this transaction is kept open for a long time. 

This PR is a first step to fixing this: we already store some pull request information on the commits table, and as we can infer the PR head sha from the commits API, we can store it when the record is created. I have 🎩ed this locally:

```
irb(main):003:0> Shipit::Commit.last.pull_request_head_sha
  Shipit::Commit Load (0.6ms)  SELECT `commits`.* FROM `commits` ORDER BY `commits`.`id` DESC LIMIT 1
=> "5b6a99494ddba625083e8ac79e4a88fd7100b928"
```

[This](https://github.com/dazworrall/junk/pull/25) was the test PR.