### PR TITLE
Handle more payload types in WebhookController calls

### DIFF
--- a/app/controllers/shipit/webhooks_controller.rb
+++ b/app/controllers/shipit/webhooks_controller.rb
@@ -42,7 +42,8 @@ module Shipit
     end
 
     def repository_owner
-      params.dig('repository', 'owner', 'login')
+      # Fallback to the organization sub-object if repository isn't included in the payload
+      params.dig('repository', 'owner', 'login') || params.dig('organization', 'login')
     end
   end
 end


### PR DESCRIPTION
Implement the following as was foreseen in https://github.com/Shopify/shipit-engine/pull/1157

> This logic should work as long as all WebhookController payloads from Github contain the repository top-level object. If desired we could use the organization top-level object as a fallback for determining the Github organization/owner that determines which Github application to use.

