### PR TITLE
Lock stack when creating a deploy

### DIFF
--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -142,8 +142,11 @@ module Shipit
 
     def trigger_deploy(*args, **kwargs)
       run_now = kwargs.delete(:run_now)
-      deploy = build_deploy(*args, **kwargs)
-      deploy.save!
+      deploy = with_lock do
+        deploy = build_deploy(*args, **kwargs)
+        deploy.save!
+        deploy
+      end
       run_now ? deploy.run_now! : deploy.enqueue
       continuous_delivery_resumed!
       deploy


### PR DESCRIPTION
~Requires #1068~

This I think is the final piece to properly close the multiple-auto-deploys problem - pessimistic locking to ensure that only one caller at a time can try to create a deploy. Since #1064 and #1065 the window for the race to happen is now very small, but something like this is required to properly close it.

Of course Stacks are loaded from the DB very regularly, so we need to be careful with locks. However as we only create deploys very infrequently, I don't expect this to cause a problem.