### PR TITLE
Retry tasks (deploys) that timeout

### DIFF
--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -92,6 +92,7 @@ module Shipit
         env: env&.to_h || {},
         allow_concurrency: force,
         ignored_safeties: force,
+        max_retries: stack.cached_deploy_spec.retries_on_rollback_timeout,
       )
     end
 

--- a/app/models/shipit/deploy_spec.rb
+++ b/app/models/shipit/deploy_spec.rb
@@ -126,6 +126,10 @@ module Shipit
       deploy_variables.map { |v| [v.name, v.default] }.to_h
     end
 
+    def retries_on_deploy_timeout
+      config('deploy', 'retries_on_timeout') { 3 }
+    end
+
     def rollback_steps
       around_steps('rollback') do
         config('rollback', 'override') { discover_rollback_steps }
@@ -134,6 +138,10 @@ module Shipit
 
     def rollback_steps!
       rollback_steps || cant_detect!(:rollback)
+    end
+
+    def retries_on_rollback_timeout
+      config('rollback', 'retries_on_timeout') { 3 }
     end
 
     def fetch_deployed_revision_steps

--- a/app/models/shipit/deploy_spec.rb
+++ b/app/models/shipit/deploy_spec.rb
@@ -127,7 +127,7 @@ module Shipit
     end
 
     def retries_on_deploy_timeout
-      config('deploy', 'retries_on_timeout') { 3 }
+      config('deploy', 'retries_on_timeout') { nil }
     end
 
     def rollback_steps
@@ -141,7 +141,7 @@ module Shipit
     end
 
     def retries_on_rollback_timeout
-      config('rollback', 'retries_on_timeout') { 3 }
+      config('rollback', 'retries_on_timeout') { nil }
     end
 
     def fetch_deployed_revision_steps

--- a/app/models/shipit/deploy_spec/file_system.rb
+++ b/app/models/shipit/deploy_spec/file_system.rb
@@ -72,7 +72,7 @@ module Shipit
             'interval' => pause_between_deploys,
             'retries_on_timeout' => retries_on_deploy_timeout,
           },
-          'rollback' => { 
+          'rollback' => {
             'override' => rollback_steps,
             'retries_on_timeout' => retries_on_rollback_timeout,
           },

--- a/app/models/shipit/deploy_spec/file_system.rb
+++ b/app/models/shipit/deploy_spec/file_system.rb
@@ -70,8 +70,12 @@ module Shipit
             'variables' => deploy_variables.map(&:to_h),
             'max_commits' => maximum_commits_per_deploy,
             'interval' => pause_between_deploys,
+            'retries_on_timeout' => retries_on_deploy_timeout,
           },
-          'rollback' => { 'override' => rollback_steps },
+          'rollback' => { 
+            'override' => rollback_steps,
+            'retries_on_timeout' => retries_on_rollback_timeout,
+          },
           'fetch' => fetch_deployed_revision_steps,
           'tasks' => cacheable_tasks,
         )

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -151,6 +151,7 @@ module Shipit
         env: filter_deploy_envs(env&.to_h || {}),
         allow_concurrency: force,
         ignored_safeties: force || !until_commit.deployable?,
+        max_retries: retries_on_deploy_timeout,
       )
     end
 
@@ -487,7 +488,8 @@ module Shipit
 
     delegate :plugins, :task_definitions, :hidden_statuses, :required_statuses, :soft_failing_statuses,
              :blocking_statuses, :deploy_variables, :filter_task_envs, :filter_deploy_envs,
-             :maximum_commits_per_deploy, :pause_between_deploys, to: :cached_deploy_spec
+             :maximum_commits_per_deploy, :pause_between_deploys, :retries_on_deploy_timeout, 
+             :retries_on_rollback_timeout, to: :cached_deploy_spec
 
     def monitoring?
       monitoring.present?

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -488,7 +488,7 @@ module Shipit
 
     delegate :plugins, :task_definitions, :hidden_statuses, :required_statuses, :soft_failing_statuses,
              :blocking_statuses, :deploy_variables, :filter_task_envs, :filter_deploy_envs,
-             :maximum_commits_per_deploy, :pause_between_deploys, :retries_on_deploy_timeout, 
+             :maximum_commits_per_deploy, :pause_between_deploys, :retries_on_deploy_timeout,
              :retries_on_rollback_timeout, to: :cached_deploy_spec
 
     def monitoring?

