### PR TITLE
Fix String coercion error

### DIFF
--- a/app/serializers/shipit/tail_task_serializer.rb
+++ b/app/serializers/shipit/tail_task_serializer.rb
@@ -33,7 +33,7 @@ module Shipit
     delegate :stack, to: :object
 
     def offset
-      (output&.bytesize || 0) + (context[:last_byte] || 0)
+      (output&.bytesize || 0) + (context[:last_byte]&.to_i || 0)
     end
 
     def rollback

--- a/test/controllers/tasks_controller_test.rb
+++ b/test/controllers/tasks_controller_test.rb
@@ -104,12 +104,21 @@ module Shipit
       @task.write("dummy output")
       last_chunk = @task.chunk_output.bytesize
 
-      get :tail, params: { stack_id: @stack.to_param, id: @task.id, last_id: 0 }, format: :json
+      get :tail, params: { stack_id: @stack.to_param, id: @task.id, last_byte: 0 }, format: :json
       assert_response :success
       assert_json_keys %w(url status output)
       assert_json 'status', @task.status
       assert_json 'output', @task.chunk_output
       assert_json 'url', "/shopify/shipit-engine/production/tasks/#{@task.id}/tail?last_byte=#{last_chunk}"
+    end
+
+    test ":tail can handle last_byte as string" do
+      @task = shipit_deploys(:shipit_running)
+      @task.write("dummy output")
+
+      get :tail, params: { stack_id: @stack.to_param, id: @task.id, last_byte: "50" }, format: :json
+      assert_response :success
+      assert_json_keys %w(url status output)
     end
 
     test ":tail doesn't returns the next url if the task is finished" do


### PR DESCRIPTION
Convert the `last_byte` param to integer to avoid a string coercion error

https://app.bugsnag.com/shopify/shipit/errors/60245d4e06dadd0017d851d9?event_id=60245d5f0069a9de55710000&i=sk&m=fq