### PR TITLE
Clarify error when branch is renamed

### DIFF
--- a/app/views/shipit/stacks/_banners.html.erb
+++ b/app/views/shipit/stacks/_banners.html.erb
@@ -23,7 +23,7 @@
           <%= link_to stack.github_repo_name, github_repo_url(stack.repo_owner, stack.repo_name) %>
           has been inaccessible for <%= time_ago_in_words(stack.inaccessible_since) %>.
 
-          This could be a permission issue, or the repository have been deleted on GitHub.
+          This could be a permission issue, or the repo could have changed on GitHub.
         </p>
       </div>
     </div>


### PR DESCRIPTION
Clarifies error shown when branch is renamed on GitHub.