### PR TITLE
Bump version to 0.33.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# Unreleased
+# 0.33.0
 
 * Use a Redis cache to store task output, instead of `output_chunks` (deprecate their use).
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shipit-engine (0.32.0)
+    shipit-engine (0.33.0)
       active_model_serializers (~> 0.9.3)
       ansi_stream (~> 0.0.6)
       attr_encrypted (~> 3.1.0)

--- a/lib/shipit/version.rb
+++ b/lib/shipit/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 module Shipit
-  VERSION = '0.32.0'
+  VERSION = '0.33.0'
 end


### PR DESCRIPTION
Bump the Gem version to 0.33.0 to officially release the Redis cache changes.