### PR TITLE
Add skipped as a valid check run conclusion

### DIFF
--- a/app/models/shipit/check_run.rb
+++ b/app/models/shipit/check_run.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 module Shipit
   class CheckRun < ApplicationRecord
-    CONCLUSIONS = %w(success failure neutral cancelled timed_out action_required stale).freeze
+    CONCLUSIONS = %w(success failure neutral cancelled timed_out action_required stale skipped).freeze
     include DeferredTouch
     include Status::Common
 
@@ -44,7 +44,7 @@ module Shipit
       case conclusion
       when nil, 'action_required'
         'pending'
-      when 'success', 'neutral'
+      when 'success', 'neutral', 'skipped'
         'success'
       when 'failure', 'cancelled', 'stale'
         'failure'


### PR DESCRIPTION
Similar to https://github.com/Shopify/shipit-engine/pull/1043, we're seeing exceptions in the wild because a new conclusion has been added - [skipped](https://developer.github.com/changes/2020-05-08-skipped-conclusion/):

> If a check run or suite is never started, you'll see the `skipped` conclusion. This is a common check run conclusion for GitHub Actions that have a job using an `if` condition.

As skipped means _intentionally_ not ran, I think we should treat is as a success state for the purposes of shipping.