### PR TITLE
Pull git recursivelly for tmp directories

### DIFF
--- a/lib/shipit/stack_commands.rb
+++ b/lib/shipit/stack_commands.rb
@@ -57,7 +57,7 @@ module Shipit
       Dir.mktmpdir do |dir|
         git(
           'clone', @stack.git_path, @stack.repo_name,
-          '--origin', 'cache',
+          '--recursive', '--origin', 'cache',
           chdir: dir
         ).run!
 


### PR DESCRIPTION
This [native gem](https://github.com/Shopify/woff2-encoder) contains git submodules. Shipit ignore those submodules when building the gem.