### PR TITLE
GitHub push events update only active stacks

### DIFF
--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -459,6 +459,8 @@ module Shipit
 
     def unarchive!
       update!(archived_since: nil, lock_reason: nil, lock_author: nil, locked_since: nil)
+
+      sync_github
     end
 
     def to_param

--- a/app/models/shipit/webhooks/handlers/push_handler.rb
+++ b/app/models/shipit/webhooks/handlers/push_handler.rb
@@ -7,7 +7,10 @@ module Shipit
           requires :ref
         end
         def process
-          stacks.where(branch: branch).each(&:sync_github)
+          stacks
+            .not_archived
+            .where(branch: branch)
+            .find_each(&:sync_github)
         end
 
         private

--- a/test/models/shipit/stacks_test.rb
+++ b/test/models/shipit/stacks_test.rb
@@ -926,6 +926,16 @@ module Shipit
       )
     end
 
+    test "#unarchive! triggers a GithubSync job" do
+      assert_no_enqueued_jobs(only: GithubSyncJob) do
+        @stack.archive!(shipit_users(:codertocat))
+      end
+
+      assert_enqueued_with(job: GithubSyncJob, args: [stack_id: @stack.id]) do
+        @stack.unarchive!
+      end
+    end
+
     private
 
     def generate_revert_commit(stack:, reverted_commit:, author: reverted_commit.author)


### PR DESCRIPTION
We are observing multiple archived stacks recreate their local file
caches. When this occurs in repositories which have
high-review-stack-volume and many files we observe large amounts of disk
utilization - especially inode space utilization. This has deleterious
effects, causing CacheDeploySpec jobs, Deployments, and anything else
which has an opportunity to interact with the local file cache to
encounter filesystem errors like:

```
$ git clone --quiet --local --origin cache [snip]
fatal: cannot create directory at '[snip]': No space left on device
warning: Clone succeeded, but checkout failed.
You can inspect what was checked out with 'git status'
and retry the checkout with 'git checkout -f HEAD'
```

There appear to be more than one cause for these old, archived stack
recreating their local file caches, but the one with which this PR
concerns itself is as follows. 

When `PushHandler#process` receives a
"Commit" GitHub webhook payload whenever a GitHub branch receives a push
from the developer. It finds every stack whose `branch` attribute matches that 
of the of the GitHub webhook's Commit payload. Then Shipit calls 
`sync_github` on the each of these stacks[^1]. `sync_github` pulls the missing 
commit information for each stack and creates Shipit::Commits for them. Then 
the `GithubSyncJob` enqueues a `CacheDeploySpecJob` for the stack[^2]. 
The `CacheDeploySpecJob` then calls 
`Shipit::StackCommands#with_temporary_directory` to sync the local git
cache and rebuild stack's DeploySpec.

This is where we end up rebuilding the on-disk cache for archived
stacks. Keep in mind that in this process, we never concern ourselves
with the `archived?` status of the stack. If an archived stack shares a
`#branch` attribute with an active stack its on-disk file cache is
recreated here because `with_temporary_directory` will run the `fetch`
command on the stack[^3].

[^1]: https://github.com/Shopify/shipit-engine/blob/e7328e83d8e78ca878f1f5ad2cdebe2ec733854d/app/models/shipit/webhooks/handlers/push_handler.rb#L10
[^2]: https://github.com/Shopify/shipit-engine/blob/a0a826555691f0c83cf74667e6df09911ff339e4/app/jobs/shipit/github_sync_job.rb#L28
[^3]: https://github.com/Shopify/shipit-engine/blob/e7328e83d8e78ca878f1f5ad2cdebe2ec733854d/lib/shipit/stack_commands.rb#L56