### PR TITLE
Use `Bundler.clean_env` if `.unbundled_env` undefined

### DIFF
--- a/lib/shipit/command.rb
+++ b/lib/shipit/command.rb
@@ -13,7 +13,8 @@ module Shipit
     Denied = Class.new(Error)
     TimedOut = Class.new(Error)
 
-    BASE_ENV = Bundler.unbundled_env.merge((ENV.keys - Bundler.unbundled_env.keys).map { |k| [k, nil] }.to_h)
+    unbundled_env = Bundler.respond_to?(:unbundled_env) ? Bundler.unbundled_env : Bundler.clean_env
+    BASE_ENV = unbundled_env.merge((ENV.keys - unbundled_env.keys).map { |k| [k, nil] }.to_h)
 
     class Failed < Error
       attr_reader :exit_code


### PR DESCRIPTION
https://github.com/Shopify/shipit-engine/pull/1152 switched us to use `Bundler.unbundled_env` instead of `Bundler.clean_env`, but for some reason this blows up for me locally when I try to setup the app from scratch:

<details><summary>✅<code>$ dev up</code></summary>

```
...
┃ ⭑ install ruby 2.6.6
...
┃ ⭑ bundle with 2.0.2
...
```

</details>

<details><summary>❌<code>$ dev bootstrap</code> (before this fix)</summary>

```
$ dev bootstrap
👩‍💻  Running bin/bootstrap shopify from dev.yml
+ profile=shopify
+ cp -n config/secrets.development.shopify.yml config/secrets.development.yml
+ bundler_flags=
+ [[ -z '' ]]
+ bundler_flags='--without ci'
+ bundle check
The following gems are missing
 * pg (1.2.3)
Install missing gems with `bundle install`
+ bundle install --without ci
Using rake 13.0.3
...
Using bundler 2.0.2
...
Using webmock 3.12.2
Bundle complete! 14 Gemfile dependencies, 126 gems now installed.
Gems in the group ci were not installed.
Use `bundle info [gemname]` to see where a bundled gem is installed.
+ rm -rf 'test/dummy/db/migrate/*.rb'
+ bundle exec rake db:drop db:create db:schema:load db:migrate
rake aborted!
NoMethodError: undefined method `unbundled_env' for Bundler:Module
~/src/github.com/Shopify/shipit-engine/lib/shipit/command.rb:16:in `<class:Command>'
~/src/github.com/Shopify/shipit-engine/lib/shipit/command.rb:8:in `<module:Shipit>'
~/src/github.com/Shopify/shipit-engine/lib/shipit/command.rb:7:in `<top (required)>'
~/.gem/ruby/2.6.6/gems/activesupport-6.1.3.2/lib/active_support/dependencies.rb:332:in `require'
~/.gem/ruby/2.6.6/gems/activesupport-6.1.3.2/lib/active_support/dependencies.rb:332:in `block in require'
~/.gem/ruby/2.6.6/gems/activesupport-6.1.3.2/lib/active_support/dependencies.rb:299:in `load_dependency'
~/.gem/ruby/2.6.6/gems/activesupport-6.1.3.2/lib/active_support/dependencies.rb:332:in `require'
~/src/github.com/Shopify/shipit-engine/lib/shipit.rb:42:in `<top (required)>'
~/.gem/ruby/2.6.6/gems/activesupport-6.1.3.2/lib/active_support/dependencies.rb:332:in `require'
~/.gem/ruby/2.6.6/gems/activesupport-6.1.3.2/lib/active_support/dependencies.rb:332:in `block in require'
~/.gem/ruby/2.6.6/gems/activesupport-6.1.3.2/lib/active_support/dependencies.rb:299:in `load_dependency'
~/.gem/ruby/2.6.6/gems/activesupport-6.1.3.2/lib/active_support/dependencies.rb:332:in `require'
~/src/github.com/Shopify/shipit-engine/lib/shipit-engine.rb:1:in `<top (required)>'
~/.gem/ruby/2.6.6/gems/bundler-2.0.2/lib/bundler/runtime.rb:81:in `require'
~/.gem/ruby/2.6.6/gems/bundler-2.0.2/lib/bundler/runtime.rb:81:in `block (2 levels) in require'
~/.gem/ruby/2.6.6/gems/bundler-2.0.2/lib/bundler/runtime.rb:76:in `each'
~/.gem/ruby/2.6.6/gems/bundler-2.0.2/lib/bundler/runtime.rb:76:in `block in require'
~/.gem/ruby/2.6.6/gems/bundler-2.0.2/lib/bundler/runtime.rb:65:in `each'
~/.gem/ruby/2.6.6/gems/bundler-2.0.2/lib/bundler/runtime.rb:65:in `require'
~/.gem/ruby/2.6.6/gems/bundler-2.0.2/lib/bundler.rb:114:in `require'
~/src/github.com/Shopify/shipit-engine/test/dummy/config/application.rb:10:in `<top (required)>'
~/src/github.com/Shopify/shipit-engine/test/dummy/Rakefile:4:in `require'
~/src/github.com/Shopify/shipit-engine/test/dummy/Rakefile:4:in `<top (required)>'
~/.gem/ruby/2.6.6/gems/railties-6.1.3.2/lib/rails/tasks/engine.rake:5:in `load'
~/.gem/ruby/2.6.6/gems/railties-6.1.3.2/lib/rails/tasks/engine.rake:5:in `block (2 levels) in <top (required)>'
~/.gem/ruby/2.6.6/gems/railties-6.1.3.2/lib/rails/tasks/engine.rake:4:in `block in <top (required)>'
~/.gem/ruby/2.6.6/gems/railties-6.1.3.2/lib/rails/tasks/engine.rake:85:in `<top (required)>'
~/src/github.com/Shopify/shipit-engine/Rakefile:12:in `load'
~/src/github.com/Shopify/shipit-engine/Rakefile:12:in `<top (required)>'
~/.gem/ruby/2.6.6/gems/rake-13.0.3/exe/rake:27:in `<top (required)>'
~/.gem/ruby/2.6.6/gems/bundler-2.0.2/lib/bundler/cli/exec.rb:74:in `load'
~/.gem/ruby/2.6.6/gems/bundler-2.0.2/lib/bundler/cli/exec.rb:74:in `kernel_load'
~/.gem/ruby/2.6.6/gems/bundler-2.0.2/lib/bundler/cli/exec.rb:28:in `run'
~/.gem/ruby/2.6.6/gems/bundler-2.0.2/lib/bundler/cli.rb:465:in `exec'
~/.gem/ruby/2.6.6/gems/bundler-2.0.2/lib/bundler/vendor/thor/lib/thor/command.rb:27:in `run'
~/.gem/ruby/2.6.6/gems/bundler-2.0.2/lib/bundler/vendor/thor/lib/thor/invocation.rb:126:in `invoke_command'
~/.gem/ruby/2.6.6/gems/bundler-2.0.2/lib/bundler/vendor/thor/lib/thor.rb:387:in `dispatch'
~/.gem/ruby/2.6.6/gems/bundler-2.0.2/lib/bundler/cli.rb:27:in `dispatch'
~/.gem/ruby/2.6.6/gems/bundler-2.0.2/lib/bundler/vendor/thor/lib/thor/base.rb:466:in `start'
~/.gem/ruby/2.6.6/gems/bundler-2.0.2/lib/bundler/cli.rb:18:in `start'
~/.gem/ruby/2.6.6/gems/bundler-2.0.2/exe/bundle:30:in `block in <top (required)>'
~/.gem/ruby/2.6.6/gems/bundler-2.0.2/lib/bundler/friendly_errors.rb:124:in `with_friendly_errors'
~/.gem/ruby/2.6.6/gems/bundler-2.0.2/exe/bundle:22:in `<top (required)>'
~/.gem/ruby/2.6.6/bin/bundle:23:in `load'
~/.gem/ruby/2.6.6/bin/bundle:23:in `<main>'
Tasks: TOP => load_app
(See full trace by running task with --trace)
```

