### PR TITLE
Properly pass the base env to git commands

### DIFF
--- a/lib/shipit/commands.rb
+++ b/lib/shipit/commands.rb
@@ -28,7 +28,9 @@ module Shipit
     end
 
     def git(*args)
-      Command.new("git", *args)
+      kwargs = args.extract_options!
+      kwargs[:env] ||= env
+      Command.new("git", *args, **kwargs)
     end
     ruby2_keywords :git if respond_to?(:ruby2_keywords, true)
 


### PR DESCRIPTION
Commands using the `git()` helper wouldn't get the base environment, which very importantly include `GIT_ASKPASS`, so in many case they can fail.
