### PR TITLE
Fix git commands for multi-org cloning

### DIFF
--- a/lib/shipit/commands.rb
+++ b/lib/shipit/commands.rb
@@ -21,8 +21,8 @@ module Shipit
 
     def env
       @env ||= Shipit.env.merge(
-        'GITHUB_DOMAIN' => Shipit.github.domain,
-        'GITHUB_TOKEN' => Shipit.github.token,
+        'GITHUB_DOMAIN' => github.domain,
+        'GITHUB_TOKEN' => github.token,
         'GIT_ASKPASS' => Shipit::Engine.root.join('lib', 'snippets', 'git-askpass').realpath.to_s,
       )
     end
@@ -31,5 +31,11 @@ module Shipit
       Command.new("git", *args)
     end
     ruby2_keywords :git if respond_to?(:ruby2_keywords, true)
+
+    private
+
+    def github
+      Shipit.github
+    end
   end
 end

--- a/lib/shipit/stack_commands.rb
+++ b/lib/shipit/stack_commands.rb
@@ -83,5 +83,11 @@ module Shipit
     def create_directories
       FileUtils.mkdir_p(@stack.deploys_path)
     end
+
+    private
+
+    def github
+      Shipit.github(organization: @stack.repository.owner)
+    end
   end
 end

--- a/lib/shipit/task_commands.rb
+++ b/lib/shipit/task_commands.rb
@@ -88,5 +88,11 @@ module Shipit
         @task.working_directory
       end
     end
+
+    private
+
+    def github
+      Shipit.github(organization: @stack.repository.owner)
+    end
   end
 end

--- a/test/unit/deploy_commands_test.rb
+++ b/test/unit/deploy_commands_test.rb
@@ -59,6 +59,12 @@ module Shipit
       assert_equal 5, command.env["SPECIFIC_CONFIG"]
     end
 
+    test "#env uses the correct Github token for a stack" do
+      Shipit.github(organization: 'shopify').stubs(:token).returns('aS3cr3Tt0kEn')
+      command = @commands.fetch
+      assert_equal 'aS3cr3Tt0kEn', command.env["GITHUB_TOKEN"]
+    end
+
     test "#clone clones the repository cache into the working directory" do
       commands = @commands.clone
       assert_equal 2, commands.size


### PR DESCRIPTION
The `git` commands were using the default organization app token for all commands.