### PR TITLE
Support non-v prefixed tags

### DIFF
--- a/lib/snippets/release-gem
+++ b/lib/snippets/release-gem
@@ -24,7 +24,8 @@ module Git
   end
 
   def tag_exists?(version)
-    system('git', 'rev-parse', '--verify', "v#{version}^{commit}", out: File::NULL, err: File::NULL)
+    system('git', 'rev-parse', '--verify', "v#{version}^{commit}", out: File::NULL, err: File::NULL) ||
+      system('git', 'rev-parse', '--verify', "#{version}^{commit}", out: File::NULL, err: File::NULL)
   end
 
   def tag(version)


### PR DESCRIPTION
Check for both v prefixed and non-v prefixed tags in `tag_exists?` so we avoid creating unnecessary v prefixed tags during deploys, leaving repos with unused tags like so.
<img width="1233" alt="Screen Shot 2021-02-18 at 17 07 44" src="https://user-images.githubusercontent.com/1557529/108332636-5d49e100-7213-11eb-9066-5a0a8cda47b3.png">

### Minor backwards compatability 🎩 
<img width="1021" alt="Screen Shot 2021-02-18 at 17 57 59" src="https://user-images.githubusercontent.com/1557529/108332660-689d0c80-7213-11eb-8bf4-e99ac772dbaf.png">

Resolves https://github.com/Shopify/shipit-engine/issues/1140