### PR TITLE
Perform rollback after abort

### DIFF
--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -109,8 +109,8 @@ module Shipit
     end
 
     # Rolls the stack back to the most recent **previous** successful deploy
-    def trigger_revert(force: false)
-      previous_successful_commit = commit_to_rollback_to
+    def trigger_revert(force: false, rollback_to: nil)
+      previous_successful_commit = rollback_to&.until_commit || commit_to_rollback_to
 
       rollback = Rollback.create!(
         user_id: user_id,
@@ -282,7 +282,7 @@ module Shipit
     def trigger_revert_if_required
       return unless rollback_once_aborted?
       return unless supports_rollback?
-      trigger_revert
+      trigger_revert(rollback_to: rollback_once_aborted_to)
     end
 
     def default_since_commit_id

--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -23,6 +23,8 @@ module Shipit
     belongs_to :until_commit, class_name: 'Commit', required: false
     belongs_to :since_commit, class_name: 'Commit', required: false
 
+    belongs_to :rollback_once_aborted_to, class_name: 'Task', optional: true
+
     deferred_touch stack: :updated_at
 
     has_many :chunks, -> { order(:id) }, class_name: 'OutputChunk', dependent: :delete_all, inverse_of: :task
@@ -292,8 +294,12 @@ module Shipit
       end
     end
 
-    def abort!(rollback_once_aborted: false, aborted_by:)
-      update!(rollback_once_aborted: rollback_once_aborted, aborted_by_id: aborted_by.id)
+    def abort!(rollback_once_aborted: false, rollback_once_aborted_to: nil, aborted_by:)
+      update!(
+        rollback_once_aborted: rollback_once_aborted,
+        rollback_once_aborted_to: rollback_once_aborted_to,
+        aborted_by_id: aborted_by.id
+      )
 
       if alive?
         aborting

--- a/app/serializers/shipit/deploy_serializer.rb
+++ b/app/serializers/shipit/deploy_serializer.rb
@@ -5,7 +5,7 @@ module Shipit
 
     has_many :commits
 
-    attributes :compare_url, :rollback_url, :additions, :deletions
+    attributes :compare_url, :rollback_url, :additions, :deletions, :rollback_once_aborted_to
 
     def html_url
       stack_deploy_url(object.stack, object)

--- a/db/migrate/20200615181558_add_rollback_once_aborted_to.rb
+++ b/db/migrate/20200615181558_add_rollback_once_aborted_to.rb
@@ -1,0 +1,5 @@
+class AddRollbackOnceAbortedTo < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tasks, :rollback_once_aborted_to_id, :integer
+  end
+end

--- a/test/controllers/api/rollback_controller_test.rb
+++ b/test/controllers/api/rollback_controller_test.rb
@@ -106,7 +106,7 @@ module Shipit
         last_deploy.reload
         assert_response :accepted
         refute_predicate last_deploy, :active?
-        assert_json 'rollback_once_aborted_to.id', 4
+        assert_json 'rollback_once_aborted_to.until_commit_id', @commit.id
       end
     end
   end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_04_27_135152) do
+ActiveRecord::Schema.define(version: 2020_06_15_181558) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text "permissions", limit: 65535
@@ -261,6 +261,7 @@ ActiveRecord::Schema.define(version: 2020_04_27_135152) do
     t.datetime "ended_at"
     t.boolean "ignored_safeties", default: false, null: false
     t.integer "aborted_by_id"
+    t.integer "rollback_once_aborted_to_id"
     t.index ["rolled_up", "created_at", "status"], name: "index_tasks_on_rolled_up_and_created_at_and_status"
     t.index ["since_commit_id"], name: "index_tasks_on_since_commit_id"
     t.index ["stack_id", "allow_concurrency", "status"], name: "index_active_tasks"

--- a/test/models/deploys_test.rb
+++ b/test/models/deploys_test.rb
@@ -304,6 +304,20 @@ module Shipit
       end
     end
 
+    test "transitioning to aborted schedule a rollback to the designated deploy if set" do
+      @rollback_to = shipit_deploys(:shipit_pending)
+      @deploy = shipit_deploys(:shipit_running)
+      @deploy.ping
+      @deploy.pid = 42
+      @deploy.abort!(rollback_once_aborted: true, rollback_once_aborted_to: @rollback_to, aborted_by: @user)
+
+      assert_difference -> { @stack.rollbacks.count }, 1 do
+        assert_enqueued_with(job: PerformTaskJob) do
+          @deploy.aborted!
+        end
+      end
+    end
+
     test "#build_rollback returns an unsaved record" do
       assert @deploy.build_rollback.new_record?
     end
@@ -430,6 +444,20 @@ module Shipit
       assert_equal commit3, test_stack.last_deployed_commit
       assert_equal commit3, last_deploy.until_commit
       assert_equal "Shipit::Rollback", last_deploy.type
+    end
+
+    test "#trigger_revert uses rollback_to if set" do
+      test_stack = create_test_stack
+      test_stack.save
+      test_stack.reload
+
+      running_deploy = shipit_deploys(:shipit_running)
+      rollback_to = shipit_deploys(:shipit_pending)
+
+      final_rollback = running_deploy.trigger_revert(rollback_to: rollback_to)
+
+      assert_equal "Shipit::Rollback", final_rollback.type
+      assert_equal 4, final_rollback.until_commit_id
     end
 
     test "#trigger_revert skips unsuccessful deploys when reverting" do


### PR DESCRIPTION
@DazWorrall Mentioned that the current strategy won't work since it takes time for the abort to take place. 

This change will use mechanism for triggering revert after abort to trigger a rollback to
a specific deploy, by saving the targeted deploy. 

