### PR TITLE
Take into account existing output_chunks when rolling up

### DIFF
--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -238,9 +238,14 @@ module Shipit
 
     def rollup_chunks
       ActiveRecord::Base.transaction do
-        self.output = chunk_output
+        chunks = Shipit::OutputChunk.where(task: self).pluck(:text)
+        chunks << chunk_output
+        self.output = chunks.join("\n")
+
         update_attribute(:rolled_up, true)
+
         Shipit.redis.del(output_key)
+        Shipit::OutputChunk.where(task: self).delete_all
       end
     end
 

--- a/test/jobs/chunk_rollup_job_test.rb
+++ b/test/jobs/chunk_rollup_job_test.rb
@@ -41,5 +41,18 @@ module Shipit
 
       @job.perform(@task)
     end
+
+    test "#perform takes into account data still in the DB" do
+      output_chunks = Shipit::OutputChunk.create(text: "DB output", task: @task)
+      expected_output = [output_chunks.text, @task.chunk_output].join("\n")
+
+      @job.perform(@task)
+
+      @task.reload
+      assert_equal expected_output, @task.chunk_output
+      assert @task.rolled_up
+      assert_empty Shipit::OutputChunk.where(task: @task)
+      assert_nil Shipit.redis.get(@task.send(:output_key))
+    end
   end
 end


### PR DESCRIPTION
With the changes introduced in #1133 existing output chunks would not be taken into account when rolling up the output of a task. This meant that task that were in flight as the new code was deployed would lose part of their output.

These changes to the rollup code make sure that existing data in the `output_chunks` table is taken into account, and inserted before the redis data.