### PR TITLE
Expose serialization issue with a test

### DIFF
--- a/test/unit/commit_serializer_test.rb
+++ b/test/unit/commit_serializer_test.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module Shipit
+  class DeploySerializerTest < ActiveSupport::TestCase
+    test 'commit includes author object' do
+      commit = shipit_commits(:first)
+
+      serializer = ActiveModel::Serializer.serializer_for(commit)
+      assert_equal CommitSerializer, serializer
+      serialized = serializer.new(commit).to_json
+
+      assert_json("author.name", commit.author.name, document: serialized)
+    end
+  end
+end

--- a/test/unit/commit_serializer_test.rb
+++ b/test/unit/commit_serializer_test.rb
@@ -2,7 +2,7 @@
 require 'test_helper'
 
 module Shipit
-  class DeploySerializerTest < ActiveSupport::TestCase
+  class CommitSerializerTest < ActiveSupport::TestCase
     test 'commit includes author object' do
       commit = shipit_commits(:first)
 

--- a/test/unit/deploy_serializer_test.rb
+++ b/test/unit/deploy_serializer_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module Shipit
+  class DeploySerializerTest < ActiveSupport::TestCase
+    test 'includes author object' do
+      deploy = shipit_deploys(:shipit)
+      first_commit_author = deploy.commits.first.author
+
+      serializer = ActiveModel::Serializer.serializer_for(deploy)
+      assert_equal DeploySerializer, serializer
+      serialized = serializer.new(deploy).to_json
+
+      assert_json("commits.0.author.name", first_commit_author.name, document: serialized)
+    end
+  end
+end

--- a/test/unit/deploy_serializer_test.rb
+++ b/test/unit/deploy_serializer_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 
 module Shipit
   class DeploySerializerTest < ActiveSupport::TestCase
-    test 'includes author object' do
+    test 'deploy commits includes author object' do
       deploy = shipit_deploys(:shipit)
       first_commit_author = deploy.commits.first.author
 


### PR DESCRIPTION
It seems ruby 2.6.6 and 2.7.1 patch versions have broken the deploy object serialization. We have our IM system listening to deploy events and notifying users and rooms of the status of their deployments. The deploy payload used to have the entire `author` in the `commits` that were deployed. While using these 2 versions the author object is now replaced by only the `author_id` and this broke our integration.

While doing some investigation we found out [this change](https://www.ruby-lang.org/en/news/2020/03/19/json-dos-cve-2020-10663/) was the patch applied that generated both versions we have problems with and coincidentally they are related to JSON serialization.

For this PR I just wrote a simple tests so we could expose the issue. The idea is to see if anyone else have run into this problem and also look from guidance from the main maintainers.

