### PR TITLE
Remove rollback retries tests and functions

### DIFF
--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -92,7 +92,6 @@ module Shipit
         env: env&.to_h || {},
         allow_concurrency: force,
         ignored_safeties: force,
-        max_retries: stack.retries_on_rollback,
       )
     end
 

--- a/app/models/shipit/deploy_spec.rb
+++ b/app/models/shipit/deploy_spec.rb
@@ -140,10 +140,6 @@ module Shipit
       rollback_steps || cant_detect!(:rollback)
     end
 
-    def retries_on_rollback
-      config('rollback', 'retries') { nil }
-    end
-
     def fetch_deployed_revision_steps
       config('fetch') || discover_fetch_deployed_revision_steps
     end

--- a/app/models/shipit/deploy_spec/file_system.rb
+++ b/app/models/shipit/deploy_spec/file_system.rb
@@ -74,7 +74,6 @@ module Shipit
           },
           'rollback' => {
             'override' => rollback_steps,
-            'retries' => retries_on_rollback,
           },
           'fetch' => fetch_deployed_revision_steps,
           'tasks' => cacheable_tasks,

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -488,7 +488,7 @@ module Shipit
 
     delegate :plugins, :task_definitions, :hidden_statuses, :required_statuses, :soft_failing_statuses,
              :blocking_statuses, :deploy_variables, :filter_task_envs, :filter_deploy_envs,
-             :maximum_commits_per_deploy, :pause_between_deploys, :retries_on_deploy, :retries_on_rollback,
+             :maximum_commits_per_deploy, :pause_between_deploys, :retries_on_deploy,
              to: :cached_deploy_spec
 
     def monitoring?

--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -404,7 +404,7 @@ module Shipit
     end
 
     def retry_if_necessary
-      return unless retries_configured? && !stack.reload.locked?
+      return if !retries_configured? || stack.reload.locked? || rollback?
 
       if retry_attempt < max_retries
         retry_task = duplicate_task

--- a/test/models/deploy_spec_test.rb
+++ b/test/models/deploy_spec_test.rb
@@ -196,16 +196,6 @@ module Shipit
       assert_equal %w(foo bar baz), @spec.rollback_steps
     end
 
-    test '#retries_on_rollback returns `rollback.retries` if present' do
-      @spec.stubs(:load_config).returns('rollback' => { 'retries' => 5 })
-      assert_equal 5, @spec.retries_on_rollback
-    end
-
-    test '#retries_on_rollback returns a default value if `rollback.retries` is not present' do
-      @spec.stubs(:load_config).returns('rollback' => {})
-      assert_nil @spec.retries_on_rollback
-    end
-
     test '#rollback_steps returns `cap $ENVIRONMENT deploy:rollback` if a `Capfile` is present' do
       @spec.expects(:bundler?).returns(true).at_least_once
       @spec.expects(:capistrano?).returns(true)
@@ -402,7 +392,6 @@ module Shipit
         },
         'rollback' => {
           'override' => nil,
-          'retries' => nil,
         },
         'fetch' => nil,
         'tasks' => {},


### PR DESCRIPTION
Retries on rollback should not be configurable, rollbacks trigger a lock on the stack and are blocked from retries 
https://github.com/Shopify/shipit-engine/blob/0f1e09f2adeac6da01efcd78cd1334481cc54a43/app/models/shipit/task.rb#L407 
