### PR TITLE
Improve the loading of GitHub apps from secrets

### DIFF
--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -119,6 +119,7 @@ module Shipit
   end
 
   def github_default_organization
+    return nil unless secrets&.github
     org = secrets.github.keys.first
     TOP_LEVEL_GH_KEYS.include?(org) ? nil : org
   end


### PR DESCRIPTION
The `secrets` hash might not be available in all cases. For example in isolated environments for building container images etc. This change should short circuit the reliance on secrets to exists.