### PR TITLE
Allow nil deploy url

### DIFF
--- a/app/controllers/shipit/api/stacks_controller.rb
+++ b/app/controllers/shipit/api/stacks_controller.rb
@@ -27,7 +27,7 @@ module Shipit
         requires :repo_name, String
         accepts :environment, String
         accepts :branch, String
-        accepts :deploy_url, String
+        accepts :deploy_url, String, allow_nil: true
         accepts :ignore_ci, Boolean
         accepts :merge_queue_enabled, Boolean
         accepts :continuous_deployment, Boolean
@@ -42,7 +42,7 @@ module Shipit
       params do
         accepts :environment, String
         accepts :branch, String
-        accepts :deploy_url, String
+        accepts :deploy_url, String, allow_nil: true
         accepts :ignore_ci, Boolean
         accepts :merge_queue_enabled, Boolean
         accepts :continuous_deployment, Boolean

--- a/test/controllers/api/stacks_controller_test.rb
+++ b/test/controllers/api/stacks_controller_test.rb
@@ -96,6 +96,24 @@ module Shipit
         assert_equal 'test', @stack.branch
       end
 
+      test "#update updates the stack when nil deploy_url" do
+        @stack.update(deploy_url: nil)
+        @stack.update(continuous_deployment: true)
+        assert_nil @stack.deploy_url
+        assert @stack.continuous_deployment
+
+        patch :update, params: {
+          id: @stack.to_param,
+          continuous_deployment: false,
+        }
+
+        assert_response :ok
+        @stack.reload
+
+        assert_nil @stack.deploy_url
+        refute @stack.continuous_deployment
+      end
+
       test "#index returns a list of stacks" do
         stack = Stack.last
         get :index


### PR DESCRIPTION
Allows `nil` `deploy_url` in stack update and creation.