### PR TITLE
Move symbolization of Rails.application.secrets up the stack

### DIFF
--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -234,7 +234,7 @@ module Shipit
   end
 
   def secrets
-    Rails.application.secrets.deep_symbolize_keys!
+    Rails.application.secrets
   end
 end
 

--- a/lib/shipit/engine.rb
+++ b/lib/shipit/engine.rb
@@ -10,6 +10,8 @@ module Shipit
       Shipit::Engine.routes.default_url_options[:host] = Shipit.host
       Pubsubstub.redis_url = Shipit.redis_url.to_s
 
+      Rails.application.secrets.deep_symbolize_keys!
+
       app.config.assets.paths << Emoji.images_path
       app.config.assets.precompile += %w(
         favicon.ico


### PR DESCRIPTION
`Rails.application.secrets.deep_symbolize_keys!` needs to be called before it's used in `lib/shipit.rb`. If you don't, it appears that the value return isn't a symbolized version of `Rails.application.secrets (ActiveSupport::OrderedOptions)`.