</details>

To get around this, we can check if `Bundler.respond_to? :unbundled_env`, and fallback to `.clean_env` if it doesn't.

<details><summary>✅<code>$ dev up</code> (after this fix)</summary>

```
$ dev bootstrap
👩‍💻  Running bin/bootstrap shopify from dev.yml
+ profile=shopify
+ cp -n config/secrets.development.shopify.yml config/secrets.development.yml
 .g/COMMIT_EDITMSG
+ true
+ bundler_flags=
+ [[ -z '' ]]
+ bundler_flags='--without ci'
+ bundle check
The Gemfile's dependencies are satisfied
+ rm -rf 'test/dummy/db/migrate/*.rb'
+ bundle exec rake db:drop db:create db:schema:load db:migrate
warning: parser/current is loading parser/ruby26, which recognizes
warning: 2.6.7-compliant syntax, but you are running 2.6.6.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
Dropped database 'db/development.sqlite3'
Database 'db/test.sqlite3' does not exist
Created database 'db/development.sqlite3'
Created database 'db/test.sqlite3'
+ bundle exec rake db:seed
warning: parser/current is loading parser/ruby26, which recognizes
warning: 2.6.7-compliant syntax, but you are running 2.6.6.
warning: please see https://github.com/whitequark/parser#compatibility-with-ruby-mri.
```

</details>

## For reviewers

Is there a reason this is a bad idea? Should we just be using a different version of bundler in local development? If so, how?

As an aside, I came across this investigating https://github.com/Shopify/shipit/issues/1593, so anything weird with Bundler is of interest to me... 😅 