### PR TITLE
Use the monotonic clock for task timing

### DIFF
--- a/app/models/shipit/task_execution_strategy/default.rb
+++ b/app/models/shipit/task_execution_strategy/default.rb
@@ -83,19 +83,18 @@ module Shipit
       end
 
       def capture!(command)
-        started_at = Time.now
+        started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
         command.start do
           @task.ping
           check_for_abort
         end
-        @task.write("$ #{command}\npid: #{command.pid}\nstarted at: #{started_at}\n")
+        @task.write("\n$ #{command}\npid: #{command.pid}\n")
         @task.pid = command.pid
         command.stream! do |line|
           @task.write(line)
         end
-        @task.write("\n")
-        finished_at = Time.now
-        @task.write("pid: #{command.pid}\nfinished at: #{finished_at}\nran in: #{finished_at - started_at} seconds\n")
+        finished_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+        @task.write("pid: #{command.pid} finished in: #{finished_at - started_at} seconds\n")
         command.success?
       end
 


### PR DESCRIPTION
Using Time.now MAY be unreliable. On some systems, Time.now uses the
`gettimeofday` system call. The `gettimeofday` documentation states:

> The time returned by gettimeofday() is affected by discontinuous jumps
in the system time (e.g., if the system administrator manually changes
the system time).

IE this returns "wall time" of the system clock which MAY change
unexpectedly - for example if the system uses NTP to set time and the
clock adjusts during the execution of a task. Time.now is prone to
jumping around an inconsistent timeline.

Instead, this uses the system's monotonic clock to ensure that "time" is
consistently measured between the "start" and "stop" of a task.

References
----------

- http://man7.org/linux/man-pages/man2/gettimeofday.2.html
- https://blog.dnsimple.com/2018/03/elapsed-time-with-ruby-the-right-way/
- https://ruby-doc.org/core-2.5.3/Process.html#method-c-clock_gettime