### PR TITLE
Don't query the GitHub API when creating PR CommitDeployments

### DIFF
--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -248,24 +248,12 @@ module Shipit
 
       # Create one for each pull request in the batch, to give feedback on the PR timeline
       commits.select(&:pull_request?).each do |commit|
-        if (pull_request_head = pull_request_head_for_commit(commit))
-          commit_deployments.create!(sha: pull_request_head)
-        end
+        next if commit.pull_request_head_sha.blank? # This attribute was not always populated
+        commit_deployments.create!(sha: commit.pull_request_head_sha)
       end
 
       # Immediately update to publish the status to the commit deployments
       update_commit_deployments
-    rescue Octokit::ClientError => error
-      Rails.logger.warn("Got #{error.class.name} (#{error.message}) when creating CommitDeployments for Deploy##{id}")
-    end
-
-    def pull_request_head_for_commit(commit)
-      pull_request = Shipit.github.api.pull_request(commit.stack.github_repo_name, commit.pull_request_number)
-      pull_request.head.sha
-    rescue Octokit::ClientError => error
-      pr_ref = "#{commit.stack.github_repo_name}##{commit.pull_request_number}"
-      Rails.logger.warn("Got #{error.class.name} (#{error.message}) when loading pull request #{pr_ref}")
-      nil
     end
 
     def update_release_status

--- a/test/fixtures/shipit/commits.yml
+++ b/test/fixtures/shipit/commits.yml
@@ -53,6 +53,7 @@ fourth:
   deletions: 342
   updated_at: <%= 8.days.ago.to_s(:db) %>
   created_at: <%= 1.day.ago.to_s(:db) %>
+  pull_request_head_sha: '6dcb09b5b57875f334f61aebed695e2e4193db5e'
 
 fifth:
   id: 5

--- a/test/models/deploys_test.rb
+++ b/test/models/deploys_test.rb
@@ -865,9 +865,6 @@ module Shipit
         until_commit: template_task.until_commit,
       )
 
-      pull_request_response = stub(head: stub(sha: '6dcb09b5b57875f334f61aebed695e2e4193db5e'))
-      Shipit.github.api.expects(:pull_request).with('shopify/shipit-engine', 7).returns(pull_request_response)
-
       expected_delta = deploy.commits.select(&:pull_request?).size + 1
       assert_difference -> { CommitDeployment.count }, expected_delta do
         assert_difference -> { CommitDeploymentStatus.count }, expected_delta do
@@ -876,25 +873,6 @@ module Shipit
       end
 
       refute_nil CommitDeployment.find_by(sha: '6dcb09b5b57875f334f61aebed695e2e4193db5e')
-      refute_nil CommitDeployment.find_by(sha: deploy.until_commit.sha)
-    end
-
-    test "#create_commit_deployments handles API errors when loading pull request details" do
-      template_task = shipit_tasks(:shipit_pending)
-      deploy = template_task.stack.deploys.build(
-        since_commit: template_task.since_commit,
-        until_commit: template_task.until_commit,
-      )
-
-      Shipit.github.api.expects(:pull_request).with('shopify/shipit-engine', 7).raises(Octokit::NotFound)
-
-      expected_delta = 1 # Only the batch head
-      assert_difference -> { CommitDeployment.count }, expected_delta do
-        assert_difference -> { CommitDeploymentStatus.count }, expected_delta do
-          deploy.save!
-        end
-      end
-
       refute_nil CommitDeployment.find_by(sha: deploy.until_commit.sha)
     end
 


### PR DESCRIPTION
As of #1064 we store this sha locally, so no need to fetch it. Currently these API requests are being made inside a DB transaction, and keeping it open way too long.