### PR TITLE
Clarify deploy start and finish datetime

### DIFF
--- a/app/views/shipit/deploys/_deploy.html.erb
+++ b/app/views/shipit/deploys/_deploy.html.erb
@@ -30,12 +30,12 @@
       </p>
       <p class="commit-meta">
         <% if read_only %>
-          <span class="utc-timecode">on <%= deploy.created_at.strftime('%Y-%m-%d %H:%M:%S') %> UTC</span>
+          Started <span class="utc-timecode">on <%= deploy.created_at.strftime('%Y-%m-%d %H:%M:%S') %> UTC</span>
         <% else %>
-          <%= timeago_tag(deploy.created_at, force: true) %>
+          Started <%= timeago_tag(deploy.created_at, force: true) %>
         <% end %>
         <% if deploy.duration? %>
-          in <%= deploy.duration %>
+          and finished in <%= deploy.duration %>
         <% end %>
       </p>
     </div>


### PR DESCRIPTION
This commit clarifies when a deploy started:

- Before: "20 minutes ago in 3m21"
- After: "Started 20 minutes ago and finished in 3m21s"

Without this commit, it's unclear whether the "20 minutes"
part is when the deploy started or when it finished.

With this commit, it's much clearer.