--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -88,7 +88,7 @@ module Shipit
       end
 
       after_transition any => :timedout do |task|
-        retry_if_necessary
+        task.retry_if_necessary
       end
 
       event :run do
@@ -388,7 +388,7 @@ module Shipit
 
     # Make private before commiting
     def retry_if_necessary
-      if self.retry_attempt < self.max_retries
+      if retry_attempt < max_retries
         retry_task = duplicate_task
         retry_task.retry_attempt = duplicate_task.retry_attempt + 1
         retry_task.save!

--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -423,7 +423,7 @@ module Shipit
     end
 
     def duplicate_task
-      copy_task = self.dup
+      copy_task = dup
       copy_task.status = 'pending'
       copy_task.started_at = nil
       copy_task.ended_at = nil

--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -386,8 +386,9 @@ module Shipit
         .reject(&:alive?)
     end
 
-    # Make private before commiting
     def retry_if_necessary
+      return if max_retries.nil?
+
       if retry_attempt < max_retries
         retry_task = duplicate_task
         retry_task.retry_attempt = duplicate_task.retry_attempt + 1

--- a/db/migrate/20201008145809_add_retry_attempt_to_tasks.rb
+++ b/db/migrate/20201008145809_add_retry_attempt_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddRetryAttemptToTasks < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tasks, :retry_attempt, :integer, null: false, default: 0
+  end
+end

--- a/db/migrate/20201008152744_add_max_retries_to_tasks.rb
+++ b/db/migrate/20201008152744_add_max_retries_to_tasks.rb
@@ -1,0 +1,5 @@
+class AddMaxRetriesToTasks < ActiveRecord::Migration[6.0]
+  def change
+    add_column :tasks, :max_retries, :integer, null: true
+  end
+end

--- a/lib/shipit/task_commands.rb
+++ b/lib/shipit/task_commands.rb
@@ -25,11 +25,6 @@ module Shipit
       end
     end
 
-    # BEFORE COMMITING -- move to DeployCommands if necessary
-    def retries
-      deploy_spec.retries_on_deploy_timeout
-    end
-
     def steps
       @task.definition.steps
     end

--- a/lib/shipit/task_commands.rb
+++ b/lib/shipit/task_commands.rb
@@ -25,6 +25,11 @@ module Shipit
       end
     end
 
+    # BEFORE COMMITING -- move to DeployCommands if necessary
+    def retries
+      deploy_spec.retries_on_deploy_timeout
+    end
+
     def steps
       @task.definition.steps
     end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_01_125502) do
+ActiveRecord::Schema.define(version: 2020_10_08_152744) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text "permissions", limit: 65535
@@ -298,6 +298,8 @@ ActiveRecord::Schema.define(version: 2020_10_01_125502) do
     t.boolean "ignored_safeties", default: false, null: false
     t.integer "aborted_by_id"
     t.integer "rollback_once_aborted_to_id"
+    t.integer "retry_attempt", default: 0, null: false
+    t.integer "max_retries"
     t.index ["rolled_up", "created_at", "status"], name: "index_tasks_on_rolled_up_and_created_at_and_status"
     t.index ["since_commit_id"], name: "index_tasks_on_since_commit_id"
     t.index ["stack_id", "allow_concurrency", "status"], name: "index_active_tasks"

--- a/test/fixtures/shipit/tasks.yml
+++ b/test/fixtures/shipit/tasks.yml
@@ -60,6 +60,8 @@ shipit_pending:
   deletions: 406
   created_at: <%= (60 - 4).minutes.ago.to_s(:db) %>
   allow_concurrency: true
+  max_retries: 1
+  retry_attempt: 0
 
 shipit_running:
   id: 5

--- a/test/fixtures/shipit/tasks.yml
+++ b/test/fixtures/shipit/tasks.yml
@@ -11,6 +11,7 @@ shipit:
   created_at: <%= (60 - 1).minutes.ago.to_s(:db) %>
   started_at: <%= (60 - 1).minutes.ago.to_s(:db) %>
   ended_at: <%= (60 - 6).minutes.ago.to_s(:db) %>
+  max_retries: 3
 
 shipit2:
   id: 2

--- a/test/models/deploy_spec_test.rb
+++ b/test/models/deploy_spec_test.rb
@@ -181,9 +181,29 @@ module Shipit
       end
     end
 
