### PR TITLE
Remove ReviewStacks awaiting provision from queue when archiving

### DIFF
--- a/app/models/shipit/review_stack.rb
+++ b/app/models/shipit/review_stack.rb
@@ -87,10 +87,12 @@ module Shipit
     end
 
     def enqueue_for_provisioning
+      return if awaiting_provision
       update!(awaiting_provision: true)
     end
 
     def remove_from_provisioning_queue
+      return unless awaiting_provision
       update!(awaiting_provision: false)
     end
 

--- a/app/models/shipit/webhooks/handlers/pull_request/review_stack_adapter.rb
+++ b/app/models/shipit/webhooks/handlers/pull_request/review_stack_adapter.rb
@@ -29,7 +29,7 @@ module Shipit
             end
             return if stack.archived?
 
-            stack.remove_from_provisioning_queue if stack.awaiting_provision
+            stack.remove_from_provisioning_queue
             stack.deprovision
             stack.archive!(user, *args, &block)
           end

--- a/app/models/shipit/webhooks/handlers/pull_request/review_stack_adapter.rb
+++ b/app/models/shipit/webhooks/handlers/pull_request/review_stack_adapter.rb
@@ -29,6 +29,7 @@ module Shipit
             end
             return if stack.archived?
 
+            stack.remove_from_provisioning_queue if stack.awaiting_provision
             stack.deprovision
             stack.archive!(user, *args, &block)
           end


### PR DESCRIPTION
Why
===

When a `ReviewStack` is created and queued for provisioning, it's
possible that the Pull Request is closed or its labels are adjusted in
such a way that the `ReviewStack` is considered "Archived" before the
`ReviewStackProvisioningQueue#work` method has a chance to process
queue. In these rare cases, we want to remove the `ReviewStack` from
the provisioning queue. While leaving the `ReviewStack` in the
`ReviewStackProvisioningQueue` doesn't cause major misbehavior of the
system, it does leave the data in a somewhat confusing state and can
unnecessarily grow the amount of `ReviewStack`s the
`ReviewStackProvisioningQueue` must process on each invocation of
`#work`.