### PR TITLE
Add new mode param to allow dark and light mode on merge status endpoint

### DIFF
--- a/app/views/layouts/merge_status.html.erb
+++ b/app/views/layouts/merge_status.html.erb
@@ -4,7 +4,7 @@
     <%= stylesheet_link_tag *(params[:stylesheets] || []).select { |url| url.start_with?('https://assets-cdn.github.com/', 'https://github.githubassets.com/') } %>
     <%= stylesheet_link_tag 'merge_status' %>
   </head>
-  <body>
+  <body data-color-mode="<%= params[:mode] %>">
     <div class="merge-status-container" data-layout-content><%= yield %></div>
     <%= javascript_include_tag 'merge_status' %>
   </body>


### PR DESCRIPTION
Hi  from Clio!! 👋🏻   
GitHub recently released the ability to [toggle between different themes](https://github.com/settings/appearance).
This PR adds a data attribute to the html body in order to use the dark or light mode CSS. The value of the data attribute is passed in through the new `mode` parameter. If the user passes in an invalid value for example `darks` or `light` the light mode CSS is loaded.

### Why
I looked at the GitHub HTML and CSS and they define a data attribute `data-color-mode=dark` or `data-color-mode=light` to switch the CSS to dark or light mode. Adding this data attribute to the body of this HTML document allows the ability to toggle between light and dark mode.

## Before
![Screen Shot 2021-02-12 at 9 30 38 AM](https://user-images.githubusercontent.com/64045331/107817768-d210ad00-6d33-11eb-97a5-a519c45fb220.png)

## After 
![Screen Shot 2021-02-12 at 1 03 25 PM](https://user-images.githubusercontent.com/64045331/107817372-47c84900-6d33-11eb-9e2f-46e90c4474dc.png)