### PR TITLE
Change maximum commits message

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -41,7 +41,7 @@ en:
     reject: Mark the release as faulty
   deploy_button:
     hint:
-      max_commits: It is recommended not to deploy more than %{maximum} commits at once.
+      max_commits: Use caution when deploying more than %{maximum} commits at once.
       blocked: This commit range includes a commit that can't be deployed.
     caption:
       pending: Pending CI


### PR DESCRIPTION
This is just a small update to the content of the "lots of commits" warning message.

The old message:

```
It is recommended not to deploy more than %{maximum} commits at once.
```

This is a warning but the word "not" is 4 words into the sentence and it isn't immediately clear that it's something you should take note of. Also, "it is recommended" is passive voice and doesn't make it clear where the recommendation comes from. I considered "we do not recommend..." but then it's still not clear who `we` is.

The new message:

```
Use caution when deploying more than %{maximum} commits at once.
```

"Use caution" is the first thing you see. It's still a recommendation but I think a bit more forceful.

----

I think there's a lot more content changes that could be made here, but this is a start. I'd be happy to revisit this sometime soon.