### PR TITLE
Fix "view on github" links for Review Stacks

### DIFF
--- a/app/controllers/shipit/deploys_controller.rb
+++ b/app/controllers/shipit/deploys_controller.rb
@@ -55,7 +55,7 @@ module Shipit
     end
 
     def load_stack
-      @stack ||= Stack.from_param!(params[:stack_id]).becomes(Stack)
+      @stack ||= Stack.from_param!(params[:stack_id])
     end
 
     def load_until_commit

--- a/app/controllers/shipit/tasks_controller.rb
+++ b/app/controllers/shipit/tasks_controller.rb
@@ -62,7 +62,7 @@ module Shipit
     def url_for_task
       base_task = @task.is_a?(Deploy) ? @task.becomes(Deploy) : @task
 
-      url_for([base_task.stack.becomes(Stack), base_task])
+      url_for([base_task.stack, base_task])
     end
 
     def task
@@ -70,7 +70,7 @@ module Shipit
     end
 
     def stack
-      @stack ||= Stack.from_param!(params[:stack_id]).becomes(Stack)
+      @stack ||= Stack.from_param!(params[:stack_id])
     end
 
     def task_params

--- a/app/models/shipit/review_stack.rb
+++ b/app/models/shipit/review_stack.rb
@@ -22,6 +22,16 @@ module Shipit
       end
     end
 
+    model_name.class_eval do
+      def route_key
+        "stacks"
+      end
+
+      def singular_route_key
+        "stack"
+      end
+    end
+
     has_one :pull_request, foreign_key: :stack_id
 
     after_commit :emit_added_hooks, on: :create


### PR DESCRIPTION
For a `ReviewStack`, "View on GitHub" link of the `stacks/_header`
template appropriately will send users to the Pull Request's so long as
the user is NOT on a "Task" oriented view - IE the History, or Task's
show view, etc. When looking at a Review Stack's tasks the "View on
GitHub" link - less-than-optimally - sends the user to the Stack's
GitHub repository.

This seems to happen because when the `GithubUrlHelper` receives the
`ReviewStack` to determine which type of link it needs to render. The
Tasks Controller up-casts the `ReviewStack` to a `Stack` instance - via
the `#becomes` method - before this call to the helper - meaning that
the helper's test of "Does this stack have a pull_request?" fails [^1].
This causes the helper to render a link to the GitHub Repository.

These up-casts serve to instruct Rails' path helpers that `ReviewStack`s
and `Stacks` are the same as far as the application's routes and view
paths are concerned. This change consolidates this fact into the
`ReviewStack` itself rather than scattering this knowledge throughout
the shipit-engine controllers and views.

[^1]: https://github.com/Shopify/shipit-engine/blob/master/app/helpers/shipit/github_url_helper.rb#L55