### PR TITLE
Add indifferent access support for searching through Github applications

### DIFF
--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -110,9 +110,8 @@ module Shipit
     if github_default_organization.nil?
       config = secrets.github
     else
-      org = organization.to_sym
-      raise GithubOrganizationUnknown, org if secrets.github[org].nil?
-      config = secrets.github[org]
+      config = github_app_config(organization)
+      raise GithubOrganizationUnknown, organization if config.nil?
     end
     @github ||= {}
     @github[organization] ||= GitHubApp.new(organization, config)
@@ -127,6 +126,12 @@ module Shipit
   def github_organizations
     return [nil] unless github_default_organization
     secrets.github.keys
+  end
+
+  def github_app_config(organization)
+    github_config = secrets.github.deep_transform_keys(&:downcase)
+    github_organization = organization.downcase.to_sym
+    github_config[github_organization]
   end
 
   def legacy_github_api

--- a/test/unit/shipit_test.rb
+++ b/test/unit/shipit_test.rb
@@ -7,6 +7,20 @@ module Shipit
       Shipit.instance_variables.each(&Shipit.method(:remove_instance_variable))
     end
 
+    test ".github uses indifferent access to search through the Github applications" do
+      secrets = ActiveSupport::OrderedOptions.new
+      secrets.merge!(Rails::Secrets.parse(['test/dummy/config/secrets.yml'], env: Rails.env))
+      secrets.merge!(YAML.load_file('test/dummy/config/secrets_double_github_app.yml'))
+      secrets.deep_symbolize_keys!
+      Shipit.stubs(:secrets).returns(secrets)
+      assert_instance_of(Shipit::GitHubApp, Shipit.github(organization: 'OrgOne'))
+      assert_instance_of(Shipit::GitHubApp, Shipit.github(organization: :OrgOne))
+      assert_instance_of(Shipit::GitHubApp, Shipit.github(organization: 'orgone'))
+      assert_instance_of(Shipit::GitHubApp, Shipit.github(organization: :orgone))
+      assert_instance_of(Shipit::GitHubApp, Shipit.github(organization: :OrgTwo))
+      Shipit.unstub(:secrets)
+    end
+
     test ".github_teams returns an empty array if there's no team" do
       assert_equal([], Shipit.github_teams)
     end


### PR DESCRIPTION
https://github.com/Shopify/shipit-engine/pull/1151 introduced multi-Github organization support. However searching the config for a particular Github organization application was case-sensitive. Instead of putting this burden on end-users to get right in the configs, we now support indifferent access.

```
irb(main):001:0> Shipit.github(organization: 'Shopify')
=> #<Shipit::GitHubApp:0x00007f5a38a69138 @_mutex=#<Thread::Mutex:0x00007f5a38a69098>
irb(main):002:0> Shipit.github(organization: 'shopify')
=> #<Shipit::GitHubApp:0x00007f5a38ad0e50 @_mutex=#<Thread::Mutex:0x00007f5a38ad0db0>
irb(main):003:0> Shipit.github(organization: :shopify)
=> #<Shipit::GitHubApp:0x00007f5a3d01b258 @_mutex=#<Thread::Mutex:0x00007f5a3d01b190>
irb(main):004:0> Shipit.github(organization: :Shopify)
=> #<Shipit::GitHubApp:0x00007f5a38a71e00 @_mutex=#<Thread::Mutex:0x00007f5a38a71db0>
```