+    test '#retries_on_deploy_timeout returns `deploy.retries_on_timeout` if present' do
+      @spec.stubs(:load_config).returns('deploy' => { 'retries_on_timeout' => 5 })
+      assert_equal 5, @spec.retries_on_deploy_timeout
+    end
+
+    test '#retries_on_deploy_timeout returns a default value if `deploy.retries_on_timeout` is not present' do
+      @spec.stubs(:load_config).returns('deploy' => {})
+      assert_nil @spec.retries_on_deploy_timeout
+    end
+
     test '#rollback_steps returns `rollback.override` if present' do
       @spec.stubs(:load_config).returns('rollback' => { 'override' => %w(foo bar baz) })
       assert_equal %w(foo bar baz), @spec.rollback_steps
+    end
+
+    test '#retries_on_rollback_timeout returns `rollback.retries_on_timeout` if present' do
+      @spec.stubs(:load_config).returns('rollback' => { 'retries_on_timeout' => 5 })
+      assert_equal 5, @spec.retries_on_rollback_timeout
+    end
+
+    test '#retries_on_rollback_timeout returns a default value if `rollback.retries_on_timeout` is not present' do
+      @spec.stubs(:load_config).returns('rollback' => {})
+      assert_nil @spec.retries_on_rollback_timeout
     end
 
     test '#rollback_steps returns `cap $ENVIRONMENT deploy:rollback` if a `Capfile` is present' do
@@ -378,8 +398,12 @@ module Shipit
           'variables' => [],
           'max_commits' => 8,
           'interval' => 0,
+          'retries_on_timeout' => nil,
         },
-        'rollback' => { 'override' => nil },
+        'rollback' => {
+          'override' => nil,
+          'retries_on_timeout' => nil,
+        },
         'fetch' => nil,
         'tasks' => {},
       }

--- a/test/models/deploys_test.rb
+++ b/test/models/deploys_test.rb
@@ -60,6 +60,98 @@ module Shipit
       assert_equal [], @deploy.commits
     end
 
+    test "deploys retry up to limit upon timeout when configured" do
+      runnable_deploy = shipit_deploys(:shipit_pending)
+      deploy_stack = runnable_deploy.stack
+
+      Shipit::Deploy.any_instance.expects(:acquire_git_cache_lock).twice
+        .raises(Shipit::Command::TimedOut, 'Deploy timed out')
+        .then.raises(Shipit::Command::Error, "Second command error failure")
+
+      perform_enqueued_jobs(only: Shipit::PerformTaskJob) do
+        runnable_deploy.enqueue
+      end
+      assert_performed_jobs 2
+
+      runnable_deploy.reload
+      assert_equal 'timedout', runnable_deploy.status
+
+      retried_deploy = deploy_stack.deploys.last
+      assert_not_equal runnable_deploy.id, retried_deploy.id
+      assert_equal runnable_deploy.since_commit, retried_deploy.since_commit
+      assert_equal runnable_deploy.until_commit, retried_deploy.until_commit
+      assert_equal 'failed', retried_deploy.status
+      assert_equal 1, retried_deploy.retry_attempt
+    end
+
+    test "deploys do not retry upon timeout when not configured" do
+      runnable_deploy = shipit_deploys(:shipit_pending)
+      runnable_deploy.update!(retry_attempt: 0, max_retries: 0)
+
+      Shipit::Deploy.any_instance.expects(:acquire_git_cache_lock)
+        .raises(Shipit::Command::TimedOut, 'Deploy timed out')
+
+      perform_enqueued_jobs(only: Shipit::PerformTaskJob) do
+        runnable_deploy.enqueue
+      end
+      assert_performed_jobs 1
+
+      runnable_deploy.reload
+
+      assert_equal 'timedout', runnable_deploy.status
+    end
+
+    test "rollbacks retry on timeouts if configured" do
+      deploy = shipit_deploys(:shipit)
+      deploy_stack = deploy.stack
+
+      DeploySpec.any_instance.expects(:retries_on_rollback_timeout).returns(1)
+
+      Shipit::Command.any_instance.expects(:run).twice
+        .raises(Shipit::Command::TimedOut, 'Rollback timed out')
+        .then.raises(Shipit::Command::Error, "Second command error failure")
+
+      first_rollback = nil
+
+      perform_enqueued_jobs(only: Shipit::PerformTaskJob) do
+        first_rollback = deploy.trigger_rollback(@user, force: true)
+      end
+      assert_performed_jobs 2
+
+      first_rollback.reload
+
+      assert_equal 'timedout', first_rollback.status
+      retried_rollback = deploy_stack.deploys_and_rollbacks.last
+
+      assert_not_equal first_rollback.id, retried_rollback.id
+      assert_equal first_rollback.since_commit, retried_rollback.since_commit
+      assert_equal first_rollback.until_commit, retried_rollback.until_commit
+      assert_equal 'failed', retried_rollback.status
+      assert_equal 1, retried_rollback.max_retries
+    end
+
+    test "rollbacks does not retry on timeouts if not configured" do
+      deploy_stack = @deploy.stack
+
+      DeploySpec.any_instance.expects(:retries_on_rollback_timeout).returns(0)
+
+      Shipit::Command.any_instance.expects(:run).once
+        .raises(Shipit::Command::TimedOut, 'Rollback timed out')
+        .then.raises(Shipit::Command::Error, "Second command error failure")
+
+      first_rollback = nil
+
+      perform_enqueued_jobs(only: Shipit::PerformTaskJob) do
+        first_rollback = @deploy.trigger_rollback(@user, force: true)
+      end
+      assert_performed_jobs 1
+
+      first_rollback.reload
+
+      assert_equal 'timedout', first_rollback.status
+      assert_equal first_rollback, deploy_stack.deploys_and_rollbacks.last
+    end
+
     test "additions and deletions are denormalized on before create" do
       stack = shipit_stacks(:shipit)
       first = shipit_commits(:first)

