### PR TITLE
Use a negative `status:delay` config value to skip automatic `MarkDeployHealthyJob` execution

### DIFF
--- a/app/models/shipit/duration.rb
+++ b/app/models/shipit/duration.rb
@@ -20,6 +20,8 @@ module Shipit
 
     class << self
       def parse(value)
+        return new(-1) if value.to_s == "-1"
+
         unless match = FORMAT.match(value.to_s)
           raise ParseError, "not a duration: #{value.inspect}"
         end

--- a/test/models/deploys_test.rb
+++ b/test/models/deploys_test.rb
@@ -967,6 +967,18 @@ module Shipit
       end
     end
 
+    test "succeeding a deploy sets the release status as pending and does not schedule job if the status delay is negative (-1)" do
+      @deploy = shipit_deploys(:canaries_running)
+      @deploy.stack.expects(:release_status_delay).at_least_once.returns(Duration.parse(-1))
+
+      assert_difference -> { ReleaseStatus.count }, +1 do
+        assert_not_equal 'success', @deploy.last_release_status.state
+        @deploy.report_complete!
+        assert_equal 'validating', @deploy.status
+        assert_equal 'pending', @deploy.last_release_status.state
+      end
+    end
+
     test "triggering a rollback via abort! sets the release status as failure" do
       @deploy = shipit_deploys(:canaries_running)
       @deploy.ping


### PR DESCRIPTION
Use a negative `status:delay` config value to skip automatic `MarkDeployHealthyJob` execution

With this, by setting the delay value to `-1`, projects can configure a validation period that does not expire, and that has to be marked as healthy either via the API or by a human.

Related to https://github.com/Shopify/deploys/issues/48