### PR TITLE
Stacks refresh api endpoint

### DIFF
--- a/app/controllers/shipit/api/stacks_controller.rb
+++ b/app/controllers/shipit/api/stacks_controller.rb
@@ -60,6 +60,11 @@ module Shipit
         head(:accepted)
       end
 
+      def refresh
+        GithubSyncJob.perform_later(id: stack.id)
+        render_resource(stack, status: :accepted)
+      end
+
       private
 
       def create_params

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,6 +20,7 @@ Shipit::Engine.routes.draw do
       get '/' => 'stacks#show'
       delete '/' => 'stacks#destroy'
       patch '/' => 'stacks#update'
+      post '/refresh' => 'stacks#refresh'
     end
 
     scope '/stacks/*stack_id', stack_id: stack_id_format, as: :stack do

--- a/test/controllers/api/stacks_controller_test.rb
+++ b/test/controllers/api/stacks_controller_test.rb
@@ -189,6 +189,13 @@ module Shipit
         assert_response :forbidden
         assert_json 'message', 'This operation requires the `write:stack` permission'
       end
+
+      test "#refresh queues a GithubSyncJob" do
+        assert_enqueued_with(job: GithubSyncJob, args: [id: @stack.id]) do
+          post :refresh, params: { id: @stack.to_param }
+        end
+        assert_response :accepted
+      end
     end
   end
 end


### PR DESCRIPTION
Adding a stacks refresh API endpoint, so other systems relying on shipit to deploy have better control over syncing. Users also don't have to rely only on shipit UI to sync with github