### PR TITLE
Update logic to be either next or latest when valid

### DIFF
--- a/docs/npm-lerna.md
+++ b/docs/npm-lerna.md
@@ -25,7 +25,7 @@ If the version in `package.json` contains one of these patterns, Shipit will pub
 [Lerna](https://github.com/lerna/lerna) is a tool for managing projects with multiple npm packages.
 Shipit understands `lerna.json` files (up to version `3.22.x`), and will publish all packages in a Lerna project to npm.
 
-### From Git
+### From Git (Default)
 
 In addition to the `semver` keyword supported by [`lerna version`](https://github.com/lerna/lerna/tree/main/commands/version#positionals), [`lerna publish`](https://github.com/lerna/lerna/tree/main/commands/publish) also supports the `from-git` keyword. This will identify packages tagged by `lerna version` and publish them to npm. This is useful in CI scenarios where you wish to manually increment versions, but have the package contents themselves consistently published by an automated process.
 
@@ -35,12 +35,21 @@ In order to use this feature with `shipit-engine`, you will need to add the foll
 ```
 machine:
   environment:
-    SHIPIT_LERNA_PUBLISH_FROM_GIT: true
+    SHIPIT_LERNA_PUBLISH_MECHANISM: 'from-git'
 ```
 
-### From Packages (Default)
+### From Package
 
 Similar to the `from-git` keyword, except the list of packages to publish is determined by inspecting each package.json and determining if any package version is not present in the registry. Any versions not present in the registry will be published. This is useful when a previous `lerna publish` failed to publish all packages to the registry.
+
+In order to use this feature with `shipit-engine`, you will need to add the following to your `shipit.yml`:
+
+#### Usage
+```
+machine:
+  environment:
+    SHIPIT_LERNA_PUBLISH_MECHANISM: 'from-package'
+```
 
 ### Pre-releases
 

--- a/lib/snippets/publish-lerna-independent-packages
+++ b/lib/snippets/publish-lerna-independent-packages
@@ -6,39 +6,32 @@ const taggedPackages = execSync("git tag --points-at HEAD")
   .trim()
   .split("\n");
 
-const hasBetaRelease = taggedPackages.some((version) =>
-  version.includes("-beta")
-);
+// anything that matches `-` after MAJOR.MINOR.PATCH
+const validPattern = new RegExp(/\d+\.\d+\.\d+-(\w+)/);
 
-// set this using machine.environment.SHIPIT_LERNA_PUBLISH_FROM_GIT in your shipit.yml
-const useFromGit = process.env.SHIPIT_LERNA_PUBLISH_FROM_GIT || false;
-
-if (
-  hasBetaRelease &&
-  !taggedPackages.every((version) => version.includes("-beta"))
-) {
-  throw Error("All packages must be beta releases. Versions cannot be mixed.");
+// Ensure that all releases use the same prerelease suffix.
+// We want to only release all final versions, or all betas etc
+const allPrereleaseSuffixes =  taggedPackages.map((version) => {
+  const result = validPattern.exec(version);
+  return result ? result[1] : '';
+});
+if ((new Set(allPrereleaseSuffixes)).size > 1) {
+  throw Error("All packages must be of the same type of release. Versions cannot be mixed.");
 }
-const isNext =
-  !hasBetaRelease &&
-  taggedPackages.some((version) => {
-    return ["-alpha", "-rc", "-next"].some((distributionType) =>
-      version.includes(distributionType)
-    );
-  });
 
-function distTag() {
-  if (hasBetaRelease) {
-    return "beta";
-  }
-  return isNext ? "next" : "latest";
+// set this using machine.environment.SHIPIT_LERNA_PUBLISH_MECHANISM in your shipit.yml
+const publishMechanism = process.env.SHIPIT_LERNA_PUBLISH_MECHANISM || 'from-git';
+
+if (!['from-package', 'from-git'].includes(publishMechanism)) {
+  throw Error("SHIPIT_LERNA_PUBLISH_MECHANISM must be 'from-package' or 'from-git'.");
 }
 
 const command = [
   "node_modules/.bin/lerna publish",
-  useFromGit ? "from-git" : "from-package",
+  publishMechanism,
   "--yes",
-  `--dist-tag ${distTag()}`,
+  "--dist-tag latest",
+  "--pre-dist-tag next",
 ];
 
 const commandString = command.join(" ");


### PR DESCRIPTION
To simplify the dist tag strategy when deploying libraries we are updating the logic to do two things:

1) Check to see if a tag has a `-` after MAJOR.MINOR.PATCH and treat this as `next` (so not a full fledged release). Otherwise fallback to `latest`.
2) Validate that all package tags are of the same type, so we don't have mixed versions being deployed.

Tested with these tags:

```
const taggedPackages = [
  "v5.37.0",
  "v5.35.1",
  "@shopify/react-web-worker@2.0.0",
  "graphql-typed@1.0.0",
  "v5.37.0-1",
  "v5.35.1-1",
  "@shopify/react-web-worker@2.0.0-1",
  "graphql-typed@1.0.0-1",
  "v5.37.0-rc",
  "v5.35.1-rc",
  "@shopify/react-web-worker@2.0.0-rc",
  "graphql-typed@1.0.0-rc",
  "v5.37.0-beta",
  "v5.35.1-beta",
  "@shopify/react-web-worker@2.0.0-rc",
  "graphql-typed@1.0.0-rc"
];
```
Note: we also changed the ENV var `SHIPIT_LERNA_PUBLISH_MECHANISM` and how it is used a bit.