### PR TITLE
Adapt merge status to new GitHub UI

### DIFF
--- a/app/assets/stylesheets/merge_status.scss
+++ b/app/assets/stylesheets/merge_status.scss
@@ -1,3 +1,0 @@
-.merge-status-container {
-  max-width: 700px;
-}


### PR DESCRIPTION
Github changed the width of their page which is why the "Add to merge queue" button looks out of place now. I removed the max-width constraint as this gave me the right results when playing around in the chrome web inspector.

Before:
<img width="859" alt="Screenshot 2020-06-29 08 50 25" src="https://user-images.githubusercontent.com/100357/86007582-9bc13000-b9e5-11ea-8c50-b7dc8fa6cf54.png">

After:

<img width="901" alt="Screenshot 2020-06-29 08 51 26" src="https://user-images.githubusercontent.com/100357/86007671-ba272b80-b9e5-11ea-915e-072a88d8eead.png">

Would be great if somebody could 🎩 this.