### PR TITLE
No longer assume `master` is the default branch

### DIFF
--- a/app/views/shipit/stacks/new.html.erb
+++ b/app/views/shipit/stacks/new.html.erb
@@ -17,7 +17,7 @@
         </div>
         <div class="field-wrapper">
           <%= f.label :branch %>
-          <%= f.text_field :branch, placeholder: 'master' %>
+          <%= f.text_field :branch, placeholder: '<default branch>' %>
         </div>
         <div class="field-wrapper">
           <%= f.label :environment %>

--- a/db/migrate/20210325194053_remove_stacks_branch_default.rb
+++ b/db/migrate/20210325194053_remove_stacks_branch_default.rb
@@ -1,0 +1,5 @@
+class RemoveStacksBranchDefault < ActiveRecord::Migration[6.1]
+  def change
+    change_column_default(:stacks, :branch, from: 'master', to: nil)
+  end
+end

--- a/test/controllers/api/ccmenu_controller_test.rb
+++ b/test/controllers/api/ccmenu_controller_test.rb
@@ -44,7 +44,7 @@ module Shipit
       end
 
       test "stacks with no deploys render correctly" do
-        stack = Stack.create!(repository: Repository.new(owner: "foo", name: "bar"))
+        stack = Stack.create!(repository: Repository.new(owner: "foo", name: "bar"), branch: 'main')
         get :show, params: { stack_id: stack.to_param }
         assert_payload 'lastBuildStatus', 'Success'
       end

--- a/test/controllers/api/stacks_controller_test.rb
+++ b/test/controllers/api/stacks_controller_test.rb
@@ -23,7 +23,7 @@ module Shipit
 
       test "#create fails with invalid stack" do
         assert_no_difference "Stack.count" do
-          post :create, params: { repo_owner: 'some', repo_name: 'owner/path' }
+          post :create, params: { repo_owner: 'some', repo_name: 'owner/path', branch: 'main' }
         end
         assert_response :unprocessable_entity
         assert_json 'errors', 'repository' => ['is invalid']

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -2,15 +2,15 @@
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
 #
-# This file is the source Rails uses to define your schema when running `rails
-# db:schema:load`. When creating a new database, `rails db:schema:load` tends to
+# This file is the source Rails uses to define your schema when running `bin/rails
+# db:schema:load`. When creating a new database, `bin/rails db:schema:load` tends to
 # be faster and is potentially less error prone than running all of your
 # migrations from scratch. Old migrations may fail to apply correctly if those
 # migrations use external dependencies or application code.
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_10_08_152744) do
+ActiveRecord::Schema.define(version: 2021_03_25_194053) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text "permissions", limit: 65535
@@ -178,14 +178,14 @@ ActiveRecord::Schema.define(version: 2020_10_08_152744) do
   end
 
   create_table "pull_request_assignments", force: :cascade do |t|
-    t.integer "pull_request_id"
-    t.integer "user_id"
+    t.bigint "pull_request_id"
+    t.bigint "user_id"
     t.index ["pull_request_id"], name: "index_pull_request_assignments_on_pull_request_id"
     t.index ["user_id"], name: "index_pull_request_assignments_on_user_id"
   end
 
   create_table "pull_requests", force: :cascade do |t|
-    t.integer "stack_id", null: false
+    t.bigint "stack_id", null: false
     t.integer "number", null: false
     t.string "title", limit: 256
     t.integer "github_id", limit: 8
@@ -195,7 +195,7 @@ ActiveRecord::Schema.define(version: 2020_10_08_152744) do
     t.integer "deletions", default: 0, null: false
     t.integer "user_id"
     t.text "labels"
-    t.integer "head_id"
+    t.bigint "head_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["head_id"], name: "index_pull_requests_on_head_id"
@@ -214,9 +214,9 @@ ActiveRecord::Schema.define(version: 2020_10_08_152744) do
     t.bigint "github_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["commit_id", "github_id"], name: "index_deploy_statuses_on_commit_id_and_github_id"
-    t.index ["stack_id", "commit_id"], name: "index_deploy_statuses_on_stack_id_and_commit_id"
-    t.index ["user_id"], name: "index_deploy_statuses_on_user_id"
+    t.index ["commit_id", "github_id"], name: "index_release_statuses_on_commit_id_and_github_id"
+    t.index ["stack_id", "commit_id"], name: "index_release_statuses_on_stack_id_and_commit_id"
+    t.index ["user_id"], name: "index_release_statuses_on_user_id"
   end
 
   create_table "repositories", force: :cascade do |t|
@@ -234,7 +234,7 @@ ActiveRecord::Schema.define(version: 2020_10_08_152744) do
     t.string "environment", limit: 50, default: "production", null: false
     t.datetime "created_at"
     t.datetime "updated_at"
-    t.string "branch", limit: 255, default: "master", null: false
+    t.string "branch", limit: 255, null: false
     t.string "deploy_url", limit: 255
     t.string "lock_reason", limit: 4096
     t.integer "tasks_count", limit: 4, default: 0, null: false
@@ -288,7 +288,7 @@ ActiveRecord::Schema.define(version: 2020_10_08_152744) do
     t.integer "additions", limit: 4, default: 0
     t.integer "deletions", limit: 4, default: 0
     t.text "definition", limit: 65535
-    t.binary "gzip_output"
+    t.binary "gzip_output", limit: 16777215
     t.boolean "rollback_once_aborted", default: false, null: false
     t.text "env"
     t.integer "confirmations", default: 0, null: false

--- a/test/dummy/db/seeds.rb
+++ b/test/dummy/db/seeds.rb
@@ -31,6 +31,7 @@ module Shipit
         name:  Faker::Internet.domain_name.parameterize,
         owner: Faker::Company.name.parameterize
       ),
+      branch: "main",
       deploy_url:  "https://#{Faker::Internet.domain_name.parameterize}.#{Faker::Internet.domain_suffix}/",
       cached_deploy_spec: DeploySpec.load(%(
         {


### PR DESCRIPTION
Since `main` is the new preferred default branch name, it seems appropriate to have this preference in shipit as well.