### PR TITLE
Fix the setup script CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -191,6 +191,6 @@ jobs:
         mkdir /tmp/new-app
         cd /tmp/new-app
         gem install rails -v '~> 6.1.4' --no-document
-        rails _6.1.4_ new shipit --skip-action-cable --skip-turbolinks --skip-action-mailer --skip-active-storage --skip-webpack-install --skip-action-mailbox --skip-action-text -m "${SHIPIT_GEM_PATH}/template.rb"
+        rails new shipit --skip-action-cable --skip-turbolinks --skip-action-mailer --skip-active-storage --skip-webpack-install --skip-action-mailbox --skip-action-text -m "${SHIPIT_GEM_PATH}/template.rb"
       env:
         SHIPIT_EDGE: "1"


### PR DESCRIPTION
It broke as soon as a rails `6.1.4.1` was released... I think if we don't specify the version in `rails new` we might be a bit more resilient.