### PR TITLE
Drop duplicate github sync jobs on duplicate

### DIFF
--- a/app/jobs/shipit/github_sync_job.rb
+++ b/app/jobs/shipit/github_sync_job.rb
@@ -7,6 +7,7 @@ module Shipit
 
     MAX_FETCHED_COMMITS = 25
     queue_as :default
+    on_duplicate :drop
 
     self.timeout = 60
     self.lock_timeout = 20


### PR DESCRIPTION
These operations are common enough, and can be triggered by end users, so it should be fine to drop them on duplicate rather than raise an error.