### PR TITLE
Allow changing the branch name via the API.

### DIFF
--- a/app/controllers/shipit/api/stacks_controller.rb
+++ b/app/controllers/shipit/api/stacks_controller.rb
@@ -40,6 +40,7 @@ module Shipit
       end
 
       params do
+        accepts :branch, String
         accepts :deploy_url, String
         accepts :ignore_ci, Boolean
         accepts :merge_queue_enabled, Boolean

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -86,7 +86,7 @@ module Shipit
     after_commit :sync_github_if_necessary, on: :update
 
     def sync_github_if_necessary
-      if archived_since_previously_changed? && archived_since.nil?
+      if (archived_since_previously_changed? && archived_since.nil?) || branch_previously_changed?
         sync_github
       end
     end

--- a/test/controllers/api/stacks_controller_test.rb
+++ b/test/controllers/api/stacks_controller_test.rb
@@ -82,6 +82,20 @@ module Shipit
         assert_equal true, @stack.continuous_deployment
       end
 
+      test "#update allows changing the branch name" do
+        assert_equal 'master', @stack.branch
+
+        patch :update, params: {
+          id: @stack.to_param,
+          branch: 'test',
+        }
+
+        assert_response :ok
+        @stack.reload
+
+        assert_equal 'test', @stack.branch
+      end
+
       test "#index returns a list of stacks" do
         stack = Stack.last
         get :index

--- a/test/models/shipit/stacks_test.rb
+++ b/test/models/shipit/stacks_test.rb
@@ -947,6 +947,12 @@ module Shipit
       end
     end
 
+    test "#update that changes the branch name triggers a GithubSync job" do
+      assert_enqueued_with(job: GithubSyncJob, args: [stack_id: @stack.id]) do
+        @stack.update!(branch: 'test')
+      end
+    end
+
     private
 
     def generate_revert_commit(stack:, reverted_commit:, author: reverted_commit.author)


### PR DESCRIPTION
This updates the `api/stacks#update` endpoint to allow changing the branch name. Changing branches means shipit-engine must re-sync git data for the new branch and it could also lead to issues with internal state. Changing this value while a deploy is ongoing for the stack might cause issues, but changing it while the stack is "at rest" should not.

I'm not sure there's anything else that needs to change in this PR to be honest. When code is checked out in shipit-next it's based on the commit SHA, not the branch name. We'll probably also start dropping webhooks once the branch is changed, but this is by design.

https://github.com/Shopify/shipit-engine/blob/c50c4a400c543dcd738c88d1d56f52006fb597eb/lib/shipit/task_commands.rb#L49-L66

cc @Shopify/deploys 