### PR TITLE
Allow variance in task execution strategy

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -38,7 +38,7 @@ Naming/PredicateName:
 
 Lint/RescueException:
   Exclude:
-    - app/jobs/shipit/perform_task_job.rb
+    - app/models/shipit/task_execution_strategy/default.rb
 
 Lint/SuppressedException:
   Enabled: false

--- a/app/jobs/shipit/perform_task_job.rb
+++ b/app/jobs/shipit/perform_task_job.rb
@@ -4,104 +4,10 @@ module Shipit
     queue_as :deploys
 
     def perform(task)
-      @task = task
-      @commands = Commands.for(@task)
-      unless @task.pending?
-        logger.error("Task ##{@task.id} already in `#{@task.status}` state. Aborting.")
-        return
-      end
-      run
-    ensure
-      @commands.clear_working_directory
-    end
-
-    def run
-      @task.ping
-      @task.run!
-      checkout_repository
-      perform_task
-      @task.write("\nCompleted successfully\n")
-      @task.report_complete!
-    rescue Command::TimedOut => error
-      @task.write("\n#{error.message}\n")
-      @task.report_timeout!(error)
-    rescue Command::Error => error
-      @task.write("\n#{error.message}\n")
-      @task.report_failure!(error)
-    rescue StandardError => error
-      @task.report_error!(error)
-    rescue Exception => error
-      @task.report_error!(error)
-      raise
-    end
-
-    def abort!(signal: 'TERM')
-      pid = @task.pid
-      if pid
-        @task.write("$ kill #{pid}\n")
-        Process.kill(signal, pid)
-      else
-        @task.write("Can't abort, no recorded pid, WTF?\n")
-      end
-    rescue SystemCallError => error
-      @task.write("kill: (#{pid}) - #{error.message}\n")
-    end
-
-    def check_for_abort
-      @task.should_abort? do |times_killed|
-        if times_killed > 3
-          abort!(signal: 'KILL')
-        else
-          abort!
-        end
-      end
-    end
-
-    def perform_task
-      capture_all!(@commands.install_dependencies)
-      capture_all!(@commands.perform)
-    end
-
-    def checkout_repository
-      unless @commands.fetched?(@task.until_commit).tap(&:run).success?
-        # acquire_git_cache_lock can take upto 15 seconds
-        # to process. Try to make sure that the job isn't
-        # marked dead while we attempt to acquire the lock.
-        @task.ping
-        @task.acquire_git_cache_lock do
-          @task.ping
-          unless @commands.fetched?(@task.until_commit).tap(&:run).success?
-            capture!(@commands.fetch)
-          end
-        end
-      end
-      capture_all!(@commands.clone)
-      capture!(@commands.checkout(@task.until_commit))
-    end
-
-    def capture_all!(commands)
-      commands.map { |c| capture!(c) }
-    end
-
-    def capture!(command)
-      command.start do
-        @task.ping
-        check_for_abort
-      end
-      @task.write("$ #{command}\npid: #{command.pid}\n")
-      @task.pid = command.pid
-      command.stream! do |line|
-        @task.write(line)
-      end
-      @task.write("\n")
-      command.success?
-    end
-
-    def capture(command)
-      capture!(command)
-      command.success?
-    rescue Command::Error
-      false
+      Shipit
+        .task_execution_strategy
+        .new(task)
+        .execute
     end
   end
 end

--- a/app/models/shipit/task_execution_strategy/base.rb
+++ b/app/models/shipit/task_execution_strategy/base.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+module Shipit
+  module TaskExecutionStrategy
+    class Base
+      def initialize(task)
+        self.task = task
+      end
+
+      def execute
+        raise(
+          NotImplmentedError,
+          "subclasses of TaskExectuionStrategy::Base must implement the #execute method"
+        )
+      end
+
+      attr_accessor :task
+    end
+  end
+end

