### PR TITLE
Add checkrun refresh for merge requests

### DIFF
--- a/app/models/shipit/merge_request.rb
+++ b/app/models/shipit/merge_request.rb
@@ -233,6 +233,7 @@ module Shipit
     def refresh!
       update!(github_pull_request: stack.github_api.pull_request(stack.github_repo_name, number))
       head.refresh_statuses!
+      head.refresh_check_runs!
       fetched! if fetching?
       @comparison = nil
     end

--- a/test/models/merge_request_test.rb
+++ b/test/models/merge_request_test.rb
@@ -125,6 +125,20 @@ module Shipit
         created_at: 1.day.ago,
       )])
 
+      Shipit.github.api.expects(:check_runs).with(@stack.github_repo_name, head_sha).returns(stub(
+        check_runs: [stub(
+          id: 123456,
+          name: 'check run',
+          conclusion: 'success',
+          output: stub(
+            title: 'a test checkrun',
+          ),
+          details_url: 'http://example.com',
+          html_url: 'http://example.com',
+          success_at: Time.now,
+        )]
+      ))
+
       merge_request.refresh!
 
       assert_predicate merge_request, :mergeable?


### PR DESCRIPTION
When someone wants to merge a PR using shipit's merge queue, the merge request refreshes the statuses and then checks its mergability.

However, if their shipit.yml requires a checkrun status, then it's possible for this request to happen before the checkrun data has been filled in, since it is only filled by webhook-triggered RefreshCheckRun jobs.

This PR ensures that we refresh checkruns inline when a user tries to enqueue a merge request, the same way we do for Statuses.

Note: We probably want https://github.com/Shopify/shipit-engine/pull/1167 first, in case a running refresh writes stale data after this request writes newer data.

It's unlikely, but possible. However, there is a user remedy - simply trying to enqueue again will refresh again - so I don't consider this blocked by that PR.