### PR TITLE
Support multiple GH organisations

### DIFF
--- a/app/controllers/shipit/stacks_controller.rb
+++ b/app/controllers/shipit/stacks_controller.rb
@@ -154,7 +154,7 @@ module Shipit
     end
 
     def create_params
-      params.require(:stack).permit(:environment, :branch, :deploy_url, :ignore_ci)
+      params.require(:stack).permit(:repo_owner, :repo_name, :environment, :branch, :deploy_url, :ignore_ci)
     end
 
     def update_params
@@ -180,7 +180,7 @@ module Shipit
     end
 
     def repository_params
-      params.require(:stack).permit(:repo_owner, :repo_name)
+      params.require(:stack).permit(:repo_owner, :repo_name, :branch, :environment, :deploy_url, :ignore_ci)
     end
   end
 end

--- a/app/controllers/shipit/webhooks_controller.rb
+++ b/app/controllers/shipit/webhooks_controller.rb
@@ -16,7 +16,8 @@ module Shipit
     private
 
     def verify_signature
-      head(422) unless Shipit.github.verify_webhook_signature(request.headers['X-Hub-Signature'], request.raw_post)
+      github_api = Shipit.github(organization: @stack.owner)
+      head(422) unless github_api.verify_webhook_signature(request.headers['X-Hub-Signature'], request.raw_post)
     end
 
     def check_if_ping

--- a/app/controllers/shipit/webhooks_controller.rb
+++ b/app/controllers/shipit/webhooks_controller.rb
@@ -16,7 +16,7 @@ module Shipit
     private
 
     def verify_signature
