### PR TITLE
Improve readability of schedule_merges_if_necessary

### DIFF
--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -607,7 +607,7 @@ module Shipit
     end
 
     def schedule_merges_if_necessary
-      if previous_changes.include?('lock_reason') && previous_changes['lock_reason'].last.blank?
+      if lock_reason_previously_changed? && lock_reason.blank?
         schedule_merges
       end
     end


### PR DESCRIPTION
Feedback provided in PR #1161 improved the readability of a similar
life-cycle callback - `sync_github_if_necessary`. This carries the idea
forward to - hopefully - save readers of the
`schedule_merges_if_necessary` method some mental computation.

References
----------

- https://github.com/Shopify/shipit-engine/pull/1161