### PR TITLE
Don't mark rollback tasks as faulty

### DIFF
--- a/app/models/shipit/rollback.rb
+++ b/app/models/shipit/rollback.rb
@@ -33,6 +33,10 @@ module Shipit
       'deploys/deploy'
     end
 
+    def report_complete!
+      complete!
+    end
+
     private
 
     def update_release_status
@@ -40,6 +44,7 @@ module Shipit
 
       # When we rollback to a certain revision, assume that all later deploys were faulty
       stack.deploys.newer_than(deploy.id).until(stack.last_completed_deploy.id).to_a.each do |deploy|
+        next if deploy.id == id
         deploy.report_faulty!(description: "A rollback of #{stack.to_param} was triggered")
       end
     end


### PR DESCRIPTION
Shipit-engine currently marks successful rollback tasks as faulty. This is because `update_release_status` runs for any changes in transitions. And when the rollback task succeeds the last completed task  (`stack.last_completed_deploy.id`) is itself and thus marks itself as faulty. 

I also overrode `report_complete!` so rollbacks will not be entering validations.