### PR TITLE
Remove old, archived review stack file caches

### DIFF
--- a/app/models/shipit/review_stack.rb
+++ b/app/models/shipit/review_stack.rb
@@ -7,8 +7,8 @@ module Shipit
         "archived_since > :earliest AND archived_since < :latest",
         earliest: 1.day.ago,
         latest: 1.hour.ago
-      ).each do |review_stack|
-        Shipit::ClearGitCacheJob.perform_later(review_stack)
+      ).find_each do |review_stack|
+        review_stack.clear_local_files
       end
     end
 

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -581,14 +581,14 @@ module Shipit
       links_spec.transform_values { |url| context.interpolate(url) }
     end
 
+    def clear_local_files
+      FileUtils.rm_rf(base_path.to_s)
+    end
+
     private
 
     def clear_cache
       remove_instance_variable(:@active_task) if defined?(@active_task)
-    end
-
-    def clear_local_files
-      FileUtils.rm_rf(base_path.to_s)
     end
 
     def update_defaults


### PR DESCRIPTION
The current implementation of `ReviewStack#clear_stale_caches` only
removes the contents of the `<stack-environment>/git directory` from
data directory. This has the effect of leaving the following structure
in the shipit-engine data directory for each archived Review Stack:

```
┌───────────────────┐
│<stack-environment>│
└───────────────────┘
          │     ┌───────┐
          ├─────│deploys│
          │     └───────┘
          │     ┌───────┐
          ├─────│git    │
          │     └───────┘
          │
          └─────.git
```

This change expands the responsibility of the
`ReviewStack#clear_stale_caches` method to remove all of the local files
of an archived Review Stack when the cleanup happens.