### PR TITLE
Rollback after abort when force param is used via api

### DIFF
--- a/app/controllers/shipit/api/rollbacks_controller.rb
+++ b/app/controllers/shipit/api/rollbacks_controller.rb
@@ -21,7 +21,7 @@ module Shipit
           param_error!(:force, "Can't rollback, deploy in progress")
         elsif stack.active_task?
           active_task = stack.active_task
-          active_task.abort!(aborted_by: current_user, rollback_once_aborted_to: deploy)
+          active_task.abort!(aborted_by: current_user, rollback_once_aborted_to: deploy, rollback_once_aborted: true)
           response = active_task
         else
           response = deploy.trigger_rollback(current_user, env: deploy_env, force: params.force, lock: params.lock)

--- a/test/controllers/api/rollback_controller_test.rb
+++ b/test/controllers/api/rollback_controller_test.rb
@@ -107,6 +107,7 @@ module Shipit
         assert_response :accepted
         refute_predicate last_deploy, :active?
         assert_json 'rollback_once_aborted_to.revision.sha', @commit.sha
+        assert last_deploy.rollback_once_aborted?
       end
     end
   end


### PR DESCRIPTION
### What

- So I believe this has actually been broken since it was added in https://github.com/Shopify/shipit-engine/pull/1087
- The issue is that while it correctly sets what to rollback to, without setting `rollback_once_aborted` the rollback will not trigger because that flag is checked before rolling back
https://github.com/Shopify/shipit-engine/blob/fcd420c2554e2b741d6595f365abbc2c0230bf06/app/models/shipit/deploy.rb#L288-L292
- Even in the initial PR in test, both params are set https://github.com/Shopify/shipit-engine/commit/d463adb758c29f38b9753a454a682c745f1a3f1e#diff-3130766d64891bca0b504fe915c08e798e04e2c9930cfeb64adc22ba60a7d8d0R312
- I believe the need for two flags is that when empty we rollback to the last commit, though it may make sense to bypass this flag if the rollback_to is set 🤷‍♂️ 