### PR TITLE
Use -c not --config and order matters

### DIFF
--- a/lib/shipit/stack_commands.rb
+++ b/lib/shipit/stack_commands.rb
@@ -72,7 +72,7 @@ module Shipit
         ).run!
 
         git_dir = File.join(dir, @stack.repo_name)
-        git('checkout', '--config', 'advice.detachedHead=false', commit.sha, chdir: git_dir).run! if commit
+        git('-c', 'advice.detachedHead=false', 'checkout', commit.sha, chdir: git_dir).run! if commit
         yield Pathname.new(git_dir)
       end
     end

--- a/lib/shipit/task_commands.rb
+++ b/lib/shipit/task_commands.rb
@@ -47,7 +47,7 @@ module Shipit
     end
 
     def checkout(commit)
-      git('checkout', commit.sha, chdir: @task.working_directory)
+      git('-c', 'advice.detachedHead=false', 'checkout', commit.sha, chdir: @task.working_directory)
     end
 
     def clone

--- a/test/unit/deploy_commands_test.rb
+++ b/test/unit/deploy_commands_test.rb
@@ -134,7 +134,7 @@ module Shipit
 
     test "#checkout checks out the deployed commit" do
       command = @commands.checkout(@deploy.until_commit)
-      assert_equal ['git', 'checkout', @deploy.until_commit.sha], command.args
+      assert_equal ['git', '-c', 'advice.detachedHead=false', 'checkout', @deploy.until_commit.sha], command.args
     end
 
     test "#checkout checks out the deployed commit from the working directory" do


### PR DESCRIPTION
Follow up to #1221

* The position of the switch matters, and there's no `--config` alias for `-c`.
* Also missed another spot where a commit checkout happens

Big oof on my part. 