### PR TITLE
Add retry fields to task serializer 

### DIFF
--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -387,7 +387,7 @@ module Shipit
     end
 
     def retry_if_necessary
-      return if max_retries.nil?
+      return unless retries_configured?
 
       if retry_attempt < max_retries
         retry_task = duplicate_task
@@ -396,6 +396,10 @@ module Shipit
 
         retry_task.enqueue
       end
+    end
+
+    def retries_configured?
+      !max_retries.nil? && max_retries > 0
     end
 
     private

--- a/app/serializers/shipit/task_serializer.rb
+++ b/app/serializers/shipit/task_serializer.rb
@@ -6,7 +6,7 @@ module Shipit
     has_one :author
     has_one :revision, serializer: ShortCommitSerializer
 
-    attributes(:id, :url, :html_url, :output_url, :type, :status, :action, :title, :description, :started_at, :ended_at, :updated_at, :created_at, :env, :ignored_safeties)
+    attributes(:id, :url, :html_url, :output_url, :type, :status, :action, :title, :description, :started_at, :ended_at, :updated_at, :created_at, :env, :ignored_safeties, :max_retries, :retry_attempt)
 
     def revision
       object.until_commit

--- a/test/models/tasks_test.rb
+++ b/test/models/tasks_test.rb
@@ -68,5 +68,16 @@ module Shipit
         task.retry_if_necessary
       end
     end
+
+    test "#retries_configured? returns true when max_retries is not nil and is greater than zero" do
+      task_with_three_retries = shipit_tasks(:shipit)
+      assert_predicate task_with_three_retries, :retries_configured?
+
+      task_with_nil_retries = shipit_tasks(:shipit2)
+      refute_predicate task_with_nil_retries, :retries_configured?
+
+      task_with_zero_retries = shipit_tasks(:shipit_restart)
+      refute_predicate task_with_zero_retries, :retries_configured?
+    end
   end
 end


### PR DESCRIPTION
## What
- update the `task_serializer` to send retry fields: `retry_attempt` and `max_retries`

## Why
- so spy can receive a webhook and parse that this deploy/rollback is one that is automatically being retried
- see PR with spy changes here: https://github.com/Shopify/spy/pull/8414