### PR TITLE
Guard against stale checkrun updates.

### DIFF
--- a/app/models/shipit/check_run.rb
+++ b/app/models/shipit/check_run.rb
@@ -5,6 +5,8 @@ module Shipit
     include DeferredTouch
     include Status::Common
 
+    CHECK_RUN_REFRESH_DELAY = 5.seconds
+
     belongs_to :stack, required: true
     belongs_to :commit, required: true
 
@@ -19,11 +21,28 @@ module Shipit
         create!(selector.merge(attributes))
       rescue ActiveRecord::RecordNotUnique
         record = find_by!(selector)
-        record.update!(attributes)
+
+        if record.github_updated_at < attributes[:github_updated_at]
+          record.update!(attributes)
+        elsif attributes[:conclusion] != record.conclusion
+          Rails.logger.warn(
+            "Conflicting stale checkrun received. Checkrun id: #{selector[:github_id]}, Details: #{attributes}"
+          )
+          RefreshCheckRunsJob.set(wait: CHECK_RUN_REFRESH_DELAY).perform_later(commit_id: record.commit_id)
+        end
+
         record
       end
 
       def create_or_update_from_github!(stack_id, github_check_run)
+        checkrun_date = github_check_run.completed_at&.to_s || github_check_run.started_at&.to_s
+
+        unless checkrun_date
+          Rails.logger.warn("No valid timestamp found in checkrun data. Checkrun id: #{github_check_run.id}.")
+          RefreshCheckRunsJob.set(wait: CHECK_RUN_REFRESH_DELAY).perform_later(stack_id: stack_id)
+          return
+        end
+
         create_or_update_by!(
           selector: {
             github_id: github_check_run.id,
@@ -35,6 +54,7 @@ module Shipit
             title: github_check_run.output.title.to_s.truncate(1_000),
             details_url: github_check_run.details_url,
             html_url: github_check_run.html_url,
+            github_updated_at: Time.parse(checkrun_date),
           },
         )
       end

--- a/db/migrate/20210504200438_add_github_updated_at_to_check_runs.rb
+++ b/db/migrate/20210504200438_add_github_updated_at_to_check_runs.rb
@@ -1,0 +1,5 @@
+class AddGithubUpdatedAtToCheckRuns < ActiveRecord::Migration[6.1]
+  def change
+    add_column :check_runs, :github_updated_at, :datetime, default: 0
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_03_25_194053) do
+ActiveRecord::Schema.define(version: 2021_05_04_200438) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text "permissions", limit: 65535
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 2021_03_25_194053) do
     t.string "html_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.datetime "github_updated_at"
     t.index ["commit_id"], name: "index_check_runs_on_commit_id"
     t.index ["github_id", "commit_id"], name: "index_check_runs_on_github_id_and_commit_id", unique: true
     t.index ["stack_id"], name: "index_check_runs_on_stack_id"
@@ -178,14 +179,14 @@ ActiveRecord::Schema.define(version: 2021_03_25_194053) do
   end
 
   create_table "pull_request_assignments", force: :cascade do |t|
-    t.bigint "pull_request_id"
-    t.bigint "user_id"
+    t.integer "pull_request_id"
+    t.integer "user_id"
     t.index ["pull_request_id"], name: "index_pull_request_assignments_on_pull_request_id"
     t.index ["user_id"], name: "index_pull_request_assignments_on_user_id"
   end
 
   create_table "pull_requests", force: :cascade do |t|
-    t.bigint "stack_id", null: false
+    t.integer "stack_id", null: false
     t.integer "number", null: false
     t.string "title", limit: 256
     t.integer "github_id", limit: 8
@@ -195,7 +196,7 @@ ActiveRecord::Schema.define(version: 2021_03_25_194053) do
     t.integer "deletions", default: 0, null: false
     t.integer "user_id"
     t.text "labels"
-    t.bigint "head_id"
+    t.integer "head_id"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["head_id"], name: "index_pull_requests_on_head_id"
@@ -214,9 +215,9 @@ ActiveRecord::Schema.define(version: 2021_03_25_194053) do
     t.bigint "github_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
-    t.index ["commit_id", "github_id"], name: "index_release_statuses_on_commit_id_and_github_id"
-    t.index ["stack_id", "commit_id"], name: "index_release_statuses_on_stack_id_and_commit_id"
-    t.index ["user_id"], name: "index_release_statuses_on_user_id"
+    t.index ["commit_id", "github_id"], name: "index_deploy_statuses_on_commit_id_and_github_id"
+    t.index ["stack_id", "commit_id"], name: "index_deploy_statuses_on_stack_id_and_commit_id"
+    t.index ["user_id"], name: "index_deploy_statuses_on_user_id"
   end
 
   create_table "repositories", force: :cascade do |t|
@@ -288,7 +289,7 @@ ActiveRecord::Schema.define(version: 2021_03_25_194053) do
     t.integer "additions", limit: 4, default: 0
     t.integer "deletions", limit: 4, default: 0
     t.text "definition", limit: 65535
-    t.binary "gzip_output", limit: 16777215
+    t.binary "gzip_output"
     t.boolean "rollback_once_aborted", default: false, null: false
     t.text "env"
     t.integer "confirmations", default: 0, null: false

--- a/test/models/commits_test.rb
+++ b/test/models/commits_test.rb
@@ -350,6 +350,7 @@ module Shipit
         output: mock(
           title: 'Tests build ran successfully',
         ),
+        completed_at: Time.now,
       )
       response = mock(
         check_runs: [check_run],

--- a/test/models/merge_request_test.rb
+++ b/test/models/merge_request_test.rb
@@ -135,7 +135,8 @@ module Shipit
           ),
           details_url: 'http://example.com',
           html_url: 'http://example.com',
