### PR TITLE
Fix WebhookController calls

### DIFF
--- a/app/controllers/shipit/webhooks_controller.rb
+++ b/app/controllers/shipit/webhooks_controller.rb
@@ -16,7 +16,8 @@ module Shipit
     private
 
     def verify_signature
-      github_app = stack&.github_app
+      head(404) unless repository_owner
+      github_app = Shipit.github(organization: repository_owner)
       verified = github_app.verify_webhook_signature(
         request.headers['X-Hub-Signature'],
         request.raw_post
@@ -32,8 +33,8 @@ module Shipit
       request.headers.fetch('X-Github-Event')
     end
 
-    def stack
-      @stack ||= Stack.find(params[:stack_id])
+    def repository_owner
+      params.dig('repository', 'owner', 'login')
     end
   end
 end

--- a/app/controllers/shipit/webhooks_controller.rb
+++ b/app/controllers/shipit/webhooks_controller.rb
@@ -23,6 +23,14 @@ module Shipit
         request.raw_post
       )
       head(422) unless verified
+
+      Rails.logger.info([
+        'WebhookController#verify_signature',
+        "event=#{event}",
+        "repository_owner=#{repository_owner}",
+        "signature=#{request.headers['X-Hub-Signature']}",
+        "status=#{status}",
+      ].join(' '))
     end
 
     def check_if_ping

--- a/test/fixtures/payloads/check_suite_master.json
+++ b/test/fixtures/payloads/check_suite_master.json
@@ -67,24 +67,7 @@
     "name": "shipit-engine",
     "full_name": "Shopify/shipit-engine",
     "owner": {
-      "login": "github",
-      "id": 340,
-      "node_id": "MDQ6VXNlcjIxMDMxMDY3",
-      "avatar_url": "http://alambic.github.com/avatars/u/340?",
-      "gravatar_id": "",
-      "url": "https://api.github.com/users/github",
-      "html_url": "http://github.com/github",
-      "followers_url": "https://api.github.com/users/github/followers",
-      "following_url": "https://api.github.com/users/github/following{/other_user}",
-      "gists_url": "https://api.github.com/users/github/gists{/gist_id}",
-      "starred_url": "https://api.github.com/users/github/starred{/owner}{/repo}",
-      "subscriptions_url": "https://api.github.com/users/github/subscriptions",
-      "organizations_url": "https://api.github.com/users/github/orgs",
-      "repos_url": "https://api.github.com/users/github/repos",
-      "events_url": "https://api.github.com/users/github/events{/privacy}",
-      "received_events_url": "https://api.github.com/users/github/received_events",
-      "type": "Organization",
-      "site_admin": false
+      "login": "Shopify"
     },
     "private": false,
     "html_url": "http://github.com/Shopify/shipit-engine",
@@ -155,18 +138,7 @@
     "default_branch": "master"
   },
   "organization": {
-    "login": "github",
-    "id": 340,
-    "node_id": "MDEyOk9yZ2FuaXphdGlvbjM4MzAyODk5",
-    "url": "https://api.github.com/orgs/github",
-    "repos_url": "https://api.github.com/orgs/github/repos",
-    "events_url": "https://api.github.com/orgs/github/events",
-    "hooks_url": "https://api.github.com/orgs/github/hooks",
-    "issues_url": "https://api.github.com/orgs/github/issues",
-    "members_url": "https://api.github.com/orgs/github/members{/member}",
-    "public_members_url": "https://api.github.com/orgs/github/public_members{/member}",
-    "avatar_url": "http://alambic.github.com/avatars/u/340?",
-    "description": "How people build software."
+    "login": "Shopify"
   },
   "sender": {
     "login": "octocat",

--- a/test/fixtures/payloads/push_master.json
+++ b/test/fixtures/payloads/push_master.json
@@ -64,7 +64,7 @@
     "fork": false,
     "size": 0,
     "owner": {
-      "name": "Shopify",
+      "login": "Shopify",
       "email": "jean.boussier@gmail.com"
     },
     "private": false,

--- a/test/fixtures/payloads/push_not_master.json
+++ b/test/fixtures/payloads/push_not_master.json
@@ -64,7 +64,7 @@
     "fork": false,
     "size": 0,
     "owner": {
-      "name": "Shopify",
+      "login": "Shopify",
       "email": "jean.boussier@gmail.com"
     },
     "private": false,


### PR DESCRIPTION
Closes https://github.com/Shopify/shipit-engine/issues/1156

Fixes a bug introduced by https://github.com/Shopify/shipit-engine/pull/1151, which stemmed from:

> params[:stack_id] is a left over from the time when each Stack would install it's own webhook. Now we install a single hook per org.

The WebhooksController now looks to the provided payload from Github to determine the Github Organization/Owner of the repository. If that can't be found it returns a 404.

I've had to update some fixture payloads as they were not in the correct format according to [Github's latest webhook docs](https://docs.github.com/en/developers/webhooks-and-events/webhook-events-and-payloads).  For `push_master.json` & `push_not_master.json` I've renamed `name` to `login` as the repository object inside the payload doesn't have a reference to `name` anymore. And for `check_suite_master.json` I believe the values underneath `owner` were a copy/paste error. I couldn't find a reference or explanation to explain why the values would ever refer `github` as the owner and not the actual owner of the repository (e.g. `Shopify` in this case).

This logic should work as long as all WebhookController payloads from Github contain the `repository` top-level object. If desired we could use the `organization` top-level object as a fallback for determining the Github organization/owner that determines which Github application to use.