### PR TITLE
Allow the deploy banner to stretch so that buttons do not get hidden

### DIFF
--- a/app/assets/stylesheets/_pages/_deploy.scss
+++ b/app/assets/stylesheets/_pages/_deploy.scss
@@ -67,7 +67,8 @@
 }
 
 .deploy-banner {
-  height: 4rem;
+  min-height: 4rem;
+  height: auto;
   background-color: #f0f4f7;
   display: flex;
   justify-content: center;


### PR DESCRIPTION
Right now it's possible for the text of the "Abort" and "Abort and Rollback" buttons to be cut-off if users are viewing this on smaller screens. This PR allows the banner to stretch taller to accommodate those buttons.

The issue:
<img width="1116" alt="Screen Shot 2021-08-17 at 4 05 42 PM" src="https://user-images.githubusercontent.com/77460334/129807141-018f1f66-cd9d-4d6d-80ca-2bba0a55701d.png">