--- a/app/models/shipit/task_execution_strategy/default.rb
+++ b/app/models/shipit/task_execution_strategy/default.rb
@@ -1,0 +1,110 @@
+# frozen_string_literal: true
+
+module Shipit
+  module TaskExecutionStrategy
+    class Default < Base
+      def execute
+        @commands = Commands.for(@task)
+        unless @task.pending?
+          Rails.logger.error("Task ##{@task.id} already in `#{@task.status}` state. Aborting.")
+          return
+        end
+        run
+      ensure
+        @commands.clear_working_directory
+      end
+
+      def run
+        @task.ping
+        @task.run!
+        checkout_repository
+        perform_task
+        @task.write("\nCompleted successfully\n")
+        @task.report_complete!
+      rescue Command::TimedOut => error
+        @task.write("\n#{error.message}\n")
+        @task.report_timeout!(error)
+      rescue Command::Error => error
+        @task.write("\n#{error.message}\n")
+        @task.report_failure!(error)
+      rescue StandardError => error
+        @task.report_error!(error)
+      rescue Exception => error
+        @task.report_error!(error)
+        raise
+      end
+
+      def abort!(signal: 'TERM')
+        pid = @task.pid
+        if pid
+          @task.write("$ kill #{pid}\n")
+          Process.kill(signal, pid)
+        else
+          @task.write("Can't abort, no recorded pid, WTF?\n")
+        end
+      rescue SystemCallError => error
+        @task.write("kill: (#{pid}) - #{error.message}\n")
+      end
+
+      def check_for_abort
+        @task.should_abort? do |times_killed|
+          if times_killed > 3
+            abort!(signal: 'KILL')
+          else
+            abort!
+          end
+        end
+      end
+
+      def perform_task
+        capture_all!(@commands.install_dependencies)
+        capture_all!(@commands.perform)
+      end
+
+      def checkout_repository
+        unless @commands.fetched?(@task.until_commit).tap(&:run).success?
+          # acquire_git_cache_lock can take upto 15 seconds
+          # to process. Try to make sure that the job isn't
+          # marked dead while we attempt to acquire the lock.
+          @task.ping
+          @task.acquire_git_cache_lock do
+            @task.ping
+            unless @commands.fetched?(@task.until_commit).tap(&:run).success?
+              capture!(@commands.fetch)
+            end
+          end
+        end
+        capture_all!(@commands.clone)
+        capture!(@commands.checkout(@task.until_commit))
+      end
+
+      def capture_all!(commands)
+        commands.map { |c| capture!(c) }
+      end
+
+      def capture!(command)
+        started_at = Time.now
+        command.start do
+          @task.ping
+          check_for_abort
+        end
+        @task.write("$ #{command}\npid: #{command.pid}\nstarted at: #{started_at}\n")
+        @task.pid = command.pid
+        command.stream! do |line|
+          @task.write(line)
+        end
+        @task.write("\n")
+        finished_at = Time.now
+        @task.write("pid: #{command.pid}\nfinished at: #{finished_at}\nran in: #{finished_at - started_at} seconds\n")
+        command.success?
+      end
+
+      def capture(command)
+        capture!(command)
+        command.success?
+      rescue Command::Error
+        false
+      end
+    end
+  end
+end

--- a/docs/task_execution_strategy.md
+++ b/docs/task_execution_strategy.md
@@ -1,0 +1,40 @@
+# Task execution strategies
+
+# Default
+
+For most applications, the default execution strategy is sufficient. This strategy processes a task within the context of a shipit-engine Sidekiq worker. shipit-engine provides the `Shipit::TaskExecutionStrategy::Default` strategy to do this - on a vanilla shipit-engine instance _this_ is the default execution strategy.
+
+# Custom task execution strategies
+
+## Registering a custom TaskExecutionStrategy
+
+1. Create a custom TaskExecutionStrategy by extending `Shipit::TaskExecutionStrategy::Base` and implementing the `#execute` method. The `Shipit::Task` to be processed is available as the `task` local - courtesy of the inherited `Shipit::TaskExecutionStrategy::Base#initialize` method:
+    ```ruby
+    class KubernetesPodExecutionStrategy < Shipit::TaskExecutionStrategy::Base
+      def execute
+        # Example: apply kubernetes templates to create a pod in which the job should
+        # be executed passing along the task to be executed
+        #
+        # Consider running a Kubernetes Pod of the host-application's image
+        # whose command - in turn - runs a rake task invoking the
+        # Shipit::TaskExecutionStrategy::Default stratgy on the task.
+        #
+        # Pseudo code below:
+        kube.apply(task_execution_pod_template)
+      end
+
+      def task_execution_pod_template
+        <<~YAML
+        ...
+          command: [ "bin/rails" ]
+          args: [ "shipit:task:run[#{task.id}]" ]
+        ...
+        YAML
+      end
+    end
+    ```
+2. Register the custom strategy. For example, the following uses the above `KubernetesPodExecutionStrategy`
+    ```ruby
+    # probably in the host application's shipit initializer
+    Shipit.task_execution_strategy = KubernetesPodExecutionStrategy
+    ```

--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -63,7 +63,16 @@ module Shipit
   delegate :table_name_prefix, to: :secrets
 
   attr_accessor :disable_api_authentication, :timeout_exit_codes
-  attr_writer :internal_hook_receivers, :task_logger, :preferred_org_emails
+  attr_writer(
+    :internal_hook_receivers,
+    :preferred_org_emails,
+    :task_execution_strategy,
+    :task_logger,
+  )
+
+  def task_execution_strategy
+    @task_execution_strategy ||= Shipit::TaskExecutionStrategy::Default
+  end
 
   self.timeout_exit_codes = [].freeze
 

--- a/test/jobs/perform_task_job_test.rb
+++ b/test/jobs/perform_task_job_test.rb
@@ -19,8 +19,8 @@ module Shipit
     end
 
     test "#perform fetch commits from the API" do
