### PR TITLE
Make locking optional on rollbacks

### DIFF
--- a/app/controllers/shipit/api/rollbacks_controller.rb
+++ b/app/controllers/shipit/api/rollbacks_controller.rb
@@ -8,6 +8,7 @@ module Shipit
         requires :sha, String, length: { in: 6..40 }
         accepts :force, Boolean, default: false
         accepts :env, Hash, default: {}
+        accepts :lock, Boolean, default: true
       end
       def create
         commit = stack.commits.by_sha(params.sha) || param_error!(:sha, 'Unknown revision')
@@ -23,7 +24,7 @@ module Shipit
           active_task.abort!(aborted_by: current_user, rollback_once_aborted_to: deploy)
           response = active_task
         else
-          response = deploy.trigger_rollback(current_user, env: deploy_env, force: params.force)
+          response = deploy.trigger_rollback(current_user, env: deploy_env, force: params.force, lock: params.lock)
         end
 
         render_resource(response, status: :accepted)

--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -97,14 +97,16 @@ module Shipit
     end
 
     # Rolls the stack back to this deploy
-    def trigger_rollback(user = AnonymousUser.new, env: nil, force: false)
+    def trigger_rollback(user = AnonymousUser.new, env: nil, force: false, lock: true)
       rollback = build_rollback(user, env: env, force: force)
       rollback.save!
       rollback.enqueue
 
-      lock_reason = "A rollback for #{rollback.since_commit.sha} has been triggered. " \
-        "Please make sure the reason for the rollback has been addressed before deploying again."
-      stack.update!(lock_reason: lock_reason, lock_author_id: user.id)
+      if lock
+        lock_reason = "A rollback for #{rollback.since_commit.sha} has been triggered. " \
+          "Please make sure the reason for the rollback has been addressed before deploying again."
+        stack.update!(lock_reason: lock_reason, lock_author_id: user.id)
+      end
 
       rollback
     end

--- a/test/models/deploys_test.rb
+++ b/test/models/deploys_test.rb
@@ -802,6 +802,12 @@ module Shipit
       assert_equal @user, @stack.lock_author
     end
 
+    test "#trigger_rollback does not lock the stack if not requested" do
+      refute @stack.locked?
+      @deploy.trigger_rollback(@user, lock: false)
+      refute @stack.reload.locked?
+    end
+
     test "#trigger_rollback marks the rollback as `ignored_safeties` if the force option was used" do
       rollback = @deploy.trigger_rollback(@user, force: true)
       assert_predicate rollback, :ignored_safeties?


### PR DESCRIPTION
### What

Adds a param to control whether to lock when a rollback is triggered. Defaults to true so not breaking current behaviour.

### Why

In our use case, deploys will be triggered by a separate application via the api. If a certain commit is not desired, we both rollback the deploy and drop the commit (and all later commits) from the tracked branch. In this case we do not required a lock because the system is working as intended.