--- a/test/models/tasks_test.rb
+++ b/test/models/tasks_test.rb
@@ -47,5 +47,26 @@ module Shipit
         "'#{Task::OUTPUT_TRUNCATED_MESSAGE.chomp}' was not present in the output",
       )
     end
+
+    test "#retry_if_necessary creates a duplicated task object with pending status and nil created_at and ended_at" do
+      task = shipit_tasks(:shipit)
+      task_stack = task.stack
+      task.retry_if_necessary
+
+      retried_task = task_stack.deploys.last
+
+      assert_not_equal task.id, retried_task.id
+      assert_nil retried_task.started_at
+      assert_nil retried_task.ended_at
+      assert_equal 'pending', retried_task.status
+    end
+
+    test "#retry_if_necessary does not create a new task object if max_retries is nil" do
+      task = shipit_tasks(:shipit2)
+
+      assert_no_difference 'Task.count', 'No new task should be created' do
+        task.retry_if_necessary
+      end
+    end
   end
 end


### PR DESCRIPTION
## What
- adds logic to retry tasks (more specifically deploys and rollbacks) that timeout

## Why
- we have quite a few deploy timeouts that are solved simply by retrying. This PR automates the retry process
- for some data see: https://app.mode.com/editor/shopify/reports/28f5c21e2860 (note that currently core deploy timeouts are recorded as failures as oppose to timeouts - a krane fix for this is WIP)

## How
**new fields on the `Task` model**:
- `max_retries` tracks the number of retries we will perform - when field is nil, we do not perform any retries
- `retry_attempt` tracks which retry attempt number this task is - this allows us to keep retrying until we reach the max number of retries set on the task

**when to retry**:
- whenever the state machine in the task model transitions to the `timedout` state, it will trigger the `retry_if_necessary` method
- `retry_if_necessary` will only retry if the `max_retires` is not nil and the current `retry_attempt` is less than the `max_retries`
- retries can be enabled on a stack by setting the max retries on a deploy or timeout using the `retries_on_timeout` field in the `shipit.yml`

**the retry process**:
- on a retry we create a new task, which is duplicated from the timed out task with the retry attempt incremented
- we enqueue this new task

## Tophat Process
1. Run `shipit-engine` locally using the test dummy app
2. Add this repo as a stack: https://github.com/Shopify/shipit-retry-tester
3. Make a commit to the `shipit-retry-tester` repo (can just add a character to the README)
4. Click `Refresh statuses & commits` on the `shipit-retry-tester` stack, you will now see the new commit you made
5. Deploy this commit
6. This deploy will use the [`test_timeout`](https://github.com/Shopify/shipit-retry-tester/blob/main/test_timeout) deploy script, which will timeout 50% of the time.
7. If it does not timeout, create new commit and try deploying it again
8. If it does timeout, verify on the stack page that it automatically created and launched a new task (i.e. deploy)

## Considerations
- [Thoughts on `enqueue` v.s. `run_now` for the retry task ?](https://github.com/Shopify/shipit-engine/pull/1109/files#r504380853)

cc @ajshepley 