### PR TITLE
Do not use response if no data was returned from block

### DIFF
--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -377,6 +377,8 @@ module Shipit
       handle_github_redirections do
         Shipit.github.api.commits(github_repo_name, sha: branch)
       end
+    rescue Octokit::Conflict
+      [] # Repository is empty...
     end
 
     def handle_github_redirections

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -377,8 +377,6 @@ module Shipit
       handle_github_redirections do
         Shipit.github.api.commits(github_repo_name, sha: branch)
       end
-    rescue Octokit::Conflict
-      [] # Repository is empty...
     end
 
     def handle_github_redirections

--- a/lib/shipit/octokit_iterator.rb
+++ b/lib/shipit/octokit_iterator.rb
@@ -4,11 +4,10 @@ module Shipit
     include Enumerable
 
     def initialize(relation = nil)
-      if relation
-        @response = relation.get(per_page: 100)
+      @response = if relation
+        relation.get(per_page: 100)
       else
-        yield Shipit.github.api
-        @response = Shipit.github.api.last_response
+        yield
       end
     end
 

--- a/lib/shipit/octokit_iterator.rb
+++ b/lib/shipit/octokit_iterator.rb
@@ -7,16 +7,13 @@ module Shipit
       if relation
         @response = relation.get(per_page: 100)
       else
-        yield Shipit.github.api
-        @response = Shipit.github.api.last_response
+        data = yield Shipit.github.api
+        @response = Shipit.github.api.last_response if data.present?
       end
-    rescue Octokit::Conflict
-      # Repository is empty...
     end
 
     def each(&block)
       response = @response
-      return unless response
 
       loop do
         response.data.each(&block)

--- a/lib/shipit/octokit_iterator.rb
+++ b/lib/shipit/octokit_iterator.rb
@@ -4,15 +4,19 @@ module Shipit
     include Enumerable
 
     def initialize(relation = nil)
-      @response = if relation
-        relation.get(per_page: 100)
+      if relation
+        @response = relation.get(per_page: 100)
       else
-        yield
+        yield Shipit.github.api
+        @response = Shipit.github.api.last_response
       end
+    rescue Octokit::Conflict
+      # Repository is empty...
     end
 
     def each(&block)
       response = @response
+      return unless response
 
       loop do
         response.data.each(&block)

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -12,8 +12,8 @@ module Shipit
     end
 
     test ".find_or_create_by_handle fetch the team from github if it's not in the db already" do
-      Shipit.github.api.expects(:org_teams).with('shopify', per_page: 100)
       response = stub(rels: {}, data: [new_team])
+      Shipit.github.api.expects(:org_teams).with('shopify', per_page: 100).returns(response.data)
       Shipit.github.api.expects(:last_response).returns(response)
 
       assert_difference -> { Team.count }, 1 do

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -12,9 +12,9 @@ module Shipit
     end
 
     test ".find_or_create_by_handle fetch the team from github if it's not in the db already" do
-      Shipit.github.api.expects(:org_teams).with('shopify', per_page: 100)
       response = stub(rels: {}, data: [new_team])
-      Shipit.github.api.expects(:last_response).returns(response)
+      Shipit.github.api.expects(:org_teams).with('shopify', per_page: 100).returns(response)
+
       assert_difference -> { Team.count }, 1 do
         Team.find_or_create_by_handle('Shopify/new-team')
       end

--- a/test/models/team_test.rb
+++ b/test/models/team_test.rb
@@ -12,8 +12,9 @@ module Shipit
     end
 
     test ".find_or_create_by_handle fetch the team from github if it's not in the db already" do
+      Shipit.github.api.expects(:org_teams).with('shopify', per_page: 100)
       response = stub(rels: {}, data: [new_team])
-      Shipit.github.api.expects(:org_teams).with('shopify', per_page: 100).returns(response)
+      Shipit.github.api.expects(:last_response).returns(response)
 
       assert_difference -> { Team.count }, 1 do
         Team.find_or_create_by_handle('Shopify/new-team')


### PR DESCRIPTION
Internal shopify issue: https://github.com/Shopify/shipit/issues/1137

Inside of `GithubSyncJob`, I've noticed that it's possible for non-existant repos to end up with commits from other repos showing up on the Stack.

Upon investigation, it seems that it's possible for the `last_response` here to grab the response from a previous job on the sidekiq thread, since it seems the `last_response` variable is not being set in the case that a repo doesn't exist.

### Evidence

Exception handling on Shipit side:
https://github.com/Shopify/shipit-engine/blob/master/app/models/shipit/stack.rb#L380

Octokit raises the exception before the response makes it back to setting the `last_response` variable:
https://github.com/octokit/octokit.rb/blob/master/lib/octokit/response/raise_error.rb#L15

### The fix

Filter out the response from the iterator if no data was returned from the block.