### PR TITLE
Detect and refresh legacy GitHub user tokens

### DIFF
--- a/app/controllers/concerns/shipit/authentication.rb
+++ b/app/controllers/concerns/shipit/authentication.rb
@@ -17,7 +17,11 @@ module Shipit
     private
 
     def force_github_authentication
-      if Shipit.authentication_disabled? || current_user.logged_in?
+      if current_user.logged_in? && current_user.requires_fresh_login?
+        Rails.logger.warn("User #{current_user.id} requires a fresh login, logging out...")
+        reset_session
+        redirect_to(Shipit::Engine.routes.url_helpers.github_authentication_path(origin: request.original_url))
+      elsif Shipit.authentication_disabled? || current_user.logged_in?
         unless current_user.authorized?
           team_handles = Shipit.github_teams.map(&:handle)
           team_list = team_handles.to_sentence(two_words_connector: ' or ', last_word_connector: ', or ')

--- a/app/models/shipit/anonymous_user.rb
+++ b/app/models/shipit/anonymous_user.rb
@@ -31,6 +31,10 @@ module Shipit
       false
     end
 
+    def requires_fresh_login?
+      false
+    end
+
     def authorized?
       Shipit.authentication_disabled?
     end

--- a/app/models/shipit/user.rb
+++ b/app/models/shipit/user.rb
@@ -123,6 +123,13 @@ module Shipit
       DEFAULT_AVATAR.dup
     end
 
+    # https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats
+    GITHUB_TOKEN_FORMAT = /^gh[a-z]_/
+
+    def requires_fresh_login?
+      github_access_token.present? && !github_access_token.match(GITHUB_TOKEN_FORMAT)
+    end
+
     private
 
     def identify_renamed_user!

--- a/test/controllers/stacks_controller_test.rb
+++ b/test/controllers/stacks_controller_test.rb
@@ -36,6 +36,17 @@ module Shipit
       assert_redirected_to '/github/auth/github?origin=http%3A%2F%2Ftest.host%2F'
     end
 
+    test "users which require a fresh login are redirected" do
+      user = shipit_users(:walrus)
+      user.update!(github_access_token: 'some_legacy_value')
+      assert_predicate user, :requires_fresh_login?
+
+      get :index
+
+      assert_redirected_to '/github/auth/github?origin=http%3A%2F%2Ftest.host%2F'
+      assert_nil session[:user_id]
+    end
+
     test "current_user must be a member of at least a Shipit.github_teams" do
       session[:user_id] = shipit_users(:bob).id
       Shipit.stubs(:github_teams).returns([shipit_teams(:cyclimse_cooks), shipit_teams(:shopify_developers)])

--- a/test/fixtures/shipit/users.yml
+++ b/test/fixtures/shipit/users.yml
@@ -2,15 +2,15 @@ walrus:
   name:  Lando Walrussian
   email: walrus@shopify.com
   login: walrus
-  encrypted_github_access_token: "ffHk4diyVKppJGfwfJefMizxF45H\n" # t0k3n
-  encrypted_github_access_token_iv: "gRSldoTZ+fmrIDoY\n"
+  encrypted_github_access_token: "n5J+kyq6EQPI/kRu3JjGAaTWXDCVsH5UBw==\n" # ghu_t0k3n
+  encrypted_github_access_token_iv: "ovGDX8uyBC4ynp/T\n"
 
 codertocat:
   name: Coding Cat
   email: coding@cat.com
   login: Codertocat
-  encrypted_github_access_token: "ffHk4diyVKppJGfwfJefMizxF45H\n" # t0k3n
-  encrypted_github_access_token_iv: "gRSldoTZ+fmrIDoY\n"
+  encrypted_github_access_token: "n5J+kyq6EQPI/kRu3JjGAaTWXDCVsH5UBw==\n" # ghu_t0k3n
+  encrypted_github_access_token_iv: "ovGDX8uyBC4ynp/T\n"
 
 bob:
   name:  Bob the Builder

--- a/test/models/users_test.rb
+++ b/test/models/users_test.rb
@@ -226,9 +226,9 @@ module Shipit
       assert_nil legacy.encrypted_github_access_token
       assert_nil legacy.encrypted_github_access_token_iv
 
-      legacy.update!(github_access_token: 't0k3n')
+      legacy.update!(github_access_token: 'ghu_t0k3n')
       legacy.reload
-      assert_equal 't0k3n', legacy.github_access_token
+      assert_equal 'ghu_t0k3n', legacy.github_access_token
     end
 
     test "users are always logged_in?" do
@@ -272,6 +272,21 @@ module Shipit
       )
       found_user = Shipit::User.find_or_create_author_from_github_commit(github_commit)
       assert_equal user, found_user
+    end
+
+    test "requires_fresh_login? defaults to false" do
+      u = User.new
+      refute_predicate u, :requires_fresh_login?
+    end
+
+    test "requires_fresh_login? is true for users with legacy github_access_token" do
+      @user.update!(github_access_token: 'some_legacy_value')
+      assert_predicate @user, :requires_fresh_login?
+    end
+
+    test "requires_fresh_login? is false for users with a new format github_access_token" do
+      @user.update!(github_access_token: 'ghu_tok3n')
+      refute_predicate @user, :requires_fresh_login?
     end
 
     private


### PR DESCRIPTION
We received this from GitHub regarding our production instance:

> We noticed that an application, Shopify Shipit, owned by an organization you are an admin of, Shopify, used a token with an outdated format to access the GitHub API ...
> 
> ... we encourage you to reset any authentication tokens used by this app, as well as tokens used by any other apps you may have, with our reset token API.
> 
> Alternatively, you can prompt your users to step through the authorization flow again, as outlined in the docs for either GitHub Apps and OAuth Apps.
> 
> To understand more about this change and why it's important, visit https://github.blog/2021-04-05-behind-githubs-new-authentication-token-formats.

This PR will detect tokens in the legacy format and take users back through the GitHub login flow to fetch an updated one. Because we aren't asking for updated permissions, this will be totally transparent to the end user - just a slightly longer page load as the browser follow some redirects to GitHub and back again. I 🎩'd this locally by updating my user with a garbage token (`user.update!(github_access_token: 'blah')` and reloading the page - it worked as intended.