### PR TITLE
Fix the setup script and add it to CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -172,3 +172,25 @@ jobs:
         bundle install --jobs 4 --retry 3
         bundle exec rake db:create db:schema:load test
         bundle exec rake db:seed
+
+  setup:
+    name: Test setup script
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - name: Set up Ruby
+      uses: actions/setup-ruby@v1
+      with:
+        ruby-version: 3.0.x
+    - name: Run setup script
+      run: |
+        git config --global user.email "you@example.com"
+        git config --global user.name "Your Name"
+
+        export SHIPIT_GEM_PATH="${PWD}"
+        mkdir /tmp/new-app
+        cd /tmp/new-app
+        gem install rails -v '~> 6.1.4' --no-document
+        rails _6.1.4_ new shipit --skip-action-cable --skip-turbolinks --skip-action-mailer --skip-active-storage --skip-webpack-install --skip-action-mailbox --skip-action-text -m "${SHIPIT_GEM_PATH}/template.rb"
+      env:
+        SHIPIT_EDGE: "1"

--- a/shipit-engine.gemspec
+++ b/shipit-engine.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_dependency('redis-objects', '~> 1.5')
   s.add_dependency('responders', '~> 3.0')
   s.add_dependency('safe_yaml', '~> 1.0.4')
-  s.add_dependency('sass-rails', '~> 5.0')
+  s.add_dependency('sass-rails', '>= 5.0')
   s.add_dependency('securecompare', '~> 1.0.0')
   s.add_dependency('sprockets-rails', '>= 2.3.2')
   s.add_dependency('state_machines-activerecord', '~> 0.8.0')

--- a/template.rb
+++ b/template.rb
@@ -10,7 +10,11 @@ end
 route %(mount Shipit::Engine, at: '/')
 
 gem 'sidekiq'
-gem 'shipit-engine'
+if ENV['SHIPIT_GEM_PATH']
+  gem 'shipit-engine', path: ENV['SHIPIT_GEM_PATH']
+else
+  gem 'shipit-engine'
+end
 gsub_file 'Gemfile', "# Use Redis adapter to run Action Cable in production", ''
 gsub_file 'Gemfile', "# gem 'redis'", "gem 'redis'"
 


### PR DESCRIPTION
Fix: https://github.com/Shopify/shipit-engine/issues/1197

We used to run the setup script as part of CI when we were on Travis, should should have it back as it's way too easy to break.