-      github_app = @stack&.github_app || Shipit.github # TODO: figure out something cleaner
+      github_app = stack&.github_app
       verified = github_app.verify_webhook_signature(
         request.headers['X-Hub-Signature'],
         request.raw_post

--- a/app/controllers/shipit/webhooks_controller.rb
+++ b/app/controllers/shipit/webhooks_controller.rb
@@ -16,12 +16,11 @@ module Shipit
     private
 
     def verify_signature
-      verified = Shipit.github_organizations.map do |gh_org|
-        Shipit.github(organization: gh_org).verify_webhook_signature(
-          request.headers['X-Hub-Signature'],
-          request.raw_post
-        )
-      end.any?
+      github_app = @stack&.repository&.github_app_instance || Shipit.github # TODO: figure out something cleaner
+      verified = github_app.verify_webhook_signature(
+        request.headers['X-Hub-Signature'],
+        request.raw_post
+      )
       head(422) unless verified
     end
 

--- a/app/controllers/shipit/webhooks_controller.rb
+++ b/app/controllers/shipit/webhooks_controller.rb
@@ -16,8 +16,13 @@ module Shipit
     private
 
     def verify_signature
-      github_api = Shipit.github(organization: @stack.owner)
-      head(422) unless github_api.verify_webhook_signature(request.headers['X-Hub-Signature'], request.raw_post)
+      verified = Shipit.github_organizations.map do |gh_org|
+        Shipit.github(organization: gh_org).verify_webhook_signature(
+          request.headers['X-Hub-Signature'],
+          request.raw_post
+        )
+      end.any?
+      head(422) unless verified
     end
 
     def check_if_ping

--- a/app/controllers/shipit/webhooks_controller.rb
+++ b/app/controllers/shipit/webhooks_controller.rb
@@ -16,7 +16,7 @@ module Shipit
     private
 
     def verify_signature
-      github_app = @stack&.repository&.github_app_instance || Shipit.github # TODO: figure out something cleaner
+      github_app = @stack&.github_app || Shipit.github # TODO: figure out something cleaner
       verified = github_app.verify_webhook_signature(
         request.headers['X-Hub-Signature'],
         request.raw_post

--- a/app/helpers/shipit/shipit_helper.rb
+++ b/app/helpers/shipit/shipit_helper.rb
@@ -43,7 +43,6 @@ module Shipit
     end
 
     def missing_github_app_message
-      # TODO: Document how to create an app
       <<-MESSAGE.html_safe
         Shipit requires a GitHub App to authenticate users and perform API calls.
       MESSAGE

--- a/app/jobs/shipit/github_sync_job.rb
+++ b/app/jobs/shipit/github_sync_job.rb
@@ -3,6 +3,8 @@ module Shipit
   class GithubSyncJob < BackgroundJob
     include BackgroundJob::Unique
 
+    attr_reader :stack
+
     MAX_FETCHED_COMMITS = 25
     queue_as :default
 
@@ -13,26 +15,26 @@ module Shipit
       @stack = Stack.find(params[:stack_id])
 
       handle_github_errors do
-        new_commits, shared_parent = fetch_missing_commits { @stack.github_commits }
+        new_commits, shared_parent = fetch_missing_commits { stack.github_commits }
 
-        @stack.transaction do
+        stack.transaction do
           shared_parent&.detach_children!
           appended_commits = new_commits.map do |gh_commit|
             append_commit(gh_commit)
           end
-          @stack.lock_reverted_commits! if appended_commits.any?(&:revert?)
+          stack.lock_reverted_commits! if appended_commits.any?(&:revert?)
         end
       end
-      CacheDeploySpecJob.perform_later(@stack)
+      CacheDeploySpecJob.perform_later(stack)
     end
 
     def append_commit(gh_commit)
-      @stack.commits.create_from_github!(gh_commit)
+      stack.commits.create_from_github!(gh_commit)
     end
 
     def fetch_missing_commits(&block)
       commits = []
-      github_api = @stack&.github_api || Shipit.github.api # TODO: figure out something cleaner
+      github_api = stack&.github_api
       iterator = Shipit::FirstParentCommitsIterator.new(github_api: github_api, &block)
       iterator.each_with_index do |commit, index|
         break if index >= MAX_FETCHED_COMMITS
@@ -50,13 +52,13 @@ module Shipit
     def handle_github_errors
       yield
     rescue Octokit::NotFound
-      @stack.mark_as_inaccessible!
+      stack.mark_as_inaccessible!
     else
-      @stack.mark_as_accessible!
+      stack.mark_as_accessible!
     end
 
     def lookup_commit(sha)
-      @stack.commits.find_by(sha: sha)
+      stack.commits.find_by(sha: sha)
     end
   end
 end

--- a/app/jobs/shipit/github_sync_job.rb
+++ b/app/jobs/shipit/github_sync_job.rb
@@ -32,7 +32,8 @@ module Shipit
 
     def fetch_missing_commits(&block)
       commits = []
-      iterator = Shipit::FirstParentCommitsIterator.new(github_client: @stack.repository.github_api, &block)
+      github_api = @stack&.repository&.github_api || Shipit.github.api # TODO: figure out something cleaner
+      iterator = Shipit::FirstParentCommitsIterator.new(github_api: github_api, &block)
       iterator.each_with_index do |commit, index|
         break if index >= MAX_FETCHED_COMMITS
 

--- a/app/jobs/shipit/github_sync_job.rb
+++ b/app/jobs/shipit/github_sync_job.rb
@@ -32,7 +32,7 @@ module Shipit
 
     def fetch_missing_commits(&block)
       commits = []
-      iterator = Shipit::FirstParentCommitsIterator.new(&block)
+      iterator = Shipit::FirstParentCommitsIterator.new(github_client: @stack.repository.github_api, &block)
       iterator.each_with_index do |commit, index|
         break if index >= MAX_FETCHED_COMMITS
 

--- a/app/jobs/shipit/github_sync_job.rb
+++ b/app/jobs/shipit/github_sync_job.rb
@@ -32,7 +32,7 @@ module Shipit
 
     def fetch_missing_commits(&block)
       commits = []
-      github_api = @stack&.repository&.github_api || Shipit.github.api # TODO: figure out something cleaner
+      github_api = @stack&.github_api || Shipit.github.api # TODO: figure out something cleaner
       iterator = Shipit::FirstParentCommitsIterator.new(github_api: github_api, &block)
       iterator.each_with_index do |commit, index|
         break if index >= MAX_FETCHED_COMMITS

--- a/app/jobs/shipit/update_github_last_deployed_ref_job.rb
+++ b/app/jobs/shipit/update_github_last_deployed_ref_job.rb
@@ -13,7 +13,7 @@ module Shipit
 
       environment = stack.environment
       stack_ref = create_full_ref(environment)
-      client = stack.repository.github_api
+      client = stack.github_api
 
       full_repo_name = stack.github_repo_name
 

--- a/app/jobs/shipit/update_github_last_deployed_ref_job.rb
+++ b/app/jobs/shipit/update_github_last_deployed_ref_job.rb
@@ -13,7 +13,7 @@ module Shipit
 
       environment = stack.environment
       stack_ref = create_full_ref(environment)
-      client = Shipit.github.api
+      client = stack.repository.github_api
 
       full_repo_name = stack.github_repo_name
 

--- a/app/models/shipit/commit.rb
+++ b/app/models/shipit/commit.rb
@@ -143,7 +143,7 @@ module Shipit
 
     def refresh_statuses!
       github_statuses = stack.handle_github_redirections do
-        Shipit.github.api.statuses(github_repo_name, sha, per_page: 100)
+        stack.repository.github_api.statuses(github_repo_name, sha, per_page: 100)
       end
       github_statuses.each do |status|
         create_status_from_github!(status)
@@ -158,7 +158,7 @@ module Shipit
 
     def refresh_check_runs!
       response = stack.handle_github_redirections do
-        Shipit.github.api.check_runs(github_repo_name, sha)
+        stack.repository.github_api.check_runs(github_repo_name, sha)
       end
       response.check_runs.each do |check_run|
         create_or_update_check_run_from_github!(check_run)
@@ -260,7 +260,7 @@ module Shipit
     end
 
     def github_commit
-      @github_commit ||= Shipit.github.api.commit(github_repo_name, sha)
+      @github_commit ||= stack.repository.github_api.commit(github_repo_name, sha)
     end
 
     def schedule_fetch_stats!

--- a/app/models/shipit/commit.rb
+++ b/app/models/shipit/commit.rb
@@ -143,7 +143,7 @@ module Shipit
 
     def refresh_statuses!
       github_statuses = stack.handle_github_redirections do
-        stack.repository.github_api.statuses(github_repo_name, sha, per_page: 100)
+        stack.github_api.statuses(github_repo_name, sha, per_page: 100)
       end
       github_statuses.each do |status|
         create_status_from_github!(status)
@@ -158,7 +158,7 @@ module Shipit
 
     def refresh_check_runs!
       response = stack.handle_github_redirections do
-        stack.repository.github_api.check_runs(github_repo_name, sha)
+        stack.github_api.check_runs(github_repo_name, sha)
       end
       response.check_runs.each do |check_run|
         create_or_update_check_run_from_github!(check_run)
@@ -260,7 +260,7 @@ module Shipit
     end
 
     def github_commit
-      @github_commit ||= stack.repository.github_api.commit(github_repo_name, sha)
+      @github_commit ||= stack.github_api.commit(github_repo_name, sha)
     end
 
     def schedule_fetch_stats!

--- a/app/models/shipit/commit_deployment.rb
+++ b/app/models/shipit/commit_deployment.rb
@@ -22,7 +22,7 @@ module Shipit
       response = begin
         create_deployment_on_github(stack.repository.github_api)
       rescue Octokit::ClientError
-        raise if Shipit.github(organization: stack.owner).api == stack.repository.github_api
+        raise if Shipit.github(organization: stack.repository.owner).api == stack.repository.github_api
         # If the deploy author didn't gave us the permission to create the deployment we falback the the main shipit
         # user.
         #

--- a/app/models/shipit/commit_deployment.rb
+++ b/app/models/shipit/commit_deployment.rb
@@ -20,15 +20,15 @@ module Shipit
       return if github_id?
 
       response = begin
-        create_deployment_on_github(stack.repository.github_api)
+        create_deployment_on_github(stack.github_api)
       rescue Octokit::ClientError
-        raise if Shipit.github(organization: stack.repository.owner).api == stack.repository.github_api
+        raise if Shipit.github(organization: stack.repository.owner).api == stack.github_api
         # If the deploy author didn't gave us the permission to create the deployment we falback the the main shipit
         # user.
         #
         # Octokit currently raise NotFound, but I'm convinced it should be Forbidden if the user can see the repository.
         # So to be future proof I catch boths.
-        create_deployment_on_github(stack.repository.github_api)
+        create_deployment_on_github(stack.github_api)
       end
       update!(github_id: response.id, api_url: response.url)
     end

--- a/app/models/shipit/commit_deployment.rb
+++ b/app/models/shipit/commit_deployment.rb
@@ -20,15 +20,15 @@ module Shipit
       return if github_id?
 
       response = begin
-        create_deployment_on_github(author.github_api)
+        create_deployment_on_github(stack.repository.github_api)
       rescue Octokit::ClientError
-        raise if Shipit.github.api == author.github_api
+        raise if Shipit.github(organization: stack.owner).api == stack.repository.github_api
         # If the deploy author didn't gave us the permission to create the deployment we falback the the main shipit
         # user.
         #
         # Octokit currently raise NotFound, but I'm convinced it should be Forbidden if the user can see the repository.
         # So to be future proof I catch boths.
-        create_deployment_on_github(Shipit.github.api)
+        create_deployment_on_github(stack.repository.github_api)
       end
       update!(github_id: response.id, api_url: response.url)
     end

--- a/app/models/shipit/commit_deployment_status.rb
+++ b/app/models/shipit/commit_deployment_status.rb
@@ -12,15 +12,15 @@ module Shipit
     def create_on_github!
       return if github_id?
       response = begin
-        create_status_on_github(stack.repository.github_api)
+        create_status_on_github(stack.github_api)
       rescue Octokit::ClientError
-        raise if Shipit.github(organization: stack.repository.owner).api == stack.repository.github_api
+        raise if Shipit.github(organization: stack.repository.owner).api == stack.github_api
         # If the deploy author didn't gave us the permission to create the deployment we falback the the main shipit
         # user.
         #
         # Octokit currently raise NotFound, but I'm convinced it should be Forbidden if the user can see the repository.
         # So to be future proof I catch boths.
-        create_status_on_github(stack.repository.github_api)
+        create_status_on_github(stack.github_api)
       end
       update!(github_id: response.id, api_url: response.url)
     end

--- a/app/models/shipit/commit_deployment_status.rb
+++ b/app/models/shipit/commit_deployment_status.rb
@@ -14,7 +14,7 @@ module Shipit
       response = begin
         create_status_on_github(stack.repository.github_api)
       rescue Octokit::ClientError
-        raise if Shipit.github(organization: stack.owner).api == stack.repository.github_api
+        raise if Shipit.github(organization: stack.repository.owner).api == stack.repository.github_api
         # If the deploy author didn't gave us the permission to create the deployment we falback the the main shipit
         # user.
         #

--- a/app/models/shipit/commit_deployment_status.rb
+++ b/app/models/shipit/commit_deployment_status.rb
@@ -12,15 +12,15 @@ module Shipit
     def create_on_github!
       return if github_id?
       response = begin
-        create_status_on_github(author.github_api)
+        create_status_on_github(stack.repository.github_api)
       rescue Octokit::ClientError
-        raise if Shipit.github.api == author.github_api
+        raise if Shipit.github(organization: stack.owner).api == stack.repository.github_api
         # If the deploy author didn't gave us the permission to create the deployment we falback the the main shipit
         # user.
         #
         # Octokit currently raise NotFound, but I'm convinced it should be Forbidden if the user can see the repository.
         # So to be future proof I catch boths.
-        create_status_on_github(Shipit.github.api)
+        create_status_on_github(stack.repository.github_api)
       end
       update!(github_id: response.id, api_url: response.url)
     end

--- a/app/models/shipit/merge_request.rb
+++ b/app/models/shipit/merge_request.rb
@@ -162,7 +162,7 @@ module Shipit
 
       raise NotReady if not_mergeable_yet?
 
-      stack.repository.github_api.merge_pull_request(
+      stack.github_api.merge_pull_request(
         stack.github_repo_name,
         number,
         merge_message,
@@ -171,8 +171,8 @@ module Shipit
         merge_method: stack.merge_method,
       )
       begin
-        if stack.repository.github_api.pull_requests(stack.github_repo_name, base: branch).empty?
-          stack.repository.github_api.delete_branch(stack.github_repo_name, branch)
+        if stack.github_api.pull_requests(stack.github_repo_name, base: branch).empty?
+          stack.github_api.delete_branch(stack.github_repo_name, branch)
         end
       rescue Octokit::UnprocessableEntity
         # branch was already deleted somehow
@@ -231,7 +231,7 @@ module Shipit
     end
 
     def refresh!
-      update!(github_pull_request: stack.repository.github_api.pull_request(stack.github_repo_name, number))
+      update!(github_pull_request: stack.github_api.pull_request(stack.github_repo_name, number))
       head.refresh_statuses!
       fetched! if fetching?
       @comparison = nil
@@ -270,7 +270,7 @@ module Shipit
     end
 
     def comparison
-      @comparison ||= stack.repository.github_api.compare(
+      @comparison ||= stack.github_api.compare(
         stack.github_repo_name,
         base_ref,
         head.sha,
@@ -293,7 +293,7 @@ module Shipit
       if commit = stack.commits.by_sha(sha)
         commit
       else
-        github_commit = stack.repository.github_api.commit(stack.github_repo_name, sha)
+        github_commit = stack.github_api.commit(stack.github_repo_name, sha)
         stack.commits.create_from_github!(github_commit, attributes)
       end
     rescue ActiveRecord::RecordNotUnique

--- a/app/models/shipit/merge_request.rb
+++ b/app/models/shipit/merge_request.rb
@@ -110,10 +110,11 @@ module Shipit
     end
 
     def self.extract_number(stack, number_or_url)
+      org = stack.repository.owner
       case number_or_url
       when /\A#?(\d+)\z/
         $1.to_i
-      when %r{\Ahttps://#{Regexp.escape(Shipit.github(organization: stack.owner).domain)}/([^/]+)/([^/]+)/pull/(\d+)}
+      when %r{\Ahttps://#{Regexp.escape(Shipit.github(organization: org).domain)}/([^/]+)/([^/]+)/pull/(\d+)}
         return unless $1.downcase == stack.repo_owner.downcase
         return unless $2.downcase == stack.repo_name.downcase
         $3.to_i

--- a/app/models/shipit/pull_request.rb
+++ b/app/models/shipit/pull_request.rb
@@ -53,7 +53,7 @@ module Shipit
       if commit = stack.commits.by_sha(sha)
         commit
       else
-        github_commit = stack.repository.github_api.commit(stack.github_repo_name, sha)
+        github_commit = stack.github_api.commit(stack.github_repo_name, sha)
         stack.commits.create_from_github!(github_commit)
       end
     rescue ActiveRecord::RecordNotUnique

--- a/app/models/shipit/pull_request.rb
+++ b/app/models/shipit/pull_request.rb
@@ -41,9 +41,9 @@ module Shipit
       self.state = github_pull_request.state
       self.additions = github_pull_request.additions
       self.deletions = github_pull_request.deletions
-      self.user = User.find_or_create_by_login!(stack.owner, github_pull_request.user.login)
+      self.user = User.find_or_create_by_login!(github_pull_request.user.login)
       self.assignees = github_pull_request.assignees.map do |github_user|
-        User.find_or_create_by_login!(stack.owner, github_user.login)
+        User.find_or_create_by_login!(github_user.login)
       end
       self.labels = github_pull_request.labels.map(&:name)
       self.head = find_or_create_commit_from_github_by_sha!(github_pull_request.head.sha)

--- a/app/models/shipit/pull_request.rb
+++ b/app/models/shipit/pull_request.rb
@@ -41,9 +41,9 @@ module Shipit
       self.state = github_pull_request.state
       self.additions = github_pull_request.additions
       self.deletions = github_pull_request.deletions
-      self.user = User.find_or_create_by_login!(github_pull_request.user.login)
+      self.user = User.find_or_create_by_login!(stack.owner, github_pull_request.user.login)
       self.assignees = github_pull_request.assignees.map do |github_user|
-        User.find_or_create_by_login!(github_user.login)
+        User.find_or_create_by_login!(stack.owner, github_user.login)
       end
       self.labels = github_pull_request.labels.map(&:name)
       self.head = find_or_create_commit_from_github_by_sha!(github_pull_request.head.sha)
@@ -53,7 +53,7 @@ module Shipit
       if commit = stack.commits.by_sha(sha)
         commit
       else
-        github_commit = Shipit.github.api.commit(stack.github_repo_name, sha)
+        github_commit = stack.repository.github_api.commit(stack.github_repo_name, sha)
         stack.commits.create_from_github!(github_commit)
       end
     rescue ActiveRecord::RecordNotUnique

--- a/app/models/shipit/release_status.rb
+++ b/app/models/shipit/release_status.rb
@@ -25,7 +25,7 @@ module Shipit
     private
 
     def create_status_on_github
-      Shipit.github.api.create_status(
+      stack.repository.github_api.create_status(
         stack.github_repo_name,
         commit.sha,
         state,

--- a/app/models/shipit/release_status.rb
+++ b/app/models/shipit/release_status.rb
@@ -25,7 +25,7 @@ module Shipit
     private
 
     def create_status_on_github
-      stack.repository.github_api.create_status(
+      stack.github_api.create_status(
         stack.github_repo_name,
         commit.sha,
         state,

--- a/app/models/shipit/repository.rb
+++ b/app/models/shipit/repository.rb
@@ -66,16 +66,8 @@ module Shipit
       [owner, name].join('/')
     end
 
-    def github_api
-      github_app_instance.api
-    end
-
-    def github_app_instance
-      Shipit.github(organization: owner)
-    end
-
     def http_url
-      github_app_instance.url(full_name)
+      github_app.url(full_name)
     end
 
     def full_name
@@ -83,7 +75,7 @@ module Shipit
     end
 
     def git_url
-      "https://#{github_app_instance.domain}/#{owner}/#{name}.git"
+      "https://#{github_app.domain}/#{owner}/#{name}.git"
     end
 
     def schedule_for_destroy!
@@ -100,6 +92,12 @@ module Shipit
         owner: repo_owner.downcase,
         name: repo_name.downcase,
       ).first!
+    end
+
+    protected
+
+    def github_app
+      Shipit.github(organization: owner)
     end
   end
 end

--- a/app/models/shipit/repository.rb
+++ b/app/models/shipit/repository.rb
@@ -66,8 +66,12 @@ module Shipit
       [owner, name].join('/')
     end
 
+    def github_api
+      github_app_instance.api
+    end
+
     def http_url
-      Shipit.github.url(full_name)
+      github_app_instance.url(full_name)
     end
 
     def full_name
@@ -75,7 +79,7 @@ module Shipit
     end
 
     def git_url
-      "https://#{Shipit.github.domain}/#{owner}/#{name}.git"
+      "https://#{github_app_instance.domain}/#{owner}/#{name}.git"
     end
 
     def schedule_for_destroy!
@@ -92,6 +96,12 @@ module Shipit
         owner: repo_owner.downcase,
         name: repo_name.downcase,
       ).first!
+    end
+
+    protected
+
+    def github_app_instance
+      Shipit.github(organization: owner)
     end
   end
 end

--- a/app/models/shipit/repository.rb
+++ b/app/models/shipit/repository.rb
@@ -70,6 +70,10 @@ module Shipit
       github_app_instance.api
     end
 
+    def github_app_instance
+      Shipit.github(organization: owner)
+    end
+
     def http_url
       github_app_instance.url(full_name)
     end
@@ -96,12 +100,6 @@ module Shipit
         owner: repo_owner.downcase,
         name: repo_name.downcase,
       ).first!
-    end
-
-    protected
-
-    def github_app_instance
-      Shipit.github(organization: owner)
     end
   end
 end

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -208,7 +208,7 @@ module Shipit
       end
 
       begin
-        trigger_deploy(commit, Shipit.user(repository.owner), env: cached_deploy_spec.default_deploy_env)
+        trigger_deploy(commit, Shipit.user, env: cached_deploy_spec.default_deploy_env)
       rescue Task::ConcurrentTaskRunning
       end
     end

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -208,7 +208,7 @@ module Shipit
       end
 
       begin
-        trigger_deploy(commit, Shipit.user, env: cached_deploy_spec.default_deploy_env)
+        trigger_deploy(commit, Shipit.user(repository.owner), env: cached_deploy_spec.default_deploy_env)
       rescue Task::ConcurrentTaskRunning
       end
     end
@@ -403,7 +403,7 @@ module Shipit
 
     def github_commits
       handle_github_redirections do
-        Shipit.github.api.commits(github_repo_name, sha: branch)
+        repository.github_api.commits(github_repo_name, sha: branch)
       end
     rescue Octokit::Conflict
       [] # Repository is empty...
@@ -421,9 +421,9 @@ module Shipit
     end
 
     def refresh_repository!
-      resource = Shipit.github.api.repo(github_repo_name)
+      resource = repository.github_api.repo(github_repo_name)
       if resource.try(:message) == 'Moved Permanently'
-        resource = Shipit.github.api.get(resource.url)
+        resource = repository.github_api.get(resource.url)
       end
       repository.update!(owner: resource.owner.login, name: resource.name)
     end

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -403,10 +403,18 @@ module Shipit
 
     def github_commits
       handle_github_redirections do
-        repository.github_api.commits(github_repo_name, sha: branch)
+        github_api.commits(github_repo_name, sha: branch)
       end
     rescue Octokit::Conflict
       [] # Repository is empty...
+    end
+
+    def github_api
+      github_app.api
+    end
+
+    def github_app
+      Shipit.github(organization: repository.owner)
     end
 
     def handle_github_redirections
@@ -421,9 +429,9 @@ module Shipit
     end
 
     def refresh_repository!
-      resource = repository.github_api.repo(github_repo_name)
+      resource = github_api.repo(github_repo_name)
       if resource.try(:message) == 'Moved Permanently'
-        resource = repository.github_api.get(resource.url)
+        resource = github_api.get(resource.url)
       end
       repository.update!(owner: resource.owner.login, name: resource.name)
     end

--- a/app/models/shipit/team.rb
+++ b/app/models/shipit/team.rb
@@ -27,7 +27,7 @@ module Shipit
 
       def find_team_on_github(organization, slug)
         gh_api = Shipit.github(organization: organization).api
-        teams = Shipit::OctokitIterator.new(github_client: gh_api) { gh_api.org_teams(organization, per_page: 100) }
+        teams = Shipit::OctokitIterator.new(github_api: gh_api) { gh_api.org_teams(organization, per_page: 100) }
         teams.find { |t| t.slug == slug }
       rescue Octokit::NotFound
       end
@@ -43,7 +43,7 @@ module Shipit
 
     def refresh_members!
       github_api = Shipit.github(organization: organization).api
-      github_members = Shipit::OctokitIterator.new(github_api.api.get(api_url).rels[:members])
+      github_members = Shipit::OctokitIterator.new(github_api.get(api_url).rels[:members])
       members = github_members.map { |u| User.find_or_create_from_github(u) }
       self.members = members
       save!

--- a/app/models/shipit/team.rb
+++ b/app/models/shipit/team.rb
@@ -26,7 +26,8 @@ module Shipit
       end
 
       def find_team_on_github(organization, slug)
-        teams = Shipit::OctokitIterator.new { Shipit.github.api.org_teams(organization, per_page: 100) }
+        gh_api = Shipit.github(organization: organization).api
+        teams = Shipit::OctokitIterator.new(github_client: gh_api) { gh_api.org_teams(organization, per_page: 100) }
         teams.find { |t| t.slug == slug }
       rescue Octokit::NotFound
       end
@@ -41,7 +42,8 @@ module Shipit
     end
 
     def refresh_members!
-      github_members = Shipit::OctokitIterator.new(Shipit.github.api.get(api_url).rels[:members])
+      github_api = Shipit.github(organization: organization).api
+      github_members = Shipit::OctokitIterator.new(github_api.api.get(api_url).rels[:members])
       members = github_members.map { |u| User.find_or_create_from_github(u) }
       self.members = members
       save!

--- a/app/models/shipit/user.rb
+++ b/app/models/shipit/user.rb
@@ -13,9 +13,11 @@ module Shipit
 
     attr_encrypted :github_access_token, key: Shipit.user_access_tokens_key
 
-    def self.find_or_create_by_login!(organization, login)
+    def self.find_or_create_by_login!(login)
       find_or_create_by!(login: login) do |user|
-        user.github_user = Shipit.github(organization: organization).api.user(login)
+        # Users are global, any app can be used
+        # This will not work for users that only exist in an Enterprise install
+        user.github_user = Shipit.github.api.user(login)
       end
     end
 
@@ -91,9 +93,9 @@ module Shipit
     end
 
     def refresh_from_github!
-      Shipit.github_config_organizations.each do |org|
-        update!(github_user: Shipit.github.api(organization: org).user(github_id))
-      end
+      # Users are global, any app can be used
+      # This will not work for users that only exist in an Enterprise install
+      update!(github_user: Shipit.github.api.user(github_id))
     rescue Octokit::NotFound
       identify_renamed_user!
     end

--- a/app/models/shipit/user.rb
+++ b/app/models/shipit/user.rb
@@ -13,9 +13,9 @@ module Shipit
 
     attr_encrypted :github_access_token, key: Shipit.user_access_tokens_key
 
-    def self.find_or_create_by_login!(login)
+    def self.find_or_create_by_login!(organization, login)
       find_or_create_by!(login: login) do |user|
-        user.github_user = Shipit.github.api.user(login)
+        user.github_user = Shipit.github(organization: organization).api.user(login)
       end
     end
 
@@ -91,7 +91,9 @@ module Shipit
     end
 
     def refresh_from_github!
-      update!(github_user: Shipit.github.api.user(github_id))
+      Shipit.github_config_organizations.each do |org|
+        update!(github_user: Shipit.github.api(organization: org).user(github_id))
+      end
     rescue Octokit::NotFound
       identify_renamed_user!
     end

--- a/app/models/shipit/webhooks/handlers/membership_handler.rb
+++ b/app/models/shipit/webhooks/handlers/membership_handler.rb
@@ -20,7 +20,7 @@ module Shipit
         end
         def process
           team = find_or_create_team!
-          member = User.find_or_create_by_login!(params.member.login)
+          member = User.find_or_create_by_login!(team.organization, params.member.login)
 
           case params.action
           when 'added'

--- a/app/models/shipit/webhooks/handlers/membership_handler.rb
+++ b/app/models/shipit/webhooks/handlers/membership_handler.rb
@@ -20,7 +20,7 @@ module Shipit
         end
         def process
           team = find_or_create_team!
-          member = User.find_or_create_by_login!(team.organization, params.member.login)
+          member = User.find_or_create_by_login!(params.member.login)
 
           case params.action
           when 'added'

--- a/app/models/shipit/webhooks/handlers/pull_request/review_stack_adapter.rb
+++ b/app/models/shipit/webhooks/handlers/pull_request/review_stack_adapter.rb
@@ -50,7 +50,7 @@ module Shipit
           end
 
           def user
-            @user ||= Shipit::User.find_or_create_by_login!(params.sender["login"])
+            @user ||= Shipit::User.find_or_create_by_login!(stack.owner, params.sender["login"])
           end
 
           private

--- a/app/models/shipit/webhooks/handlers/pull_request/review_stack_adapter.rb
+++ b/app/models/shipit/webhooks/handlers/pull_request/review_stack_adapter.rb
@@ -50,7 +50,7 @@ module Shipit
           end
 
           def user
-            @user ||= Shipit::User.find_or_create_by_login!(stack.owner, params.sender["login"])
+            @user ||= Shipit::User.find_or_create_by_login!(params.sender["login"])
           end
 
           private

--- a/config/secrets.development.example.yml
+++ b/config/secrets.development.example.yml
@@ -1,7 +1,7 @@
 host: 'localhost:3000'
 redis_url: 'redis://127.0.0.1:6379/0'
 
-# TODO: document creating a dev app
+# For creating an app see: https://github.com/Shopify/shipit-engine/blob/master/docs/setup.md#creating-the-github-app
 # Can be obtained there: https://github.com/settings/apps
 # Set the "Authorization callback URL" as `<host>/github/auth/github/callback`
 

--- a/config/secrets.development.example.yml
+++ b/config/secrets.development.example.yml
@@ -1,8 +1,10 @@
 host: 'localhost:3000'
 redis_url: 'redis://127.0.0.1:6379/0'
 
+# TODO: document creating a dev app
 # Can be obtained there: https://github.com/settings/apps
 # Set the "Authorization callback URL" as `<host>/github/auth/github/callback`
+
 github:
   app_id:
   installation_id:
@@ -12,3 +14,25 @@ github:
     id:
     secret:
     teams: # Optional
+
+# Use this configuration schema if you are configuring multiple Github applications for different Github organizations
+
+# github:
+#   somegithuborg:
+#     app_id:
+#     installation_id:
+#     webhook_secret: # nil
+#     private_key:
+#     oauth:
+#       id:
+#       secret:
+#       teams: # Optional
+#   someothergithuborg:
+#     app_id:
+#     installation_id:
+#     webhook_secret: # nil
+#     private_key:
+#     oauth:
+#       id:
+#       secret:
+#       teams: # Optional

--- a/config/secrets.development.shopify.yml
+++ b/config/secrets.development.shopify.yml
@@ -1,7 +1,8 @@
 host: 'shipit-engine.myshopify.io'
 redis_url: 'redis://shipit-engine.railgun:6379'
 
-# TODO: document creating a dev app
+# For creating an app see: https://github.com/Shopify/shipit-engine/blob/master/docs/setup.md#creating-the-github-app
+
 github:
   somegithuborg:
     app_id:

--- a/config/secrets.development.shopify.yml
+++ b/config/secrets.development.shopify.yml
@@ -3,14 +3,15 @@ redis_url: 'redis://shipit-engine.railgun:6379'
 
 # TODO: document creating a dev app
 github:
-  app_id:
-  installation_id:
-  webhook_secret: # nil
-  private_key:
-  oauth:
-    id:
-    secret:
-    teams:
+  somegithuborg:
+    app_id:
+    installation_id:
+    webhook_secret: # nil
+    private_key:
+    oauth:
+      id:
+      secret:
+      teams:
   someothergithuborg:
     app_id:
     installation_id:

--- a/config/secrets.development.shopify.yml
+++ b/config/secrets.development.shopify.yml
@@ -11,3 +11,12 @@ github:
     id:
     secret:
     teams:
+  someothergithuborg:
+    app_id:
+    installation_id:
+    webhook_secret: # nil
+    private_key:
+    oauth:
+      id:
+      secret:
+      teams:

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -160,6 +160,35 @@ production:
   update_latest_deployed_ref: true
 ```
 
+### Using Multiple Github Applications
+
+A Github application can only authenticate to the Github organization it's installed in. If you want to deploy code from multiple Github organizations the `github` section of your `config/secrets.yml` will need to be formatted differently. The top-level keys should be the name of each Github organization, and the following sub-keys are the Github app details for that particular organization.
+
+For example:
+
+```yml
+production:
+  github:
+    somegithuborg:
+      app_id:
+      installation_id:
+      webhook_secret:
+      private_key:
+      oauth:
+        id:
+        secret:
+        teams:
+    someothergithuborg:
+      app_id:
+      installation_id:
+      webhook_secret:
+      private_key:
+      oauth:
+        id:
+        secret:
+        teams:
+```
+
 ## Running Cron
 
 Shipit requires some periodic tasks to be executed to function properly. If you're running on Heroku, you can use the [Heroku Scheduler](https://devcenter.heroku.com/articles/scheduler) add on to run Shipit cron jobs, though it will only run at a maximum frequency of once every 10 minutes.

--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -138,7 +138,6 @@ module Shipit
     if github.bot_login
       User.find_or_create_by_login!(github.bot_login)
     else
-      # TODO: Anything needed here?
       AnonymousUser.new
     end
   end

--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -105,12 +105,13 @@ module Shipit
   end
 
   def github(organization: github_default_organization)
-    # Backwards compatibility
+    # Backward compatibility
+    # nil signifies the single github app config schema is being used
     if github_default_organization.nil?
       config = secrets.github
     else
       org = organization.to_sym
-      raise GithubOrganizationUnknown if secrets.github[org].nil?
+      raise GithubOrganizationUnknown, org if secrets.github[org].nil?
       config = secrets.github[org]
     end
     @github ||= {}
@@ -118,12 +119,12 @@ module Shipit
   end
 
   def github_default_organization
-    # github_config_organizations.first
-    org = github_config_organizations.first
+    org = secrets.github.keys.first
     TOP_LEVEL_GH_KEYS.include?(org) ? nil : org
   end
 
-  def github_config_organizations
+  def github_organizations
+    return [nil] unless github_default_organization
     secrets.github.keys
   end
 
@@ -133,9 +134,9 @@ module Shipit
     end
   end
 
-  def user(organization)
+  def user
     if github.bot_login
-      User.find_or_create_by_login!(organization, github.bot_login)
+      User.find_or_create_by_login!(github.bot_login)
     else
       # TODO: Anything needed here?
       AnonymousUser.new

--- a/lib/shipit/github_app.rb
+++ b/lib/shipit/github_app.rb
@@ -42,8 +42,9 @@ module Shipit
 
     attr_reader :oauth_teams, :domain, :bot_login
 
-    def initialize(config)
+    def initialize(organization, config)
       super()
+      @organization = organization
       @config = (config || {}).with_indifferent_access
       @domain = @config[:domain] || DOMAIN
       @webhook_secret = @config[:webhook_secret].presence
@@ -85,7 +86,7 @@ module Shipit
 
     def token
       return 't0kEn' if Rails.env.test? # TODO: figure out something cleaner
-      return unless private_key && app_id && installation_id
+      return unless private_key && @organization && installation_id
 
       @token = @token.presence || synchronize { @token.presence || fetch_new_token }
       @token.to_s
@@ -95,7 +96,7 @@ module Shipit
       # Rails can add 5 minutes to the cache entry expiration time when any TTL is provided,
       # so our TTL setting can be lower, and TTL + expires_in should be lower than the GitHub token expiration.
       Rails.cache.fetch(
-        'github:integration:access-token',
+        "github:integration:#{@organization}:access-token",
         expires_in: GITHUB_TOKEN_RAILS_CACHE_LIFETIME,
         race_condition_ttl: 4.minutes,
       ) do
@@ -181,15 +182,15 @@ module Shipit
     end
 
     def app_id
-      @app_id ||= @config.fetch(:app_id)
+      @config.fetch(:app_id)
     end
 
     def installation_id
-      @installation_id ||= @config.fetch(:installation_id)
+      @config.fetch(:installation_id)
     end
 
     def private_key
-      @private_key ||= @config.fetch(:private_key)
+      @config.fetch(:private_key)
     end
 
     def authentication_payload

--- a/lib/shipit/github_app.rb
+++ b/lib/shipit/github_app.rb
@@ -86,17 +86,18 @@ module Shipit
 
     def token
       return 't0kEn' if Rails.env.test? # TODO: figure out something cleaner
-      return unless private_key && @organization && installation_id
+      return unless private_key && app_id && installation_id
 
       @token = @token.presence || synchronize { @token.presence || fetch_new_token }
       @token.to_s
     end
 
     def fetch_new_token
+      cache_key = @organization.nil? ? '' : "#{@organization.downcase}:"
       # Rails can add 5 minutes to the cache entry expiration time when any TTL is provided,
       # so our TTL setting can be lower, and TTL + expires_in should be lower than the GitHub token expiration.
       Rails.cache.fetch(
-        "github:integration:#{@organization}:access-token",
+        "github:integration:#{cache_key}access-token",
         expires_in: GITHUB_TOKEN_RAILS_CACHE_LIFETIME,
         race_condition_ttl: 4.minutes,
       ) do

--- a/lib/shipit/octokit_iterator.rb
+++ b/lib/shipit/octokit_iterator.rb
@@ -3,12 +3,12 @@ module Shipit
   class OctokitIterator
     include Enumerable
 
-    def initialize(relation = nil)
+    def initialize(relation = nil, github_client: nil)
       if relation
         @response = relation.get(per_page: 100)
       else
-        data = yield Shipit.github.api
-        @response = Shipit.github.api.last_response if data.present?
+        data = yield github_client
+        @response = github_client.last_response if data.present?
       end
     end
 

--- a/lib/shipit/octokit_iterator.rb
+++ b/lib/shipit/octokit_iterator.rb
@@ -3,12 +3,12 @@ module Shipit
   class OctokitIterator
     include Enumerable
 
-    def initialize(relation = nil, github_client: nil)
+    def initialize(relation = nil, github_api: nil)
       if relation
         @response = relation.get(per_page: 100)
       else
-        data = yield github_client
-        @response = github_client.last_response if data.present?
+        data = yield github_api
+        @response = github_api.last_response if data.present?
       end
     end
 

--- a/test/controllers/webhooks_controller_test.rb
+++ b/test/controllers/webhooks_controller_test.rb
@@ -10,7 +10,7 @@ module Shipit
 
     test "create github repository which is not yet present in the datastore" do
       request.headers['X-Github-Event'] = 'push'
-      unknown_repo_payload = JSON.parse(payload(:push_master))
+      unknown_repo_payload = JSON.parse(payload(:push_master)).merge(stack_params)
       unknown_repo_payload["repository"]["full_name"] = "owner/unknown-repository"
       unknown_repo_payload = unknown_repo_payload.to_json
 
@@ -22,14 +22,15 @@ module Shipit
     test ":push with the target branch queues a GithubSyncJob" do
       request.headers['X-Github-Event'] = 'push'
 
+      body = JSON.parse(payload(:push_master)).merge(stack_params).to_json
       assert_enqueued_with(job: GithubSyncJob, args: [stack_id: @stack.id]) do
-        post :create, body: payload(:push_master), as: :json
+        post :create, body: body, as: :json
       end
     end
 
     test ":push does not enqueue a job if not the target branch" do
       request.headers['X-Github-Event'] = 'push'
-      params = payload(:push_not_master)
+      params = JSON.parse(payload(:push_not_master)).merge(stack_params).to_json
       assert_no_enqueued_jobs do
         post :create, body: params, as: :json
       end
@@ -40,8 +41,9 @@ module Shipit
 
       commit = shipit_commits(:first)
 
+      body = JSON.parse(payload(:status_master)).merge(stack_params).to_json
       assert_difference 'commit.statuses.count', 1 do
-        post :create, body: payload(:status_master), as: :json
+        post :create, body: body, as: :json
       end
 
       status = commit.statuses.last
@@ -55,14 +57,14 @@ module Shipit
 
     test ":state with a unexisting commit respond with 200 OK" do
       request.headers['X-Github-Event'] = 'status'
-      params = { 'sha' => 'notarealcommit', 'state' => 'pending', 'branches' => [{ 'name' => 'master' }] }.to_json
+      params = { 'sha' => 'notarealcommit', 'state' => 'pending', 'branches' => [{ 'name' => 'master' }] }.merge(stack_params).to_json
       post :create, body: params, as: :json
       assert_response :ok
     end
 
     test ":state in an untracked branche bails out" do
       request.headers['X-Github-Event'] = 'status'
-      params = { 'sha' => 'notarealcommit', 'state' => 'pending', 'branches' => [] }.to_json
+      params = { 'sha' => 'notarealcommit', 'state' => 'pending', 'branches' => [] }.merge(stack_params).to_json
       post :create, body: params, as: :json
       assert_response :ok
     end
@@ -70,8 +72,9 @@ module Shipit
     test ":check_suite with the target branch queues a RefreshCheckRunsJob" do
       request.headers['X-Github-Event'] = 'check_suite'
 
+      body = JSON.parse(payload(:check_suite_master)).merge(stack_params).to_json
       assert_enqueued_with(job: RefreshCheckRunsJob) do
-        post :create, body: payload(:check_suite_master), as: :json
+        post :create, body: body, as: :json
         assert_response :ok
       end
     end
@@ -88,13 +91,13 @@ module Shipit
     test "verifies webhook signature" do
       commit = shipit_commits(:first)
 
-      payload = { "sha" => commit.sha, "state" => "pending", "target_url" => "https://ci.example.com/1000/output" }.to_json
+      payload = { "sha" => commit.sha, "state" => "pending", "target_url" => "https://ci.example.com/1000/output" }.merge(stack_params).to_json
       signature = 'sha1=4848deb1c9642cd938e8caa578d201ca359a8249'
 
       @request.headers['X-Github-Event'] = 'push'
       @request.headers['X-Hub-Signature'] = signature
 
-      Shipit.github.expects(:verify_webhook_signature).with(signature, payload).returns(false)
+      Shipit.github(organization: 'shopify').expects(:verify_webhook_signature).with(signature, payload).returns(false)
 
       post :create, body: payload, as: :json
       assert_response :unprocessable_entity
@@ -168,15 +171,19 @@ module Shipit
     private
 
     def pull_request_params
-      { action: 'opened', number: 2, pull_request: 'foobar' }
+      { action: 'opened', number: 2, pull_request: 'foobar' }.merge(stack_params)
     end
 
     def membership_params
-      { action: 'added', team: team_params, organization: { login: 'shopify' }, member: { login: 'walrus' } }
+      { action: 'added', team: team_params, organization: { login: 'shopify' }, member: { login: 'walrus' } }.merge(stack_params)
     end
 
     def team_params
       { id: shipit_teams(:shopify_developers).id, slug: 'developers', name: 'Developers', url: 'http://example.com' }
+    end
+
+    def stack_params
+      { stack_id: @stack.id }
     end
 
     def george

--- a/test/dummy/config/secrets_double_github_app.yml
+++ b/test/dummy/config/secrets_double_github_app.yml
@@ -1,0 +1,79 @@
+  github:
+    OrgOne:
+      domain: # defaults to github.com
+      app_id: 42
+      installation_id: 43
+      bot_login: "shipit[bot]"
+      webhook_secret: # nil
+      # Randomly generated
+      private_key: |
+        -----BEGIN RSA PRIVATE KEY-----
+        MIIEpAIBAAKCAQEA7iUQC2uUq/gtQg0gxtyaccuicYgmq1LUr1mOWbmwM1Cv63+S
+        73qo8h87FX+YyclY5fZF6SMXIys02JOkImGgbnvEOLcHnImCYrWs03msOzEIO/pG
+        M0YedAPtQ2MEiLIu4y8htosVxeqfEOPiq9kQgFxNKyETzjdIA9q1md8sofuJUmPv
+        ibacW1PecuAMnn+P8qf0XIDp7uh6noB751KvhCaCNTAPtVE9NZ18OmNG9GOyX/pu
+        pQHIrPgTpTG6KlAe3r6LWvemzwsMtuRGU+K+KhK9dFIlSE+v9rA32KScO8efOh6s
+        Gu3rWorV4iDu14U62rzEfdzzc63YL94sUbZxbwIDAQABAoIBADLJ8r8MxZtbhYN1
+        u0zOFZ45WL6v09dsBfITvnlCUeLPzYUDIzoxxcBFittN6C744x3ARS6wjimw+EdM
+        TZALlCSb/sA9wMDQzt7wchhz9Zh2H5RzDu+2f54sjDh38KqancdT8PO2fAFGxX/b
+        qicOVyeZB9gv6MJtJc20olBbuXAeBNfcDABF9oxF+0i+Ssg7B4VXiqgcjtGbr/Og
+        qRll7AqyTArVx2xEcVfZxeZ4zGnigzcJq4te7yYpxzwk+RxblkPh54Yt4WxZ+8DI
+        Rsn3r6ajlpwzpwvsJFU2Txq7xBTzGQMFmy/Pnjk83kP2cogxB2+tRyjITGqTwD8b
+        gg9PFCkCgYEA+7u8A0l0Cz6p0SI6c7ftVePVRiIhpawWN7og/wEmI6zUjm/3rA+R
+        hrhaVKuOD8QF/HdDsqTck5gjGAjTmJz6r33/cl1Tz+pr62znsrB4r0yMKvQbKN81
+        WGaWOsi2+ZXqLNv5h5wpUF0MTKlXHeKnwP5kuEvGwVn6WURFCh6PhLMCgYEA8i5e
+        JjulJVGyd5HuoY3xyO7E6DjidsqRnVRq+hYpORjnHvTmSwe4+tH4ha2p9Kv2Y6k3
+        C1NYY/fSMQoYCCRaYyJleI+la/9tsZqAmtms4ZB8KhFmPHf9fW75i6G0xKWyZ8K+
+        E2Ft/UaEiM282593cguV6+Kt5uExnyPxLLK4FlUCgYEAwRJ/JGI8/7bjFkTTYheq
+        j5q75BufhOrU6471acAe2XPgXxLfefdC3Xodxh0CS3NESBvNL4Ikr4sbN37lk4Kq
+        /th7iOKtuqUIeru/hZy2I3VpeDRbdGCmEJQ2GwYA2LKztg5Nd0Y9paaIHXAwIfrK
+        QUqcQ4HTAk8ZpUeoUBeaaeMCgYANLmbjb9WiPVsYVPIHCwHA7PX8qbPxwT7BsGmO
+        KQyfVfKmZa/vH4F67Vi4deZNMdrcO8aKMEQcVM2065a5QrlEsgeR00eupB1lUEJ1
+        qylUsZeAdqf43JMIc7TTW77KATa/nQLZbTEeWus1wvTngztuEqFbUGAks9cOkVc8
+        FpIcbQKBgQDVIL8gPLmn0f+4oLF8MBC+oxtKpz14X5iJ1saGFkzW5I+nIEskpS0S
+        qtirnTCnJFGdCrFwctnxiuiCmyGwpBYdjIfHyvYAHnqAtMnESzCUyeSFZiquVW5W
+        MvbMmDPoV27XOHU9kIq6NXtfrkpufiyo6/VEYWozXalxKLNuqLYfPQ==
+        -----END RSA PRIVATE KEY-----
+      oauth:
+        id: Iv1.bf2c2c45b449bfd9
+        secret: ef694cd6e45223075d78d138ef014049052665f1
+        teams:
+    OrgTwo:
+      domain: # defaults to github.com
+      app_id: 42
+      installation_id: 43
+      bot_login: "shipit[bot]"
+      webhook_secret: # nil
+      # Randomly generated
+      private_key: |
+        -----BEGIN RSA PRIVATE KEY-----
+        MIIEpAIBAAKCAQEA7iUQC2uUq/gtQg0gxtyaccuicYgmq1LUr1mOWbmwM1Cv63+S
+        73qo8h87FX+YyclY5fZF6SMXIys02JOkImGgbnvEOLcHnImCYrWs03msOzEIO/pG
+        M0YedAPtQ2MEiLIu4y8htosVxeqfEOPiq9kQgFxNKyETzjdIA9q1md8sofuJUmPv
+        ibacW1PecuAMnn+P8qf0XIDp7uh6noB751KvhCaCNTAPtVE9NZ18OmNG9GOyX/pu
+        pQHIrPgTpTG6KlAe3r6LWvemzwsMtuRGU+K+KhK9dFIlSE+v9rA32KScO8efOh6s
+        Gu3rWorV4iDu14U62rzEfdzzc63YL94sUbZxbwIDAQABAoIBADLJ8r8MxZtbhYN1
+        u0zOFZ45WL6v09dsBfITvnlCUeLPzYUDIzoxxcBFittN6C744x3ARS6wjimw+EdM
+        TZALlCSb/sA9wMDQzt7wchhz9Zh2H5RzDu+2f54sjDh38KqancdT8PO2fAFGxX/b
+        qicOVyeZB9gv6MJtJc20olBbuXAeBNfcDABF9oxF+0i+Ssg7B4VXiqgcjtGbr/Og
+        qRll7AqyTArVx2xEcVfZxeZ4zGnigzcJq4te7yYpxzwk+RxblkPh54Yt4WxZ+8DI
+        Rsn3r6ajlpwzpwvsJFU2Txq7xBTzGQMFmy/Pnjk83kP2cogxB2+tRyjITGqTwD8b
+        gg9PFCkCgYEA+7u8A0l0Cz6p0SI6c7ftVePVRiIhpawWN7og/wEmI6zUjm/3rA+R
+        hrhaVKuOD8QF/HdDsqTck5gjGAjTmJz6r33/cl1Tz+pr62znsrB4r0yMKvQbKN81
+        WGaWOsi2+ZXqLNv5h5wpUF0MTKlXHeKnwP5kuEvGwVn6WURFCh6PhLMCgYEA8i5e
+        JjulJVGyd5HuoY3xyO7E6DjidsqRnVRq+hYpORjnHvTmSwe4+tH4ha2p9Kv2Y6k3
+        C1NYY/fSMQoYCCRaYyJleI+la/9tsZqAmtms4ZB8KhFmPHf9fW75i6G0xKWyZ8K+
+        E2Ft/UaEiM282593cguV6+Kt5uExnyPxLLK4FlUCgYEAwRJ/JGI8/7bjFkTTYheq
+        j5q75BufhOrU6471acAe2XPgXxLfefdC3Xodxh0CS3NESBvNL4Ikr4sbN37lk4Kq
+        /th7iOKtuqUIeru/hZy2I3VpeDRbdGCmEJQ2GwYA2LKztg5Nd0Y9paaIHXAwIfrK
+        QUqcQ4HTAk8ZpUeoUBeaaeMCgYANLmbjb9WiPVsYVPIHCwHA7PX8qbPxwT7BsGmO
+        KQyfVfKmZa/vH4F67Vi4deZNMdrcO8aKMEQcVM2065a5QrlEsgeR00eupB1lUEJ1
+        qylUsZeAdqf43JMIc7TTW77KATa/nQLZbTEeWus1wvTngztuEqFbUGAks9cOkVc8
+        FpIcbQKBgQDVIL8gPLmn0f+4oLF8MBC+oxtKpz14X5iJ1saGFkzW5I+nIEskpS0S
+        qtirnTCnJFGdCrFwctnxiuiCmyGwpBYdjIfHyvYAHnqAtMnESzCUyeSFZiquVW5W
+        MvbMmDPoV27XOHU9kIq6NXtfrkpufiyo6/VEYWozXalxKLNuqLYfPQ==
+        -----END RSA PRIVATE KEY-----
+      oauth:
+        id: Iv1.bf2c2c45b449bfd9
+        secret: ef694cd6e45223075d78d138ef014049052665f1
+        teams:

--- a/test/jobs/github_sync_job_test.rb
+++ b/test/jobs/github_sync_job_test.rb
@@ -91,7 +91,7 @@ module Shipit
       last = stub(sha: 123)
       first = stub(sha: 345)
       Shipit::FirstParentCommitsIterator.any_instance.stubs(:each).multiple_yields(last, first)
-      @job.stubs(lookup_commit: nil)
+      @job.stubs(lookup_commit: nil, stack: @stack)
 
       commits, parent = @job.fetch_missing_commits { stub }
       assert_nil parent
@@ -104,6 +104,7 @@ module Shipit
       Shipit::FirstParentCommitsIterator.any_instance.stubs(:each).multiple_yields(last, first)
       @job.stubs(:lookup_commit).with(123).returns(nil)
       @job.stubs(:lookup_commit).with(345).returns(first)
+      @job.stubs(stack: @stack)
 
       commits, parent = @job.fetch_missing_commits { stub }
       assert_equal first, parent

--- a/test/models/commit_deployment_status_test.rb
+++ b/test/models/commit_deployment_status_test.rb
@@ -12,7 +12,7 @@ module Shipit
 
     test 'creation on GitHub' do
       response = stub(id: 44, url: 'https://example.com')
-      @author.github_api.expects(:create_deployment_status).with(
+      @author.github_api.class.any_instance.expects(:create_deployment_status).with(
         @deployment.api_url,
         'in_progress',
         accept: "application/vnd.github.flash-preview+json",
@@ -33,7 +33,7 @@ module Shipit
       status = deployment.statuses.create!(status: 'success')
       status.stubs(:description).returns('desc' * limit)
       create_status_response = stub(id: 'abcd', url: 'https://github.com/status/abcd')
-      status.author.github_api.expects(:create_deployment_status).with do |_url, _status, kwargs|
+      status.author.github_api.class.any_instance.expects(:create_deployment_status).with do |_url, _status, kwargs|
         kwargs[:description].size <= limit
       end.returns(create_status_response)
 
@@ -47,7 +47,7 @@ module Shipit
       stack = status.stack
       stack.deploy_url = "stack-deploy-url"
       create_status_response = stub(id: 'abcd', url: 'https://github.com/status/abcd')
-      status.author.github_api.expects(:create_deployment_status).with do |_url, _status, kwargs|
+      status.author.github_api.class.any_instance.expects(:create_deployment_status).with do |_url, _status, kwargs|
         kwargs[:environment_url] == 'stack-deploy-url'
       end.returns(create_status_response)
 

--- a/test/models/merge_request_test.rb
+++ b/test/models/merge_request_test.rb
@@ -60,7 +60,7 @@ module Shipit
 
       assert_nil MergeRequest.extract_number(@stack, 'https://github.com/ACME/shipit-engine/pull/42')
 
-      Shipit.github.expects(:domain).returns('github.acme.com').at_least_once
+      Shipit.github.class.any_instance.expects(:domain).returns('github.acme.com').at_least_once
       assert_equal 42, MergeRequest.extract_number(@stack, 'https://github.acme.com/Shopify/shipit-engine/pull/42')
       assert_nil MergeRequest.extract_number(@stack, 'https://github.com/Shopify/shipit-engine/pull/42')
     end

--- a/test/unit/github_app_test.rb
+++ b/test/unit/github_app_test.rb
@@ -18,7 +18,7 @@ module Shipit
 
     test "#initialize doesn't raise if given an empty config" do
       assert_nothing_raised do
-        GitHubApp.new({})
+        GitHubApp.new(nil, {})
       end
     end
 
@@ -183,7 +183,6 @@ module Shipit
           .any_instance
           .expects(:create_app_installation_access_token).with(config[:installation_id], anything)
           .returns(second_token)
-
         first_token = valid_app.token
 
         first_cached_token = Rails.cache.fetch(@token_cache_key)
@@ -199,7 +198,7 @@ module Shipit
     private
 
     def app(extra_config = {})
-      GitHubApp.new(default_config.deep_merge(extra_config))
+      GitHubApp.new(nil, default_config.deep_merge(extra_config))
     end
 
     def default_config

--- a/test/unit/github_apps_test.rb
+++ b/test/unit/github_apps_test.rb
@@ -1,0 +1,416 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module Shipit
+  class GitHubAppsTestOrgOne < ActiveSupport::TestCase
+    setup do
+      @organization = "OrgOne"
+      @github = app(@organization)
+      @enterprise = app(@organization, domain: 'github.example.com')
+      @rails_env = Rails.env
+      @token_cache_key = "github:integration:#{@organization.downcase}:access-token"
+      Rails.cache.delete(@token_cache_key)
+    end
+
+    teardown do
+      Rails.env = @rails_env
+      Rails.cache.delete(@token_cache_key)
+    end
+
+    test "#domain defaults to github.com" do
+      assert_equal 'github.com', @github.domain
+    end
+
+    test "#url returns the HTTPS url to the github installation" do
+      assert_equal 'https://github.example.com', @enterprise.url
+      assert_equal 'https://github.example.com/foo/bar', @enterprise.url('/foo/bar')
+      assert_equal 'https://github.example.com/foo/bar/baz', @enterprise.url('foo/bar', 'baz')
+    end
+
+    test "#new_client retruns an Octokit::Client configured to use the github installation" do
+      assert_equal 'https://github.example.com/', @enterprise.new_client.web_endpoint
+      assert_equal 'https://github.example.com/api/v3/', @enterprise.new_client.api_endpoint
+    end
+
+    test "#oauth_config.last[:client_options] is nil if domain is not overriden" do
+      assert_nil @github.oauth_config.last[:client_options][:site]
+    end
+
+    test "#oauth_config.last[:client_options] returns Enterprise endpoint if domain is overriden" do
+      assert_equal 'https://github.example.com/api/v3/', @enterprise.oauth_config.last[:client_options][:site]
+    end
+
+    test "#initialize doesn't raise if given an empty config" do
+      assert_nothing_raised do
+        GitHubApp.new(@organization, {})
+      end
+    end
+
+    test "#api_status" do
+      stub_request(:get, "https://www.githubstatus.com/api/v2/components.json").to_return(
+        status: 200,
+        body: %(
+          {
+            "page":{},
+            "components":[
+              {
+                "id":"brv1bkgrwx7q",
+                "name":"API Requests",
+                "status":"operational",
+                "created_at":"2017-01-31T20:01:46.621Z",
+                "updated_at":"2019-07-23T18:41:18.197Z",
+                "position":2,
+                "description":"Requests for GitHub APIs",
+                "showcase":false,
+                "group_id":null,
+                "page_id":"kctbh9vrtdwd",
+                "group":false,
+                "only_show_if_degraded":false
+              }
+            ]
+          }
+        ),
+      )
+      assert_equal "operational", app(@organization).api_status[:status]
+    end
+
+    test "#github token is refreshed after expiration" do
+      Rails.env = 'not_test'
+      config = {
+        app_id: "test_id",
+        installation_id: "test_installation_id",
+        private_key: "test_private_key",
+      }
+      initial_token = OpenStruct.new(
+        token: "some_initial_github_token",
+        expires_at: Time.now.utc + 60.minutes,
+      )
+      second_token = OpenStruct.new(
+        token: "some_new_github_token",
+        expires_at: initial_token.expires_at + 60.minutes,
+      )
+      auth_payload = "test_auth_payload"
+
+      GitHubApp.any_instance.expects(:authentication_payload).twice.returns(auth_payload)
+      valid_app = app(@organization, config)
+
+      freeze_time do
+        Octokit::Client
+          .any_instance
+          .expects(:create_app_installation_access_token).twice.with(config[:installation_id], anything)
+          .returns(initial_token, second_token)
+
+        initial_token = valid_app.token
+        initial_cached_token = Rails.cache.fetch(@token_cache_key)
+        assert_equal initial_token, initial_cached_token.to_s
+
+        travel 5.minutes
+        assert_equal initial_token, valid_app.token
+
+        travel_to initial_cached_token.expires_at + 5.minutes
+        assert_equal second_token.token, valid_app.token
+      end
+    end
+
+    test "#github token is refreshed in refresh window before expiry" do
+      Rails.env = 'not_test'
+      config = {
+        app_id: "test_id",
+        installation_id: "test_installation_id",
+        private_key: "test_private_key",
+      }
+      initial_token = OpenStruct.new(
+        token: "some_initial_github_token",
+        expires_at: Time.now.utc + 60.minutes,
+      )
+      second_token = OpenStruct.new(
+        token: "some_new_github_token",
+        expires_at: initial_token.expires_at + 60.minutes,
+      )
+      auth_payload = "test_auth_payload"
+
+      GitHubApp.any_instance.expects(:authentication_payload).twice.returns(auth_payload)
+      valid_app = app(@organization, config)
+
+      freeze_time do
+        Octokit::Client
+          .any_instance
+          .expects(:create_app_installation_access_token).twice.with(config[:installation_id], anything)
+          .returns(initial_token, second_token)
+
+        initial_token = valid_app.token
+        initial_cached_token = Rails.cache.fetch(@token_cache_key)
+        assert_equal initial_token, initial_cached_token.to_s
+
+        # Travel forward, but before the token is refreshed, so the cached value should be the same.
+        travel 40.minutes
+        assert_equal initial_token, valid_app.token
+
+        # Travel to when the token should refresh, but is not expired, which should result in our cache.fetch update block.
+        travel 15.minutes
+        updated_token = valid_app.token
+        assert_not_equal initial_token, updated_token
+
+        cached_token = Rails.cache.fetch(@token_cache_key)
+        assert_operator cached_token.expires_at, :>, initial_cached_token.expires_at
+      end
+    end
+
+    test "#github token is missing refresh_at field" do
+      # $debugging = true
+      Rails.env = 'not_test'
+      config = {
+        app_id: "test_id",
+        installation_id: "test_installation_id",
+        private_key: "test_private_key",
+      }
+      initial_cached_token = Shipit::GitHubApp::Token.new("some_initial_github_token", Time.now.utc - 1.minute)
+      initial_cached_token.instance_variable_set(:@refresh_at, nil)
+
+      second_token = OpenStruct.new(
+        token: "some_new_github_token",
+        expires_at: initial_cached_token.expires_at + 60.minutes,
+      )
+      auth_payload = "test_auth_payload"
+
+      GitHubApp.any_instance.expects(:authentication_payload).returns(auth_payload)
+      valid_app = app(@organization, config)
+
+      freeze_time do
+        valid_app.instance_variable_set(:@token, initial_cached_token)
+        Rails.cache.write(@token_cache_key, initial_cached_token, expires_in: 1.minute)
+
+        Octokit::Client
+          .any_instance
+          .expects(:create_app_installation_access_token).with(config[:installation_id], anything)
+          .returns(second_token)
+
+        first_token = valid_app.token
+
+        first_cached_token = Rails.cache.fetch(@token_cache_key)
+        assert_equal first_token, first_cached_token.to_s
+
+        travel_to first_cached_token.expires_at + 5.minutes
+        new_token = valid_app.token
+
+        assert_equal second_token.token, new_token
+      end
+    end
+
+    private
+
+    def app(organization, extra_config = {})
+      GitHubApp.new(organization, double_github_app_config.deep_merge(extra_config))
+    end
+
+    def double_github_app_config
+      YAML.load_file('test/dummy/config/secrets_double_github_app.yml')
+    end
+  end
+
+  class GitHubAppsTestOrgTwo < ActiveSupport::TestCase
+    setup do
+      @organization = "OrgTwo"
+      @github = app(@organization)
+      @enterprise = app(@organization, domain: 'github.example.com')
+      @rails_env = Rails.env
+      @token_cache_key = "github:integration:#{@organization.downcase}:access-token"
+      Rails.cache.delete(@token_cache_key)
+    end
+
+    teardown do
+      Rails.env = @rails_env
+      Rails.cache.delete(@token_cache_key)
+    end
+
+    test "#domain defaults to github.com" do
+      assert_equal 'github.com', @github.domain
+    end
+
+    test "#url returns the HTTPS url to the github installation" do
+      assert_equal 'https://github.example.com', @enterprise.url
+      assert_equal 'https://github.example.com/foo/bar', @enterprise.url('/foo/bar')
+      assert_equal 'https://github.example.com/foo/bar/baz', @enterprise.url('foo/bar', 'baz')
+    end
+
+    test "#new_client retruns an Octokit::Client configured to use the github installation" do
+      assert_equal 'https://github.example.com/', @enterprise.new_client.web_endpoint
+      assert_equal 'https://github.example.com/api/v3/', @enterprise.new_client.api_endpoint
+    end
+
+    test "#oauth_config.last[:client_options] is nil if domain is not overriden" do
+      assert_nil @github.oauth_config.last[:client_options][:site]
+    end
+
+    test "#oauth_config.last[:client_options] returns Enterprise endpoint if domain is overriden" do
+      assert_equal 'https://github.example.com/api/v3/', @enterprise.oauth_config.last[:client_options][:site]
+    end
+
+    test "#initialize doesn't raise if given an empty config" do
+      assert_nothing_raised do
+        GitHubApp.new(@organization, {})
+      end
+    end
+
+    test "#api_status" do
+      stub_request(:get, "https://www.githubstatus.com/api/v2/components.json").to_return(
+        status: 200,
+        body: %(
+          {
+            "page":{},
+            "components":[
+              {
+                "id":"brv1bkgrwx7q",
+                "name":"API Requests",
+                "status":"operational",
+                "created_at":"2017-01-31T20:01:46.621Z",
+                "updated_at":"2019-07-23T18:41:18.197Z",
+                "position":2,
+                "description":"Requests for GitHub APIs",
+                "showcase":false,
+                "group_id":null,
+                "page_id":"kctbh9vrtdwd",
+                "group":false,
+                "only_show_if_degraded":false
+              }
+            ]
+          }
+        ),
+      )
+      assert_equal "operational", app(@organization).api_status[:status]
+    end
+
+    test "#github token is refreshed after expiration" do
+      Rails.env = 'not_test'
+      config = {
+        app_id: "test_id",
+        installation_id: "test_installation_id",
+        private_key: "test_private_key",
+      }
+      initial_token = OpenStruct.new(
+        token: "some_initial_github_token",
+        expires_at: Time.now.utc + 60.minutes,
+      )
+      second_token = OpenStruct.new(
+        token: "some_new_github_token",
+        expires_at: initial_token.expires_at + 60.minutes,
+      )
+      auth_payload = "test_auth_payload"
+
+      GitHubApp.any_instance.expects(:authentication_payload).twice.returns(auth_payload)
+      valid_app = app(@organization, config)
+
+      freeze_time do
+        Octokit::Client
+          .any_instance
+          .expects(:create_app_installation_access_token).twice.with(config[:installation_id], anything)
+          .returns(initial_token, second_token)
+
+        initial_token = valid_app.token
+        initial_cached_token = Rails.cache.fetch(@token_cache_key)
+        assert_equal initial_token, initial_cached_token.to_s
+
+        travel 5.minutes
+        assert_equal initial_token, valid_app.token
+
+        travel_to initial_cached_token.expires_at + 5.minutes
+        assert_equal second_token.token, valid_app.token
+      end
+    end
+
+    test "#github token is refreshed in refresh window before expiry" do
+      Rails.env = 'not_test'
+      config = {
+        app_id: "test_id",
+        installation_id: "test_installation_id",
+        private_key: "test_private_key",
+      }
+      initial_token = OpenStruct.new(
+        token: "some_initial_github_token",
+        expires_at: Time.now.utc + 60.minutes,
+      )
+      second_token = OpenStruct.new(
+        token: "some_new_github_token",
+        expires_at: initial_token.expires_at + 60.minutes,
+      )
+      auth_payload = "test_auth_payload"
+
+      GitHubApp.any_instance.expects(:authentication_payload).twice.returns(auth_payload)
+      valid_app = app(@organization, config)
+
+      freeze_time do
+        Octokit::Client
+          .any_instance
+          .expects(:create_app_installation_access_token).twice.with(config[:installation_id], anything)
+          .returns(initial_token, second_token)
+
+        initial_token = valid_app.token
+        initial_cached_token = Rails.cache.fetch(@token_cache_key)
+        assert_equal initial_token, initial_cached_token.to_s
+
+        # Travel forward, but before the token is refreshed, so the cached value should be the same.
+        travel 40.minutes
+        assert_equal initial_token, valid_app.token
+
+        # Travel to when the token should refresh, but is not expired, which should result in our cache.fetch update block.
+        travel 15.minutes
+        updated_token = valid_app.token
+        assert_not_equal initial_token, updated_token
+
+        cached_token = Rails.cache.fetch(@token_cache_key)
+        assert_operator cached_token.expires_at, :>, initial_cached_token.expires_at
+      end
+    end
+
+    test "#github token is missing refresh_at field" do
+      # $debugging = true
+      Rails.env = 'not_test'
+      config = {
+        app_id: "test_id",
+        installation_id: "test_installation_id",
+        private_key: "test_private_key",
+      }
+      initial_cached_token = Shipit::GitHubApp::Token.new("some_initial_github_token", Time.now.utc - 1.minute)
+      initial_cached_token.instance_variable_set(:@refresh_at, nil)
+
+      second_token = OpenStruct.new(
+        token: "some_new_github_token",
+        expires_at: initial_cached_token.expires_at + 60.minutes,
+      )
+      auth_payload = "test_auth_payload"
+
+      GitHubApp.any_instance.expects(:authentication_payload).returns(auth_payload)
+      valid_app = app(@organization, config)
+
+      freeze_time do
+        valid_app.instance_variable_set(:@token, initial_cached_token)
+        Rails.cache.write(@token_cache_key, initial_cached_token, expires_in: 1.minute)
+
+        Octokit::Client
+          .any_instance
+          .expects(:create_app_installation_access_token).with(config[:installation_id], anything)
+          .returns(second_token)
+
+        first_token = valid_app.token
+
+        first_cached_token = Rails.cache.fetch(@token_cache_key)
+        assert_equal first_token, first_cached_token.to_s
+
+        travel_to first_cached_token.expires_at + 5.minutes
+        new_token = valid_app.token
+
+        assert_equal second_token.token, new_token
+      end
+    end
+
+    private
+
+    def app(organization, extra_config = {})
+      GitHubApp.new(organization, double_github_app_config.deep_merge(extra_config))
+    end
+
+    def double_github_app_config
+      YAML.load_file('test/dummy/config/secrets_double_github_app.yml')
+    end
+  end
+end


### PR DESCRIPTION
## Summary

A Github application can only authenticate to the organization its installed in. This is a problem if one wishes to deploy code from multiple Github organizations using a single Shipit instance. This pull requests adds the capability to configure multiple Github applications in the `github` section of `config/secrets.yml`. It also preserves the current schema for backwards compatibility support.

### New `config/secrets.yml` Example

```yml
github:
  somegithuborg:
    app_id:
    installation_id:
    webhook_secret: # nil
    private_key:
    oauth:
      id:
      secret:
      teams: # Optional
  someothergithuborg:
    app_id:
    installation_id:
    webhook_secret: # nil
    private_key:
    oauth:
      id:
      secret:
      teams: # Optional
```
