### PR TITLE
Add dedicated view for tasks

### DIFF
--- a/app/controllers/shipit/stacks_controller.rb
+++ b/app/controllers/shipit/stacks_controller.rb
@@ -78,6 +78,11 @@ module Shipit
     def settings
     end
 
+    def tasks
+      @stack = Stack.from_param!(params[:id])
+      @tasks = @stack.tasks.where(type: nil).order(id: :desc).preload(:since_commit, :until_commit, :user).limit(10)
+    end
+
     def statistics
       previous_deploy_stats = Shipit::DeployStats.new(@stack.deploys.not_active.previous_seven_days)
       @deploy_stats = Shipit::DeployStats.new(@stack.deploys.not_active.last_seven_days)

--- a/app/views/shipit/stacks/_header.html.erb
+++ b/app/views/shipit/stacks/_header.html.erb
@@ -38,6 +38,9 @@
               <%= link_to "#{definition.action}…", new_stack_tasks_path(stack, definition_id: definition.id), class: "trigger-deploy" %>
             </li>
           <% end %>
+          <li class="nav__list__sub__item">
+            <%= link_to "All tasks", stack_tasks_list_path(stack), class: "trigger-deploy" %>
+          </li>
         </ul>
       </li>
     <% end %>

--- a/app/views/shipit/stacks/tasks.html.erb
+++ b/app/views/shipit/stacks/tasks.html.erb
@@ -1,0 +1,28 @@
+<% subscribe events_path(channels: ["stack.#{@stack.id}"]), '#layout-content' %>
+
+<%= render partial: 'shipit/stacks/header', locals: {stack: @stack} %>
+<%= render partial: 'shipit/stacks/banners', locals: {stack: @stack} %>
+
+<div class="wrapper">
+  <section>
+    <header class="section-header">
+      <h2>Available tasks</h2>
+    </header>
+    <ul class="task-list">
+      <% @stack.task_definitions.each do |definition| %>
+        <li class="task" id="task-<%= definition.id %>">
+          <%= link_to "#{definition.action}", new_stack_tasks_path(@stack, definition_id: definition.id), class: "trigger-deploy" %>
+        </li>
+      <% end %>
+    </ul>
+  </section>
+
+  <section>
+    <header class="section-header">
+      <h2>Previous Tasks</h2>
+    </header>
+    <ul class="commit-list">
+      <%= render @tasks %>
+    </ul>
+  </section>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -64,6 +64,7 @@ Shipit::Engine.routes.draw do
     patch '/' => 'stacks#update'
     delete '/' => 'stacks#destroy'
     get :settings, controller: :stacks
+    get :tasks, controller: :stacks, as: :tasks_list
     get :statistics, controller: :stacks
     post :refresh, controller: :stacks
     get :refresh, controller: :stacks # For easier design, sorry :/


### PR DESCRIPTION
We have new and different tooling providing views into the state of deploys and rollbacks, but tasks are currently out of scope for those new things. Shipit may be used more as a generic task executor while we are experimenting and transitioning our delpoy tooling, so this adds a dedicated task-only scoped view which could be used to help with that. Instead of commits it only lists available tasks, and the job history is also only tasks.

![Screen Recording 2020-06-10 at 14 55 40](https://user-images.githubusercontent.com/398706/84277352-494dcb80-ab2b-11ea-8cf6-5fc3445934be.gif)

Someone with some _actual_ frontend skills should make the new task area nicer I think!