### PR TITLE
Adjust padding in plugins container

### DIFF
--- a/app/assets/stylesheets/_pages/_deploy.scss
+++ b/app/assets/stylesheets/_pages/_deploy.scss
@@ -196,8 +196,6 @@
   width: 100%;
   overflow-y: auto;
   overflow-x: hidden;
-  padding-right: 20px;
-  padding-left: 15px;
 }
 
 .commit-checks {


### PR DESCRIPTION
Before (the div is way bigger than its container):

<img width="399" alt="Screenshot 2021-07-27 at 13 28 03" src="https://user-images.githubusercontent.com/522155/127167240-267801a1-a421-4ef6-a1a7-a93a80c8a8f3.png">

After (the div is properly sized):

<img width="429" alt="Screenshot 2021-07-27 at 13 27 47" src="https://user-images.githubusercontent.com/522155/127167253-fca377d0-a446-4e40-9043-8fde3c83cb99.png">
