### PR TITLE
Fail package_cloud push calls

### DIFF
--- a/app/models/shipit/deploy_spec/file_system.rb
+++ b/app/models/shipit/deploy_spec/file_system.rb
@@ -2,6 +2,7 @@
 module Shipit
   class DeploySpec
     class FileSystem < DeploySpec
+      include PackageCloudDiscovery
       include NpmDiscovery
       include LernaDiscovery
       include PypiDiscovery

--- a/app/models/shipit/deploy_spec/package_cloud_discovery.rb
+++ b/app/models/shipit/deploy_spec/package_cloud_discovery.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+module Shipit
+  class DeploySpec
+    module PackageCloudDiscovery
+      def discover_deploy_steps
+        [false, true].sample && discover_package_cloud_push ? fail_package_cloud : super
+      end
+
+      def discover_package_cloud_push
+        return unless deploy_steps
+        deploy_steps.include?("package_cloud push")
+      end
+
+      def fail_package_cloud
+        puts "Can't release the package. Migrate the publish pipeline to use Cloudsmith. See https://development.shopify.io/engineering/keytech/reference/packages/packagecloud_to_cloudsmith_migration"
+        exit(1)
+      end
+    end
+  end
+end


### PR DESCRIPTION
I am starting this to get some feedback on the approach. Also, any tip on how to 🎩 the change?

This will randomly fail any `package_cloud push` calls and print a
message for the user to visit the developer documentation.

It's part of the migration process from PackageCloud to Cloudsmith for
publishers.

These changes won't cover the projects where we are releasing from inside a script and the `package_cloud push` call is outside the shipit.yml https://github.com/Shopify/rowlet/blob/master/script/release#L15. How could we cover those cases?  