### PR TITLE
Serialize rollback once aborted to value

### DIFF
--- a/app/serializers/shipit/deploy_serializer.rb
+++ b/app/serializers/shipit/deploy_serializer.rb
@@ -22,5 +22,11 @@ module Shipit
     def type
       :deploy
     end
+
+    def rollback_once_aborted_to
+      return nil unless object.rollback_once_aborted_to
+
+      DeploySerializer.new(object.rollback_once_aborted_to)
+    end
   end
 end

--- a/test/controllers/api/rollback_controller_test.rb
+++ b/test/controllers/api/rollback_controller_test.rb
@@ -106,7 +106,7 @@ module Shipit
         last_deploy.reload
         assert_response :accepted
         refute_predicate last_deploy, :active?
-        assert_json 'rollback_once_aborted_to.until_commit_id', @commit.id
+        assert_json 'rollback_once_aborted_to.revision.sha', @commit.sha
       end
     end
   end


### PR DESCRIPTION
I realized since this was not being serialized properly, we were taking the raw contents of the object which included fields like gzip_output, which will fail to encode.

This change ensures that we go through the serializer, which will omit fields such as that. 