### PR TITLE
Normalise Stack#cached_deploy_spec in test env 

### DIFF
--- a/app/models/shipit/deploy_spec.rb
+++ b/app/models/shipit/deploy_spec.rb
@@ -6,19 +6,33 @@ module Shipit
     Error = Class.new(StandardError)
 
     class << self
+      attr_accessor :pretty_generate
+
       def load(json)
         config = json.blank? ? {} : JSON.parse(json)
         new(config)
       end
 
       def dump(spec)
-        JSON.dump(spec.cacheable.config) if spec
+        return unless spec
+
+        if pretty_generate?
+          JSON.pretty_generate(spec.cacheable.config)
+        else
+          JSON.dump(spec.cacheable.config)
+        end
       end
 
       def bundle_path
         Rails.root.join('data', 'bundler')
       end
+
+      def pretty_generate?
+        @pretty_generate
+      end
     end
+
+    self.pretty_generate = false
 
     def initialize(config)
       @config = config

--- a/test/dummy/config/environments/test.rb
+++ b/test/dummy/config/environments/test.rb
@@ -42,5 +42,7 @@ Rails.application.configure do
 
   config.to_prepare do
     Shipit::DeferredTouch.enabled = false
+    # The deploy specs in fixtures are pretty printed, we should do the same to avoid marking stacks as dirty
+    Shipit::DeploySpec.pretty_generate = true
   end
 end

--- a/test/fixtures/shipit/stacks.yml
+++ b/test/fixtures/shipit/stacks.yml
@@ -7,27 +7,70 @@ shipit:
   merge_queue_enabled: true
   tasks_count: 8
   undeployed_commits_count: 2
-  cached_deploy_spec: >
+  cached_deploy_spec: |-
     {
-      "machine": {"environment": {}},
+      "machine": {
+        "environment": {
+        }
+      },
       "review": {
-        "checklist": ["foo", "bar", "baz"],
+        "checklist": [
+          "foo",
+          "bar",
+          "baz"
+        ],
         "monitoring": [
-          {"image": "https://example.com/monitor.png", "width": 200, "height": 300}
+          {
+            "image": "https://example.com/monitor.png",
+            "width": 200,
+            "height": 300
+          }
         ]
       },
-      "dependencies": {"override": []},
-      "deploy": {"override": null, "interval": 60, "max_commits": 3, "variables": [{"name": "SAFETY_DISABLED", "title": "Set to 1 to do dangerous things", "default": 0}]},
-      "rollback": {"override": ["echo 'Rollback!'"]},
-      "fetch": ["echo '42'"],
+      "dependencies": {
+        "override": [
+
+        ]
+      },
+      "deploy": {
+        "override": null,
+        "interval": 60,
+        "max_commits": 3,
+        "variables": [
+          {
+            "name": "SAFETY_DISABLED",
+            "title": "Set to 1 to do dangerous things",
+            "default": 0
+          }
+        ]
+      },
+      "rollback": {
+        "override": [
+          "echo 'Rollback!'"
+        ]
+      },
+      "fetch": [
+        "echo '42'"
+      ],
       "tasks": {
         "restart": {
           "action": "Restart application",
           "description": "Restart app and job servers",
           "variables": [
-            {"name": "FOO", "title": "Set to 0 to foo", "default": 1},
-            {"name": "BAR", "title": "Set to 1 to bar", "default": 0},
-            {"name": "WALRUS", "title": "Walrus without a default value"}
+            {
+              "name": "FOO",
+              "title": "Set to 0 to foo",
+              "default": 1
+            },
+            {
+              "name": "BAR",
+              "title": "Set to 1 to bar",
+              "default": 0
+            },
+            {
+              "name": "WALRUS",
+              "title": "Walrus without a default value"
+            }
           ],
           "steps": [
             "cap $ENVIRONMENT deploy:restart"
@@ -46,8 +89,12 @@ shipit:
         "revalidate_after": 900
       },
       "ci": {
-        "hide": ["ci/hidden"],
-        "allow_failures": ["ci/ok_to_fail"]
+        "hide": [
+          "ci/hidden"
+        ],
+        "allow_failures": [
+          "ci/ok_to_fail"
+        ]
       }
     }
   last_deployed_at: <%= 8.days.ago.to_s(:db) %>

--- a/test/models/deploy_spec_test.rb
+++ b/test/models/deploy_spec_test.rb
@@ -1084,5 +1084,10 @@ module Shipit
       )
       assert_nil @spec.max_divergence_age
     end
+
+    test "serialised deploy specs are normalised" do
+      stack = shipit_stacks(:shipit)
+      assert_equal stack.cached_deploy_spec_before_type_cast, DeploySpec.dump(stack.cached_deploy_spec)
+    end
   end
 end

--- a/test/models/stacks_test.rb
+++ b/test/models/stacks_test.rb
@@ -390,7 +390,7 @@ module Shipit
 
     test "updating the stack emit a hook" do
       expect_hook(:stack, @stack, action: :updated, stack: @stack) do
-        @stack.update(repo_name: 'foo')
+        @stack.update(environment: 'foo')
       end
     end
 


### PR DESCRIPTION
I've broken this out from something else I'm working on:

```
(byebug) @stack.changed?
false
(byebug) @stack.cached_deploy_spec.blank?
false
(byebug) @stack.changed?
true
```

Right now every time we touch `cached_deploy_spec` in the tests the model instance gets marked as dirty - this is because  the serialised spec does not match exactly the literals we have in the fixture. This fixes that by:

* Supporting pretty generation on the serialiser
* Enabling it in the test env
* Normalising the fixture