### PR TITLE
Skip git submodules when not necessary

### DIFF
--- a/lib/shipit/stack_commands.rb
+++ b/lib/shipit/stack_commands.rb
@@ -48,12 +48,12 @@ module Shipit
     end
 
     def build_cacheable_deploy_spec
-      with_temporary_working_directory do |dir|
+      with_temporary_working_directory(recursive: false) do |dir|
         DeploySpec::FileSystem.new(dir, @stack.environment).cacheable
       end
     end
 
-    def with_temporary_working_directory(commit: nil)
+    def with_temporary_working_directory(commit: nil, recursive: true)
       commit ||= @stack.last_deployed_commit.presence || @stack.commits.reachable.last
 
       if !commit || !fetched?(commit).tap(&:run).success?
@@ -64,10 +64,12 @@ module Shipit
         end
       end
 
+      git_args = []
+      git_args << '--recursive' if recursive
       Dir.mktmpdir do |dir|
         git(
           'clone', @stack.git_path, @stack.repo_name,
-          '--recursive', '--origin', 'cache',
+          *git_args, '--origin', 'cache',
           chdir: dir
         ).run!
 


### PR DESCRIPTION
For some jobs we know we don't need the submodules. e.g. `build_cacheable_deploy_spec`.

So we can save a lot of time and network by skipping it.