### PR TITLE
Move rollback button logic to a helper

### DIFF
--- a/app/helpers/shipit/stacks_helper.rb
+++ b/app/helpers/shipit/stacks_helper.rb
@@ -36,6 +36,17 @@ module Shipit
       link_to(t("deploy_button.caption.#{deploy_state}"), url, class: classes, data: data)
     end
 
+    def rollback_button(deploy)
+      if deploy.stack.active_task?
+        link_to('Deploy in progress...', '#', class: 'btn disabled deploy-action')
+      else
+        url = rollback_stack_deploy_path(deploy.stack, deploy)
+        classes = %w(btn btn--delete deploy-action rollback-action)
+
+        link_to('Rollback to this deploy...', url, class: classes)
+      end
+    end
+
     def github_change_url(commit)
       if commit.pull_request?
         github_pull_request_url(commit)

--- a/app/views/shipit/deploys/_deploy.html.erb
+++ b/app/views/shipit/deploys/_deploy.html.erb
@@ -55,11 +55,7 @@
   <% unless read_only %>
     <div class="deploy-actions">
       <% if deploy.rollbackable? %>
-        <% if deploy.stack.active_task? %>
-          <%= link_to 'Deploy in progress...', '#', class: 'btn disabled deploy-action' %>
-        <% else %>
-          <%= link_to 'Rollback to this deploy...', rollback_stack_deploy_path(@stack, deploy), class: 'btn btn--delete deploy-action rollback-action' %>
-        <% end %>
+        <%= rollback_button(deploy) %>
       <% elsif deploy.currently_deployed? && !deploy.stack.active_task? %>
         <%= redeploy_button(deploy.until_commit) %>
       <% end %>


### PR DESCRIPTION
### What

- Moves the logic surrounding the rollback button out of the erb and into a helper
- Allows for easier customization of the button itself