-      @job.stubs(:capture!)
-      @job.stubs(:capture)
+      Shipit::TaskExecutionStrategy::Default.any_instance.stubs(:capture!)
+      Shipit::TaskExecutionStrategy::Default.any_instance.stubs(:capture)
       @commands = stub
       Commands.expects(:for).with(@deploy).returns(@commands)
 
@@ -39,7 +39,7 @@ module Shipit
       @deploy.stack.expects(:release_status?).at_least_once.returns(false)
       Dir.stubs(:chdir).yields
       DeployCommands.any_instance.expects(:perform).returns([])
-      @job.stubs(:capture!)
+      Shipit::TaskExecutionStrategy::Default.any_instance.stubs(:capture!)
 
       assert_enqueued_with(job: FetchDeployedRevisionJob, args: [@deploy.stack]) do
         @job.perform(@deploy)
@@ -50,7 +50,7 @@ module Shipit
       @deploy.stack.expects(:release_status?).at_least_once.returns(false)
       Dir.stubs(:chdir).yields
       DeployCommands.any_instance.expects(:perform).returns([])
-      @job.stubs(:capture!)
+      Shipit::TaskExecutionStrategy::Default.any_instance.stubs(:capture!)
 
       assert_equal 'pending', @deploy.status
       @job.perform(@deploy)
@@ -63,7 +63,7 @@ module Shipit
 
       Dir.stubs(:chdir).yields
       DeployCommands.any_instance.expects(:perform).returns([])
-      @job.stubs(:capture!)
+      Shipit::TaskExecutionStrategy::Default.any_instance.stubs(:capture!)
 
       assert_equal 'pending', @deploy.status
       @job.perform(@deploy)
@@ -77,7 +77,7 @@ module Shipit
 
       Dir.stubs(:chdir).yields
       DeployCommands.any_instance.expects(:perform).returns([])
-      @job.stubs(:capture!)
+      Shipit::TaskExecutionStrategy::Default.any_instance.stubs(:capture!)
 
       assert_equal 'pending', @deploy.status
       @job.perform(@deploy)
@@ -85,7 +85,7 @@ module Shipit
     end
 
     test "marks deploy as `error` if any application error is raised" do
-      @job.expects(:capture!).raises("some error")
+      Shipit::TaskExecutionStrategy::Default.any_instance.expects(:capture!).raises("some error")
       assert_nothing_raised do
         @job.perform(@deploy)
       end
@@ -94,7 +94,7 @@ module Shipit
     end
 
     test "marks deploy as `failed` if a command exit with an error code" do
-      @job.expects(:capture!).at_least_once.raises(Command::Error.new('something'))
+      Shipit::TaskExecutionStrategy::Default.any_instance.expects(:capture!).at_least_once.raises(Command::Error.new('something'))
       @job.perform(@deploy)
       assert_equal 'failed', @deploy.reload.status
     end

--- a/test/unit/shipit_task_execution_strategy_test.rb
+++ b/test/unit/shipit_task_execution_strategy_test.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+require 'test_helper'
+
+module Shipit
+  class ShipitTaskExecutionStrategyTest < ActiveSupport::TestCase
+    setup do
+      class FakeExecutionStrategy < Shipit::TaskExecutionStrategy::Base
+        def execute; end
+      end
+    end
+
+    teardown do
+      Shipit.task_execution_strategy = nil
+
+      Object.send(:remove_const, :FakeExecutionStrategy) if Object.const_defined?(:FakeExecutionStrategy)
+    end
+
+    test "uses the default strategy" do
+      Shipit.task_execution_strategy = nil
+
+      assert_equal Shipit::TaskExecutionStrategy::Default, Shipit.task_execution_strategy
+    end
+
+    test "allows registration of an execution strategy" do
+      strategy = FakeExecutionStrategy
+
+      Shipit.task_execution_strategy = strategy
+
+      assert_equal(
+        strategy,
+        Shipit.task_execution_strategy
+      )
+    end
+
+    test "the registered execution strategy is invoked during execution of a task" do
+      task_type = Shipit::Deploy
+      task = task_type.new
+      strategy = FakeExecutionStrategy
+      strategy.any_instance.expects(:execute)
+
+      Shipit.task_execution_strategy = strategy
+
+      Shipit::PerformTaskJob.new.perform(task)
+    end
+  end
+end


### PR DESCRIPTION
Why
===

The host application _may_ want more control over how work is scheduled and executed given the topology / capabilities of its environment. 

An example, _we_ deploy our host application into a Kubernetes cluster. We'd like the ability to schedule Shipit::Deploy tasks to run in their own pod, rather than relying on a processing the Shipit::Deploy task inside the context of the Sidekiq worker container - which _may_ be processing other jobs, like Sidekiq health checks, etc.

How
===

This change set extracts the current task execution logic into a "Default Execution Strategy" - a vanilla instance of shipit-engine should NOT be affected by this change. We also expose an interface whereby the host application _may_ register a custom "execution strategy" for a given task type - overriding the default. The `PerformTaskJob` looks-up the strategy to use for a given task, then executes the task using the appropriate execution strategy.
