### PR TITLE
Avoid reading the shipit.yml before the repo is fully cloned

### DIFF
--- a/lib/shipit/commands.rb
+++ b/lib/shipit/commands.rb
@@ -20,21 +20,25 @@ module Shipit
     delegate :git_version, to: :class
 
     def env
-      @env ||= Shipit.env.merge(
-        'GITHUB_DOMAIN' => github.domain,
-        'GITHUB_TOKEN' => github.token,
-        'GIT_ASKPASS' => Shipit::Engine.root.join('lib', 'snippets', 'git-askpass').realpath.to_s,
-      )
+      base_env
     end
 
     def git(*args)
       kwargs = args.extract_options!
-      kwargs[:env] ||= env
+      kwargs[:env] ||= base_env
       Command.new("git", *args, **kwargs)
     end
     ruby2_keywords :git if respond_to?(:ruby2_keywords, true)
 
     private
+
+    def base_env
+      @base_env ||= Shipit.env.merge(
+        'GITHUB_DOMAIN' => github.domain,
+        'GITHUB_TOKEN' => github.token,
+        'GIT_ASKPASS' => Shipit::Engine.root.join('lib', 'snippets', 'git-askpass').realpath.to_s,
+      )
+    end
 
     def github
       Shipit.github


### PR DESCRIPTION
By accessing `env`, we ended up reading the shipit.yml before the proper revision was checked out. So we were reading outdated configurations.

NB: this is a quick fix. We should keep some state in the object to know when we checked out the repo, and blow up of the `deploy_spec` is read before.