### PR TITLE
Remove capitilisation from ShipIt repo listing

### DIFF
--- a/app/assets/stylesheets/_pages/_stacks.scss
+++ b/app/assets/stylesheets/_pages/_stacks.scss
@@ -93,9 +93,6 @@
 
 .commits-path {
   font-size: 18px;
-  span {
-    text-transform: capitalize;
-  }
   small {
     font-size: 18px;
     color: #8D9EB0;


### PR DESCRIPTION
The list looks a bit odd capitalising the GitHub repositories. This removes this capitlisation.

Before:
![Screen Shot 2020-07-07 at 7 18 41 PM](https://user-images.githubusercontent.com/19199063/86854601-b438e680-c086-11ea-885e-a532ce79184e.png)

After:
![Screen Shot 2020-07-07 at 7 18 34 PM](https://user-images.githubusercontent.com/19199063/86854594-b00cc900-c086-11ea-8937-d6ddaa427859.png)

