### PR TITLE
Guard against nil record field

### DIFF
--- a/app/models/shipit/check_run.rb
+++ b/app/models/shipit/check_run.rb
@@ -22,7 +22,7 @@ module Shipit
       rescue ActiveRecord::RecordNotUnique
         record = find_by!(selector)
 
-        if record.github_updated_at < attributes[:github_updated_at]
+        if !record.github_updated_at || record.github_updated_at < attributes[:github_updated_at]
           record.update!(attributes)
         elsif attributes[:conclusion] != record.conclusion
           Rails.logger.warn(


### PR DESCRIPTION
Under certain dbs and rails versions, it seems like the current migration does not ensure that the record field will have a default nonnull value, so I think it's worth having a guard clause.