### PR TITLE
Drop unhandled events for Webhooks Controller 

### DIFF
--- a/test/controllers/webhooks_controller_test.rb
+++ b/test/controllers/webhooks_controller_test.rb
@@ -168,6 +168,14 @@ module Shipit
       assert_response :ok
     end
 
+    test "events with no handler are dropped" do
+      event = 'not_a_real_event'
+
+      @request.headers['X-Github-Event'] = event
+      post :create, body: pull_request_params.to_json, as: :json
+      assert_response 204
+    end
+
     private
 
     def pull_request_params


### PR DESCRIPTION
Some payloads from Github don't send the `repository`, or `organization` sub-object. This adds another `before_action` method to drop events we don't have a handler for.