### PR TITLE
Fix corrupt git cache causes "exit status 128"

### DIFF
--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -380,15 +380,15 @@ module Shipit
     delegate :git_url, to: :repository, prefix: :repo
 
     def base_path
-      Rails.root.join('data', 'stacks', repo_owner, repo_name, environment)
+      @base_path ||= Rails.root.join('data', 'stacks', repo_owner, repo_name, environment)
     end
 
     def deploys_path
-      base_path.join("deploys")
+      @deploys_path ||= base_path.join("deploys")
     end
 
     def git_path
-      base_path.join("git")
+      @git_path ||= base_path.join("git")
     end
 
     def acquire_git_cache_lock(timeout: 15, &block)

--- a/lib/shipit/stack_commands.rb
+++ b/lib/shipit/stack_commands.rb
@@ -15,19 +15,25 @@ module Shipit
 
     def fetch
       create_directories
-      if Dir.exist?(@stack.git_path)
+      if valid_git_repository?(@stack.git_path)
         git('fetch', 'origin', '--tags', @stack.branch, env: env, chdir: @stack.git_path)
       else
+        @stack.clear_git_cache!
         git_clone(@stack.repo_git_url, @stack.git_path, branch: @stack.branch, env: env, chdir: @stack.deploys_path)
       end
     end
 
     def fetched?(commit)
-      git_dir = File.join(@stack.git_path, '.git')
-      if Dir.exist?(git_dir)
+      if valid_git_repository?(@stack.git_path)
         git('rev-parse', '--quiet', '--verify', "#{commit.sha}^{commit}", env: env, chdir: @stack.git_path)
       else
-        Command.new('test', '-d', git_dir, env: env, chdir: @stack.deploys_path)
+        # When the stack's git cache is not valid, the commit is
+        # NOT fetched. To keep the interface of this method
+        # consistent, we must return a Shipit::Command whose #success?
+        # method returns false - has a non-zero exit status. We utilize
+        # the POSIX 'test' command with no arguments which should
+        # always have an exit status of 1.
+        Command.new('test', env: env, chdir: @stack.deploys_path)
       end
     end
 
@@ -69,6 +75,18 @@ module Shipit
         git('checkout', commit.sha, chdir: git_dir).run! if commit
         yield Pathname.new(git_dir)
       end
+    end
+
+    def valid_git_repository?(path)
+      path.exist? &&
+        !path.empty? &&
+        git_cmd_succeeds?(path)
+    end
+
+    def git_cmd_succeeds?(path)
+      git("rev-parse", "--git-dir", chdir: path)
+        .tap(&:run)
+        .success?
     end
 
     def git_clone(url, path, branch: 'master', **kwargs)


### PR DESCRIPTION
When the stack's git cache repository is in an invalid state, tasks and
deployments will fail indicating that `git: exited with status 128`
until a human intervenes to clear the stack's git cache.

For example, when shipit first creates a stack a background job like
CacheDeploySpecJob and/or FetchDeployedRevisionJob will run shortly
after. These make use of the
StackCommands#with_temporary_working_directory method to populate the
local git cache before performing their primary work. When the initial
clone of the git cache fails the git repository may be in an invalid
state. Subsequent attempts to interact with the git repository will
result in the git program exiting with status 128.

A concrete scenario in which we've seen this surface. We recently
experienced instability due to over-scheduling of memory resources on
one of the nodes in our Kubernetes clusters on which these shipit-engine
jobs run. Some of the sidekiq workers running these jobs were OOMKilled
by the kernel due to congestion / contention on node memory. The result
is that these stacks remain in a state where they did not yet, nor would
they ever be able to, cache their deploy spec. This means they appear
"stuck" until a human realizes the on-disk git cache is broken and
manually schedules a ClearGitCacheJob through the UI for the stack.

The idea of behind this bod of work is to make shipit-engine more
resilient - self-healing - in such cases. The approach enhances
shipit-engine's existing file-system checks of the stack's git cache. If
the git cache is a working git repository, then use it. Otherwise throw
away the broken on-disk git cache and re-clone the repository.