### PR TITLE
Include plugins on other stack pages

### DIFF
--- a/app/views/shipit/stacks/_links.html.erb
+++ b/app/views/shipit/stacks/_links.html.erb
@@ -1,1 +1,3 @@
 <%# Placeholder to be used by the host application %>
+
+<%= include_plugins(@stack) %>

--- a/app/views/shipit/tasks/_task_output.html.erb
+++ b/app/views/shipit/tasks/_task_output.html.erb
@@ -1,7 +1,6 @@
 <% content_for :main_classes do %>no-footer<% end %>
 
 <%= javascript_include_tag 'task' %>
-<%= include_plugins(@stack) %>
 <%= render partial: 'shipit/stacks/header', locals: { stack: @stack } %>
 
 <div class="sidebar">


### PR DESCRIPTION
## Why
Shipit currently allows the parent application to define extension and/or modification to a page by the use of plugins. Unfortunately the defined plugins are only included on the task output page, a.k.a the deployment logs page. Considering that the plugin is defined at the stack level, it would be helpful if it is also enable on other pages that involve the stack. This would allow a new level o customization on the stack pages. An example would be extra warnings on the commits and tasks page.

## How
We are basically moving the inclusion of the plugins scripts one level above so it can be defined for all stacks pages.

I'm not quite sure this is really the best place to have this. I'm open for feedback.