-          success_at: Time.now,
+          completed_at: Time.now,
+          started_at: 1.minute.ago,
         )]
       ))
 

--- a/test/models/shipit/check_run_test.rb
+++ b/test/models/shipit/check_run_test.rb
@@ -9,13 +9,65 @@ module Shipit
       @check_run = shipit_check_runs(:second_pending_travis)
     end
 
-    test ".create_or_update_from_github! is idempotent" do
+    test ".create_or_update_from_github! updates successfully" do
+      checkrun_time = Time.now
       assert_difference -> { @commit.check_runs.count }, +1 do
-        @commit.check_runs.create_or_update_from_github!(@stack.id, github_check_run)
+        @commit.check_runs.create_or_update_from_github!(
+          @stack.id,
+          github_check_run(conclusion: nil, checkrun_time: '2021-04-29T18:05:12Z')
+        )
+      end
+
+      assert_no_enqueued_jobs(only: RefreshCheckRunsJob) do
+        @commit.check_runs.create_or_update_from_github!(
+          @stack.id,
+          github_check_run(conclusion: 'success', checkrun_time: checkrun_time + 1.minute)
+        )
+      end
+
+      assert_equal 'success', @commit.check_runs.last.conclusion
+    end
+
+    test ".create_or_update_from_github! is idempotent" do
+      checkrun_time = Time.now
+      assert_difference -> { @commit.check_runs.count }, +1 do
+        @commit.check_runs.create_or_update_from_github!(@stack.id, github_check_run(checkrun_time: checkrun_time))
       end
 
       assert_no_difference -> { @commit.check_runs.count } do
-        @commit.check_runs.create_or_update_from_github!(@stack.id, github_check_run)
+        assert_no_enqueued_jobs(only: RefreshCheckRunsJob) do
+          @commit.check_runs.create_or_update_from_github!(@stack.id, github_check_run(checkrun_time: checkrun_time))
+        end
+      end
+    end
+
+    test ".create_or_update_from_github! enqueues refresh when new statuses have stale timestamps" do
+      checkrun_time = Time.now
+      assert_difference -> { @commit.check_runs.count }, +1 do
+        @commit.check_runs.create_or_update_from_github!(
+          @stack.id,
+          github_check_run(conclusion: 'success', checkrun_time: checkrun_time)
+        )
+      end
+
+      assert_no_difference -> { @commit.check_runs.count } do
+        assert_enqueued_with(job: RefreshCheckRunsJob) do
+          @commit.check_runs.create_or_update_from_github!(
+            @stack.id,
+            github_check_run(conclusion: nil, checkrun_time: checkrun_time - 1.minute)
+          )
+        end
+      end
+    end
+
+    test ".create_or_update_from_github! enqueues refresh when new statues have no timestamps" do
+      assert_no_difference -> { @commit.check_runs.count } do
+        assert_enqueued_with(job: RefreshCheckRunsJob, args: [stack_id: @stack.id]) do
+          @commit.check_runs.create_or_update_from_github!(
+            @stack.id,
+            github_check_run(conclusion: nil, checkrun_time: nil)
+          )
+        end
       end
     end
 
@@ -36,16 +88,17 @@ module Shipit
 
     private
 
-    def github_check_run
-      @github_check_run ||= OpenStruct.new(
+    def github_check_run(conclusion: 'success', checkrun_time: Time.now)
+      OpenStruct.new(
         id: 424_242,
-        conclusion: 'success',
+        conclusion: conclusion,
         output: OpenStruct.new(
           description: 'This is a description',
         ),
         name: 'Test Suite',
         html_url: 'http://example.com/run',
         details_url: 'http://example.com/details',
+        completed_at: checkrun_time,
       )
     end
   end


### PR DESCRIPTION
### The problem

Shipit parses CheckSuite events and uses them to enqueue [refresh jobs](https://github.com/Shopify/shipit-engine/blob/master/app/jobs/shipit/refresh_check_runs_job.rb#L8). These jobs sync checkruns via [`Commit.refresh_check_runs`](https://github.com/Shopify/shipit-engine/blob/master/app/models/shipit/commit.rb#L171).

We're seeing cases where this job seems to be returning stale data - either that, or we receive the correct data for our checkruns api request, but GitHub then does not send us a new CheckSuite event.

This seems to happen when the CheckSuite webhook event is received within one second of a successful checkrun webhook. Perhaps there's an ordering or timing issue, or some sort of debouncing on GitHub's end that would result in no second checksuite event.

More details are available on our internal issues page.

Some potential solutions to this may involve persisting or retrieving checkruns more often (see `Followups`) so guarding against outdated information would be helpful.

### This PR / The Change

This PR changes the Checkrun class to compare an updated checkrun against the db record before we update the record.

We now compare the timestamps between the new GitHub checkrun data and our db record, and:

* If the github data is a new checkrun, we persist it.
* If it's a known checkrun, but has a newer github timestamp than the db record, then we update the record with the new one's data.
* If the new checkrun has a different timestamp but the same conclusion, we ignore it (keeping the Idempotence we have today).
* If the new checkrun has a different conclusion, but has an older (or equal) timestamp, we enqueue a new refresh for a little bit later.
  * Unfortunately, GitHub's timestamp only has seconds-resolution. I think enqueuing a refresh makes sense here. If GitHub has somehow permanently reverted a timestamp, then this could be problematic. But I don't think we've ever seen that before.

### Followups, mergeability

This PR is a draft, as it's not a change that makes sense without deciding to move forward with some other changes, such as handling CheckRun events and persisting a checkrun from those events (like we do with [Statuses](https://github.com/Shopify/shipit-engine/blob/master/app/models/shipit/webhooks/handlers/status_handler.rb#L21)). I'll prepare a PR to demonstrate those ideas, and point it at this branch for simplicity of review.