### PR TITLE
Revert "Stack#git_path and deploys_path now returns Pathname instances"

### DIFF
--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -384,11 +384,11 @@ module Shipit
     end
 
     def deploys_path
-      @deploys_path ||= base_path.join("deploys")
+      File.join(base_path, "deploys")
     end
 
     def git_path
-      @git_path ||= base_path.join("git")
+      File.join(base_path, "git")
     end
 
     def acquire_git_cache_lock(timeout: 15, &block)
@@ -398,9 +398,9 @@ module Shipit
 
     def clear_git_cache!
       tmp_path = "#{git_path}-#{SecureRandom.hex}"
-      return unless git_path.exist?
+      return unless File.exist?(git_path)
       acquire_git_cache_lock do
-        git_path.rename(tmp_path)
+        File.rename(git_path, tmp_path)
       end
       FileUtils.rm_rf(tmp_path)
     end

--- a/lib/shipit/command.rb
+++ b/lib/shipit/command.rb
@@ -29,7 +29,7 @@ module Shipit
     def initialize(*args, default_timeout: Shipit.default_inactivity_timeout, env: {}, chdir:)
       @args, options = parse_arguments(args)
       @timeout = options['timeout'] || options[:timeout] || default_timeout
-      @env = env.transform_values(&:to_s)
+      @env = env
       @chdir = chdir.to_s
       @timed_out = false
     end
@@ -216,7 +216,7 @@ module Shipit
           argument
         end
       end
-      [args.map(&:to_s), options]
+      [args, options]
     end
 
     def running?

--- a/test/unit/deploy_commands_test.rb
+++ b/test/unit/deploy_commands_test.rb
@@ -35,8 +35,7 @@ module Shipit
       @stack.git_path.stubs(:empty?).returns(false)
 
       command = @commands.fetch
-
-      assert_equal @stack.git_path.to_s, command.chdir
+      assert_equal @stack.git_path, command.chdir
     end
 
     test "#fetch calls git clone if repository cache do not exist" do
@@ -45,7 +44,7 @@ module Shipit
       command = @commands.fetch
 
       expected = %W(git clone --single-branch --recursive --branch master #{@stack.repo_git_url} #{@stack.git_path})
-      assert_equal expected, command.args.map(&:to_s)
+      assert_equal expected, command.args
     end
 
     test "#fetch calls git clone if repository cache is empty" do
@@ -92,21 +91,20 @@ module Shipit
       command = @commands.fetch
 
       expected = %W(git clone --recursive --branch master #{@stack.repo_git_url} #{@stack.git_path})
-      assert_equal expected, command.args.map(&:to_s)
+      assert_equal expected, command.args
     end
 
     test "#fetch calls git fetch in base_path directory if repository cache do not exist" do
       @stack.git_path.stubs(:exist?).returns(false)
 
       command = @commands.fetch
-
-      assert_equal @stack.deploys_path.to_s, command.chdir
+      assert_equal @stack.deploys_path, command.chdir
     end
 
     test "#fetch merges Shipit.env in ENVIRONMENT" do
       Shipit.stubs(:env).returns("SPECIFIC_CONFIG" => 5)
       command = @commands.fetch
-      assert_equal '5', command.env["SPECIFIC_CONFIG"]
+      assert_equal 5, command.env["SPECIFIC_CONFIG"]
     end
 
     test "#env uses the correct Github token for a stack" do
@@ -121,15 +119,15 @@ module Shipit
       clone_args = [
         'git', 'clone', '--quiet',
         '--local', '--origin', 'cache',
-        @stack.git_path.to_s, @deploy.working_directory
+        @stack.git_path, @deploy.working_directory
       ]
       assert_equal clone_args, commands.first.args
-      assert_equal ['git', 'remote', 'add', 'origin', @stack.repo_git_url.to_s], commands.second.args
+      assert_equal ['git', 'remote', 'add', 'origin', @stack.repo_git_url], commands.second.args
     end
 
     test "#clone clones the repository cache from the deploys_path" do
       commands = @commands.clone
-      assert_equal @stack.deploys_path.to_s, commands.first.chdir
+      assert_equal @stack.deploys_path, commands.first.chdir
     end
 
     test "#checkout checks out the deployed commit" do
@@ -238,7 +236,7 @@ module Shipit
     test "#install_dependencies merges Shipit.env in ENVIRONMENT" do
       Shipit.stubs(:env).returns("SPECIFIC_CONFIG" => 5)
       command = @commands.install_dependencies.first
-      assert_equal '5', command.env["SPECIFIC_CONFIG"]
+      assert_equal 5, command.env["SPECIFIC_CONFIG"]
     end
 
     test "#install_dependencies merges machine_env in ENVIRONMENT" do


### PR DESCRIPTION
This reverts https://github.com/Shopify/shipit-engine/commit/ceac6468710bed766ee63a374e1b0aae031c25b1.

With this commit, we've observed that environment information does not pass completely correctly to subshells in some systems. The exact problem and mechanism causing the issue is unclear.