### PR TITLE
Add ENVIRONMENT to StackCommands

### DIFF
--- a/lib/shipit/stack_commands.rb
+++ b/lib/shipit/stack_commands.rb
@@ -79,5 +79,9 @@ module Shipit
     def create_directories
       FileUtils.mkdir_p(@stack.deploys_path)
     end
+
+    def env
+      super.merge({ "ENVIRONMENT" => @stack.environment })
+    end
   end
 end


### PR DESCRIPTION
This allows `$ENVIRONMENT` to be used in `fetch`.