### PR TITLE
Support for sending signed webhooks with the secret key

### DIFF
--- a/app/models/shipit/hook.rb
+++ b/app/models/shipit/hook.rb
@@ -51,7 +51,7 @@ module Shipit
       end
 
       def signature
-        return nil if secret.empty?
+        return nil if secret.blank?
 
         DeliverySigner.new(secret).sign(payload)
       end

--- a/app/models/shipit/hook.rb
+++ b/app/models/shipit/hook.rb
@@ -2,11 +2,12 @@
 module Shipit
   class Hook < Record
     class DeliverySpec
-      def initialize(event:, url:, content_type:, payload:)
+      def initialize(event:, url:, content_type:, payload:, secret:)
         @event = event
         @url = url
         @content_type = content_type
         @payload = payload
+        @secret = secret
       end
 
       def send!
@@ -15,7 +16,7 @@ module Shipit
 
       private
 
-      attr_reader :event, :url, :content_type, :payload
+      attr_reader :event, :url, :content_type, :payload, :secret
 
       def http
         Faraday::Connection.new do |connection|
@@ -29,6 +30,7 @@ module Shipit
           'User-Agent' => 'Shipit Webhook',
           'Content-Type' => content_type,
           'X-Shipit-Event' => event,
+          'X-Shipit-Secret' => secret,
           'Accept' => '*/*',
         }
       end
@@ -119,6 +121,7 @@ module Shipit
         url: delivery_url,
         content_type: CONTENT_TYPES[content_type],
         payload: serialize_payload(payload),
+        secret: secret,
       )
     end
 

--- a/app/models/shipit/hook.rb
+++ b/app/models/shipit/hook.rb
@@ -51,6 +51,8 @@ module Shipit
       end
 
       def signature
+        return nil if secret.empty?
+
         DeliverySigner.new(secret).sign(payload)
       end
     end

--- a/test/fixtures/shipit/hooks.yml
+++ b/test/fixtures/shipit/hooks.yml
@@ -3,6 +3,7 @@ shipit_deploys:
   events: 'deploy,rollback'
   delivery_url: https://example.com/events/deploy
   content_type: json
+  secret: 'example-secret-key'
 
 all_deploys:
   events: 'deploy,rollback'


### PR DESCRIPTION
Fixes #919

The `Hook` model has a "secret" column but the value is currently unused. 

~This change will send that string as the HTTP header X-Shipit-Secret in the webhook, which can be coordinated with the recipient to provide authentication.~

This change will introduce an HMAC signature of the request body that's signed using the secret key. This signature will be provided in the `X-Shipit-Signature` header and can be used to authenticate the request and verify it was untampered. This follows [the same convention that GitHub uses](https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads#delivery-headers) with the notable exception that we don't have separate `X-Shipit-Signature` and `X-Shipit-Signature-256` headers, opting to use sha256 from the start.

An example would be: `X-Shipit-Signature: sha256=7afd930f629997b6228284fd5db061914112a1bb8eddfce15017dde1e4c6c69e`