### PR TITLE
Adjust GitHub team slug size

### DIFF
--- a/db/migrate/20211103154121_increase_github_team_slug_size.rb
+++ b/db/migrate/20211103154121_increase_github_team_slug_size.rb
@@ -1,0 +1,5 @@
+class IncreaseGithubTeamSlugSize < ActiveRecord::Migration[6.1]
+  def change
+    change_column :teams, :slug, :string, limit: 255, null: true
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_08_23_075617) do
+ActiveRecord::Schema.define(version: 2021_11_03_154121) do
 
   create_table "api_clients", force: :cascade do |t|
     t.text "permissions", limit: 65535
@@ -315,7 +315,7 @@ ActiveRecord::Schema.define(version: 2021_08_23_075617) do
   create_table "teams", force: :cascade do |t|
     t.integer "github_id", limit: 4
     t.string "api_url", limit: 255
-    t.string "slug", limit: 50
+    t.string "slug", limit: 255
     t.string "name", limit: 255
     t.string "organization", limit: 39
     t.datetime "created_at", null: false


### PR DESCRIPTION
GitHub does not seem to specify a limit to the maximum length of a team name or slug size. I've observed a couple of instances of a team slug being too big for this field, so this PR updates it to the max string size (255), which matches the Team Name max length as well.

Another option would be to trim the slug, but it's used in record lookups and creation, so that could be problematic. Likewise, it could potentially be used in API requests at some point (though I don't think we do so here), and so it makes more sense to keep the field "accurate" to the information we receive.

A last option would be to change the field to the TEXT type, but I think we would also want to change the team name to be a longer length as well, and I'm not sure if we've seen a slug longer than (or approaching) 255 before. So I think this is a simple approach we can take for now, and we can alter both fields together at a later date if it becomes necessary.