### PR TITLE
Now serializes "ignore_ci" attribute of Stacks

### DIFF
--- a/app/serializers/shipit/stack_serializer.rb
+++ b/app/serializers/shipit/stack_serializer.rb
@@ -8,7 +8,7 @@ module Shipit
     attributes :id, :repo_owner, :repo_name, :environment, :html_url, :url, :tasks_url, :deploy_url,
       :merge_requests_url, :deploy_spec, :undeployed_commits_count, :is_locked, :lock_reason, :continuous_deployment,
       :created_at, :updated_at, :locked_since, :last_deployed_at, :branch, :merge_queue_enabled, :is_archived,
-      :archived_since
+      :archived_since, :ignore_ci
 
     def url
       api_stack_url(object)


### PR DESCRIPTION
This PR allows the REST API to additionally serialize the `ignore_ci: Boolean` attribute of Stacks.

The `GET /api/stacks/` endpoint response is enhanced with a new top-level key of the Stack object named `ignore_ci` which is a boolean value.