### PR TITLE
Retry task failures in addition to timeouts.

### DIFF
--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -92,7 +92,7 @@ module Shipit
         env: env&.to_h || {},
         allow_concurrency: force,
         ignored_safeties: force,
-        max_retries: stack.cached_deploy_spec.retries_on_rollback_timeout,
+        max_retries: stack.retries_on_rollback,
       )
     end
 

--- a/app/models/shipit/deploy_spec.rb
+++ b/app/models/shipit/deploy_spec.rb
@@ -126,8 +126,8 @@ module Shipit
       deploy_variables.map { |v| [v.name, v.default] }.to_h
     end
 
-    def retries_on_deploy_timeout
-      config('deploy', 'retries_on_timeout') { nil }
+    def retries_on_deploy
+      config('deploy', 'retries') { nil }
     end
 
     def rollback_steps
@@ -140,8 +140,8 @@ module Shipit
       rollback_steps || cant_detect!(:rollback)
     end
 
-    def retries_on_rollback_timeout
-      config('rollback', 'retries_on_timeout') { nil }
+    def retries_on_rollback
+      config('rollback', 'retries') { nil }
     end
 
     def fetch_deployed_revision_steps

--- a/app/models/shipit/deploy_spec/file_system.rb
+++ b/app/models/shipit/deploy_spec/file_system.rb
@@ -70,11 +70,11 @@ module Shipit
             'variables' => deploy_variables.map(&:to_h),
             'max_commits' => maximum_commits_per_deploy,
             'interval' => pause_between_deploys,
-            'retries_on_timeout' => retries_on_deploy_timeout,
+            'retries' => retries_on_deploy,
           },
           'rollback' => {
             'override' => rollback_steps,
-            'retries_on_timeout' => retries_on_rollback_timeout,
+            'retries' => retries_on_rollback,
           },
           'fetch' => fetch_deployed_revision_steps,
           'tasks' => cacheable_tasks,

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -151,7 +151,7 @@ module Shipit
         env: filter_deploy_envs(env&.to_h || {}),
         allow_concurrency: force,
         ignored_safeties: force || !until_commit.deployable?,
-        max_retries: retries_on_deploy_timeout,
+        max_retries: retries_on_deploy,
       )
     end
 
@@ -488,8 +488,8 @@ module Shipit
 
     delegate :plugins, :task_definitions, :hidden_statuses, :required_statuses, :soft_failing_statuses,
              :blocking_statuses, :deploy_variables, :filter_task_envs, :filter_deploy_envs,
-             :maximum_commits_per_deploy, :pause_between_deploys, :retries_on_deploy_timeout,
-             :retries_on_rollback_timeout, to: :cached_deploy_spec
+             :maximum_commits_per_deploy, :pause_between_deploys, :retries_on_deploy, :retries_on_rollback,
+             to: :cached_deploy_spec
 
     def monitoring?
       monitoring.present?

--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -87,7 +87,7 @@ module Shipit
         task.async_update_estimated_deploy_duration
       end
 
-      after_transition any => :timedout do |task|
+      after_transition any => %i(failed error timedout) do |task|
         task.retry_if_necessary
       end
 

--- a/test/models/deploy_spec_test.rb
+++ b/test/models/deploy_spec_test.rb
@@ -181,14 +181,14 @@ module Shipit
       end
     end
 
-    test '#retries_on_deploy_timeout returns `deploy.retries_on_timeout` if present' do
-      @spec.stubs(:load_config).returns('deploy' => { 'retries_on_timeout' => 5 })
-      assert_equal 5, @spec.retries_on_deploy_timeout
+    test '#retries_on_deploy returns `deploy.retries` if present' do
+      @spec.stubs(:load_config).returns('deploy' => { 'retries' => 5 })
+      assert_equal 5, @spec.retries_on_deploy
     end
 
-    test '#retries_on_deploy_timeout returns a default value if `deploy.retries_on_timeout` is not present' do
+    test '#retries_on_deploy returns a default value if `deploy.retries` is not present' do
       @spec.stubs(:load_config).returns('deploy' => {})
-      assert_nil @spec.retries_on_deploy_timeout
+      assert_nil @spec.retries_on_deploy
     end
 
     test '#rollback_steps returns `rollback.override` if present' do
@@ -196,14 +196,14 @@ module Shipit
       assert_equal %w(foo bar baz), @spec.rollback_steps
     end
 
-    test '#retries_on_rollback_timeout returns `rollback.retries_on_timeout` if present' do
-      @spec.stubs(:load_config).returns('rollback' => { 'retries_on_timeout' => 5 })
-      assert_equal 5, @spec.retries_on_rollback_timeout
+    test '#retries_on_rollback returns `rollback.retries` if present' do
+      @spec.stubs(:load_config).returns('rollback' => { 'retries' => 5 })
+      assert_equal 5, @spec.retries_on_rollback
     end
 
-    test '#retries_on_rollback_timeout returns a default value if `rollback.retries_on_timeout` is not present' do
+    test '#retries_on_rollback returns a default value if `rollback.retries` is not present' do
       @spec.stubs(:load_config).returns('rollback' => {})
-      assert_nil @spec.retries_on_rollback_timeout
+      assert_nil @spec.retries_on_rollback
     end
 
     test '#rollback_steps returns `cap $ENVIRONMENT deploy:rollback` if a `Capfile` is present' do
@@ -398,11 +398,11 @@ module Shipit
           'variables' => [],
           'max_commits' => 8,
           'interval' => 0,
-          'retries_on_timeout' => nil,
+          'retries' => nil,
         },
         'rollback' => {
           'override' => nil,
-          'retries_on_timeout' => nil,
+          'retries' => nil,
         },
         'fetch' => nil,
         'tasks' => {},


### PR DESCRIPTION
This is a refactor of #1109 to include deploy failures. It is technically a breaking change since the `shipit.yml` syntax must change to:

```
deploy:
  retries: 2
rollback:
  retries: 2
 ```

As a follow-up (if necessary) we can allow configuring the types of "failures" that need retries, but right now this is hardcoded.