### PR TITLE
Fix rubocop failures on master

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -56,3 +56,12 @@ Style/StringLiterals:
 
 Style/StringLiteralsInInterpolation:
   Enabled: false
+
+Style/WordArray:
+  Enabled: false
+
+Style/SymbolArray:
+  Enabled: false
+
+Naming/InclusiveLanguage:
+  Enabled: false

--- a/app/models/shipit/repository.rb
+++ b/app/models/shipit/repository.rb
@@ -38,7 +38,7 @@ module Shipit
     private_constant :NAME_MAX_SIZE
 
     validates :name, uniqueness: { scope: %i(owner), case_sensitive: false,
-                                   message: 'cannot be used more than once' }
+                                   message: 'cannot be used more than once', }
     validates :owner, :name, presence: true, ascii_only: true
     validates :owner, format: { with: /\A[a-z0-9_\-\.]+\z/ }, length: { maximum: OWNER_MAX_SIZE }
     validates :name, format: { with: /\A[a-z0-9_\-\.]+\z/ }, length: { maximum: NAME_MAX_SIZE }

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -93,7 +93,7 @@ module Shipit
 
     validates :repository, uniqueness: {
       scope: %i(environment), case_sensitive: false,
-      message: 'cannot be used more than once with this environment. Check archived stacks.'
+      message: 'cannot be used more than once with this environment. Check archived stacks.',
     }
     validates :environment, format: { with: /\A[a-z0-9\-_\:]+\z/ }, length: { maximum: ENVIRONMENT_MAX_SIZE }
     validates :deploy_url, format: { with: URI.regexp(%w(http https ssh)) }, allow_blank: true

--- a/test/unit/deploy_commands_test.rb
+++ b/test/unit/deploy_commands_test.rb
@@ -121,7 +121,7 @@ module Shipit
       clone_args = [
         'git', 'clone', '--quiet',
         '--local', '--origin', 'cache',
-        @stack.git_path.to_s, @deploy.working_directory
+        @stack.git_path.to_s, @deploy.working_directory,
       ]
       assert_equal clone_args, commands.first.args
       assert_equal ['git', 'remote', 'add', 'origin', @stack.repo_git_url.to_s], commands.second.args


### PR DESCRIPTION
It looks like when [ci requirements were updated](https://github.com/shopify/shipit-engine/commit/e9ca0dee3faaf4626ed54bc1e99551267d489f9a) it added some new cops.

To limit the amount of review required so that the rest of the commits waiting can go out, I've turned off the ones that were causing 50+ changes.