### PR TITLE
Perform fetch without progress output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Unreleased
 
+* Suppress git fetch progress output. (#1225)
+
 # 0.35.1
 
 * Fixup #1219: Suppress detached head advisory. (#1222)

--- a/lib/shipit/stack_commands.rb
+++ b/lib/shipit/stack_commands.rb
@@ -16,7 +16,7 @@ module Shipit
     def fetch
       create_directories
       if valid_git_repository?(@stack.git_path)
-        git('fetch', 'origin', '--tags', @stack.branch, env: env, chdir: @stack.git_path)
+        git('fetch', 'origin', '--quiet', '--tags', @stack.branch, env: env, chdir: @stack.git_path)
       else
         @stack.clear_git_cache!
         git_clone(@stack.repo_git_url, @stack.git_path, branch: @stack.branch, env: env, chdir: @stack.deploys_path)

--- a/test/unit/deploy_commands_test.rb
+++ b/test/unit/deploy_commands_test.rb
@@ -27,7 +27,7 @@ module Shipit
 
       command = @commands.fetch
 
-      assert_equal %w(git fetch origin --tags master), command.args
+      assert_equal %w(git fetch origin --quiet --tags master), command.args
     end
 
     test "#fetch calls git fetch in git_path directory if repository cache already exist" do


### PR DESCRIPTION
The fetch output fills up the log with A LOT OF progress output:

```
$ git fetch origin --tags main
pid: 37023
remote: Enumerating objects: 269, done.        
remote: Counting objects:   0% (1/269)        
remote: Counting objects:   1% (3/269)        
remote: Counting objects:   2% (6/269)        
remote: Counting objects:   3% (9/269)        
...
Resolving deltas:  99% (117/118)   
Resolving deltas: 100% (118/118)   
Resolving deltas: 100% (118/118), completed with 7 local objects.
```

(This also causes garbled rendering on Shipit)

Adding `--quiet` suppresses all of it.

Tested by running the combined arguments locally on some repo:

```
git fetch origin --quiet --tags master
```
