### PR TITLE
Optionally record Review Stack latest deployed ref

### DIFF
--- a/app/models/shipit/review_stack.rb
+++ b/app/models/shipit/review_stack.rb
@@ -22,6 +22,10 @@ module Shipit
       end
     end
 
+    def update_latest_deployed_ref
+      # noop: last deployed ref is useless for review stacks
+    end
+
     model_name.class_eval do
       def route_key
         "stacks"

--- a/test/models/shipit/review_stack_test.rb
+++ b/test/models/shipit/review_stack_test.rb
@@ -74,5 +74,18 @@ module Shipit
         stack.unarchive!
       end
     end
+
+    test "#trigger_continuous_delivery does not enqueue deployment ref update job" do
+      Shipit.stubs(:update_latest_deployed_ref).returns(true)
+      @stack = shipit_stacks(:review_stack)
+      assert_no_enqueued_jobs(only: Shipit::UpdateGithubLastDeployedRefJob) do
+        task = @stack.trigger_continuous_delivery
+        task.update!(status: "running")
+      end
+
+      assert_no_enqueued_jobs(only: Shipit::UpdateGithubLastDeployedRefJob) do
+        @stack.last_active_task.complete!
+      end
+    end
   end
 end


### PR DESCRIPTION
If enabled, `update_latest_deployed_ref` creates a branch for each
Review Stack that shipit-engine deploys. In a Repository with high
Review Stack turnover this quickly adds up to a lot of "noise" branches
in the git object database- our flagship monorepo currently has over 3k
such branches. However, in some scenarios it is still useful to record
the "latest deployed ref" of "plain old, manually managed" stacks - in
our case we DO still want to track the latest deployed ref of our
staging and production "environments" of this flagship monorepo.

This allows the host application to en/disable the recording of the
latest deployed ref for Review Stacks independently of "plain old,
manually defined" stacks.