### PR TITLE
Run git commands less noisily

### DIFF
--- a/lib/shipit/stack_commands.rb
+++ b/lib/shipit/stack_commands.rb
@@ -72,7 +72,7 @@ module Shipit
         ).run!
 
         git_dir = File.join(dir, @stack.repo_name)
-        git('checkout', commit.sha, chdir: git_dir).run! if commit
+        git('checkout', '--config', 'advice.detachedHead=false', commit.sha, chdir: git_dir).run! if commit
         yield Pathname.new(git_dir)
       end
     end
@@ -90,7 +90,7 @@ module Shipit
     end
 
     def git_clone(url, path, branch: 'master', **kwargs)
-      git('clone', *modern_git_args, '--recursive', '--branch', branch, url, path, **kwargs)
+      git('clone', '--quiet', *modern_git_args, '--recursive', '--branch', branch, url, path, **kwargs)
     end
 
     def modern_git_args

--- a/test/unit/deploy_commands_test.rb
+++ b/test/unit/deploy_commands_test.rb
@@ -44,7 +44,7 @@ module Shipit
 
       command = @commands.fetch
 
-      expected = %W(git clone --single-branch --recursive --branch master #{@stack.repo_git_url} #{@stack.git_path})
+      expected = %W(git clone --quiet --single-branch --recursive --branch master #{@stack.repo_git_url} #{@stack.git_path})
       assert_equal expected, command.args.map(&:to_s)
     end
 
@@ -54,7 +54,7 @@ module Shipit
 
       command = @commands.fetch
 
-      expected = %W(git clone --single-branch --recursive --branch master #{@stack.repo_git_url} #{@stack.git_path})
+      expected = %W(git clone --quiet --single-branch --recursive --branch master #{@stack.repo_git_url} #{@stack.git_path})
       assert_equal expected, command.args
     end
 
@@ -67,7 +67,7 @@ module Shipit
 
       command = @commands.fetch
 
-      expected = %W(git clone --single-branch --recursive --branch master #{@stack.repo_git_url} #{@stack.git_path})
+      expected = %W(git clone --quiet --single-branch --recursive --branch master #{@stack.repo_git_url} #{@stack.git_path})
       assert_equal expected, command.args
     end
 
@@ -81,7 +81,7 @@ module Shipit
 
       command = @commands.fetch
 
-      expected = %W(git clone --single-branch --recursive --branch master #{@stack.repo_git_url} #{@stack.git_path})
+      expected = %W(git clone --quiet --single-branch --recursive --branch master #{@stack.repo_git_url} #{@stack.git_path})
       assert_equal expected, command.args
     end
 
@@ -91,7 +91,7 @@ module Shipit
 
       command = @commands.fetch
 
-      expected = %W(git clone --recursive --branch master #{@stack.repo_git_url} #{@stack.git_path})
+      expected = %W(git clone --quiet --recursive --branch master #{@stack.repo_git_url} #{@stack.git_path})
       assert_equal expected, command.args.map(&:to_s)
     end
 


### PR DESCRIPTION
The initial `git clone` spams the log with progress output:

```
$ git clone --single-branch --recursive --branch master https://github.com/shopify/shipit.git /app/data/stacks/shopify/shipit/production/git
pid: 32373
Cloning into '/app/data/stacks/shopify/shipit/production/git'...
remote: Enumerating objects: 21925, done.        
remote: Counting objects:   0% (1/2009)        
remote: Counting objects:   1% (21/2009)        
remote: Counting objects:   2% (41/2009)        
...
```
_many many lines later_
```
...
Resolving deltas:  99% (14043/14182)   
Resolving deltas: 100% (14182/14182)   
Resolving deltas: 100% (14182/14182), done.
```

Adding a `--quiet` to keep git quieter.

The commit hash checkout results in git giving us a lecture about detached heads:

```
$ git checkout 0216b407c09b8198caec9ec12786e3c6a952cb1c
pid: 32416

Note: checking out '0216b407c09b8198caec9ec12786e3c6a952cb1c'.

You are in 'detached HEAD' state. You can look around, make experimental
changes and commit them, and you can discard any commits you make in this
state without impacting any branches by performing another checkout.

If you want to create a new branch to retain commits you create, you may
do so (now or later) by using -b with the checkout command again. Example:

  git checkout -b <new-branch-name>
```

Adding `--config advice.detachedHead=false` to turn off this advisory.