### PR TITLE
Truncate commit messages on creation.

### DIFF
--- a/app/models/shipit/commit.rb
+++ b/app/models/shipit/commit.rb
@@ -114,7 +114,7 @@ module Shipit
     def message=(message)
       limit = self.class.columns_hash['message'].limit
       if limit && message && message.size > limit
-        message = message.slice(0, limit)
+        message = message.truncate_bytes(limit)
       end
       super(message)
     end


### PR DESCRIPTION
I figured we should use the same logic for both the assignment truncation and the instantiation truncation.

Didn't know if we want `...` vs. slice truncation, but the slice is what we were doing before so I went with reusing the old logic. It also checks the field size first.