### PR TITLE
Add `require_ci` param to prevent deploying failing commits

### DIFF
--- a/app/controllers/shipit/api/deploys_controller.rb
+++ b/app/controllers/shipit/api/deploys_controller.rb
@@ -11,11 +11,13 @@ module Shipit
       params do
         requires :sha, String, length: { in: 6..40 }
         accepts :force, Boolean, default: false
+        accepts :require_ci, Boolean, default: false
         accepts :env, Hash, default: {}
       end
       def create
         commit = stack.commits.by_sha(params.sha) || param_error!(:sha, 'Unknown revision')
         param_error!(:force, "Can't deploy a locked stack") if !params.force && stack.locked?
+        param_error!(:require_ci, "Commit is not deployable") if params.require_ci && !commit.deployable?
         deploy = stack.trigger_deploy(commit, current_user, env: params.env, force: params.force)
         render_resource(deploy, status: :accepted)
       end


### PR DESCRIPTION
### What

- This adds a flag `require_ci` with a default of `false` that when sent will return an error unless the commit is considered deployable. 

### Why

- The current behaviour when a commit is pending is to deploy but mark `ignore_safeties` as true.
- Outside of pulling all of the commits from Shipit it can be hard to predict the current state as a commit may be green in github, but Shipit may not have finishing refreshing its internal state
- This will allow external services using the api to wait and retry deploys when the response succeeds rather than creating deploys that `ignore_safeties`