### PR TITLE
Fix "view on github" links for Review Stacks

### DIFF
--- a/app/controllers/shipit/deploys_controller.rb
+++ b/app/controllers/shipit/deploys_controller.rb
@@ -55,7 +55,7 @@ module Shipit
     end
 
     def load_stack
-      @stack ||= Stack.from_param!(params[:stack_id]).becomes(Stack)
+      @stack ||= Stack.from_param!(params[:stack_id])
     end
 
     def load_until_commit

--- a/app/controllers/shipit/tasks_controller.rb
+++ b/app/controllers/shipit/tasks_controller.rb
@@ -36,7 +36,7 @@ module Shipit
           env: task_params[:env],
           force: params[:force].present?,
         )
-        redirect_to([stack, @task])
+        redirect_to([stack.becomes(Stack), @task])
       rescue Task::ConcurrentTaskRunning
         redirect_to(new_stack_tasks_path(stack, @definition))
       end
@@ -70,7 +70,7 @@ module Shipit
     end
 
     def stack
-      @stack ||= Stack.from_param!(params[:stack_id]).becomes(Stack)
+      @stack ||= Stack.from_param!(params[:stack_id])
     end
 
     def task_params


### PR DESCRIPTION
For a `ReviewStack`, "View on GitHub" link of the `stacks/_header`
template appropriately will send users to the Pull Request's so long as
the user is NOT on a "Task" oriented view - IE the History, or Task's
show view, etc. When looking at a Review Stack's tasks the "View on
GitHub" link - less-than-optimally - sends the user to the Stack's
GitHub repository.

This seems to happen because when the `GithubUrlHelper` receives the
`ReviewStack` to determine which type of link it needs to render. The
Tasks Controller casts the `ReviewStack` to a Stack instance before this
call to the helper - meaning that the helper's test of "Does this stack
have a pull_request?" fails [^1]. This causes the helper to render a
link to the GitHub Repository.

The TasksController casts the ReviewStack so that the post-create
redirects send the user to the Task's show view - since
review_stacks_task_path is not a valid path helper. This change isolates
the cast to the post-create redirect.

[^1]: https://github.com/Shopify/shipit-engine/blob/master/app/helpers/shipit/github_url_helper.rb#L55