### PR TITLE
Force standardization of github config keys

### DIFF
--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -131,7 +131,7 @@ module Shipit
 
   def legacy_github_api
     if secrets&.github_api.present?
-      @legacy_github_api ||= github.new_client(access_token: secrets.github_api['access_token'])
+      @legacy_github_api ||= github.new_client(access_token: secrets.github_api[:access_token])
     end
   end
 
@@ -234,7 +234,7 @@ module Shipit
   end
 
   def secrets
-    Rails.application.secrets
+    Rails.application.secrets.deep_symbolize_keys!
   end
 end
 


### PR DESCRIPTION
`Rails.application.secrets` can return either Symbols or Strings depending on how it's loaded and parsed. For the purpose of ease of evaluation, we'll force all keys to be symbols.