### PR TITLE
Work Continuous Delivery jobs as deploys

### DIFF
--- a/app/jobs/shipit/continuous_delivery_job.rb
+++ b/app/jobs/shipit/continuous_delivery_job.rb
@@ -3,7 +3,7 @@ module Shipit
   class ContinuousDeliveryJob < BackgroundJob
     include BackgroundJob::Unique
 
-    queue_as :default
+    queue_as :deploys
     on_duplicate :drop
 
     def perform(stack)


### PR DESCRIPTION
These jobs may run checks similarly to `PerformCommitChecksJob`, which may require any access to special resources which are granted to deployment jobs; for example, our case involves making a Docker daemon available to deployment jobs so deployment routines can be executed in containers, and we don't provision this or the resources necessary for it on the nodes which work other queues.