### PR TITLE
Use bytesize for commit message string truncation.

### DIFF
--- a/app/models/shipit/commit.rb
+++ b/app/models/shipit/commit.rb
@@ -113,7 +113,7 @@ module Shipit
 
     def message=(message)
       limit = self.class.columns_hash['message'].limit
-      if limit && message && message.size > limit
+      if limit && message && message.bytesize > limit
         message = message.truncate_bytes(limit)
       end
       super(message)

--- a/test/models/commits_test.rb
+++ b/test/models/commits_test.rb
@@ -170,6 +170,15 @@ module Shipit
       assert_equal limit, @commit.message.bytesize
     end
 
+    test "#message= truncates multibyte messages" do
+      skip unless Shipit::Commit.columns_hash['message'].limit
+      limit = Shipit::Commit.columns_hash['message'].limit
+
+      @commit.update!(message: '国' * limit)
+      assert_operator @commit.message.length, :<=, limit
+      assert_operator @commit.message.bytesize, :<=, limit
+    end
+
     test "#pull_request? detect pull request based on message format" do
       assert @pr.pull_request?
       refute @commit.pull_request?


### PR DESCRIPTION
I noticed that we were using size instead of bytesize when truncating strings, which may fail if we run into a commit message containing multibyte chars.

I figure it's worth guarding against this.