### PR TITLE
Configurable respect bare shipit file behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,19 @@ Lastly, if you override the `app_name` configuration in your Shipit deployment, 
 
 * * *
 
+<h3 id="respecting-bare-files">Respecting bare <code>shipit.yml</code> files</h3>
+
+Shipit will, by default, respect the "bare" <code>shipit.yml</code> file as a fallback option if no more specifically-named file exists (such as <code>shipit.staging.yml</code>).
+
+You can configure this behavior via the attribute <code>Shipit.respect_bare_shipit_file</code>.
+
+- The value <code>false</code> will disable this behavior and instead cause Shipit to emit an error upon deploy if Shipit cannot find a more specifically-named file.
+- Setting this attribute to any other value (**including <code>nil</code>**), or not setting this attribute, will cause Shipit to use the default behavior of respecting bare <code>shipit.yml</code> files.
+
+You can determine if Shipit is configured to respect bare files using <code>Shipit.respect_bare_shipit_file?</code>.
+
+* * *
+
 <h3 id="installing-dependencies">Installing dependencies</h3>
 
 The **<code>dependencies</code>** step allows you to install all the packages your deploy script needs.

--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -69,6 +69,7 @@ module Shipit
     :preferred_org_emails,
     :task_execution_strategy,
     :task_logger,
+    :respect_bare_shipit_file,
   )
 
   def task_execution_strategy
@@ -234,6 +235,13 @@ module Shipit
   def task_logger
     @task_logger ||= Logger.new(nil)
   end
+
+  def respect_bare_shipit_file
+    @respect_bare_shipit_file = true if @respect_bare_shipit_file.nil?
+    !!@respect_bare_shipit_file
+  end
+
+  alias_method :respect_bare_shipit_file?, :respect_bare_shipit_file
 
   protected
 

--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -63,13 +63,12 @@ module Shipit
 
   delegate :table_name_prefix, to: :secrets
 
-  attr_accessor :disable_api_authentication, :timeout_exit_codes, :deployment_checks
+  attr_accessor :disable_api_authentication, :timeout_exit_codes, :deployment_checks, :respect_bare_shipit_file
   attr_writer(
     :internal_hook_receivers,
     :preferred_org_emails,
     :task_execution_strategy,
     :task_logger,
-    :respect_bare_shipit_file,
   )
 
   def task_execution_strategy
@@ -77,6 +76,9 @@ module Shipit
   end
 
   self.timeout_exit_codes = [].freeze
+  self.respect_bare_shipit_file = true
+
+  alias_method :respect_bare_shipit_file?, :respect_bare_shipit_file
 
   def authentication_disabled?
     ENV['SHIPIT_DISABLE_AUTH'].present?
@@ -235,13 +237,6 @@ module Shipit
   def task_logger
     @task_logger ||= Logger.new(nil)
   end
-
-  def respect_bare_shipit_file
-    @respect_bare_shipit_file = true if @respect_bare_shipit_file.nil?
-    !!@respect_bare_shipit_file
-  end
-
-  alias_method :respect_bare_shipit_file?, :respect_bare_shipit_file
 
   protected
 

--- a/test/models/deploy_spec_test.rb
+++ b/test/models/deploy_spec_test.rb
@@ -286,29 +286,6 @@ module Shipit
       assert_equal({ 'GLOBAL' => '1' }, @spec.machine_env)
     end
 
-    test '#load_config can grab the env-specific shipit.yml file' do
-      config = {}
-      config.expects(:exist?).returns(true)
-      config.expects(:read).returns({ 'dependencies' => { 'override' => %w(foo bar baz) } }.to_yaml)
-      spec = DeploySpec::FileSystem.new('.', 'staging')
-      spec.expects(:file).with('shipit.staging.yml', root: true).returns(config)
-      assert_equal %w(foo bar baz), spec.dependencies_steps
-    end
-
-    test '#load_config grabs the global shipit.yml file if there is no env-specific file' do
-      not_config = {}
-      not_config.expects(:exist?).returns(false)
-
-      config = {}
-      config.expects(:exist?).returns(true)
-      config.expects(:read).returns({ 'dependencies' => { 'override' => %w(foo bar baz) } }.to_yaml)
-
-      spec = DeploySpec::FileSystem.new('.', 'staging')
-      spec.expects(:file).with('shipit.staging.yml', root: true).returns(not_config)
-      spec.expects(:file).with('shipit.yml', root: true).returns(config)
-      assert_equal %w(foo bar baz), spec.dependencies_steps
-    end
-
     test '#gemspec gives the path of the repo gemspec if present' do
       spec = DeploySpec::FileSystem.new('foobar/', 'production')
       Dir.expects(:[]).with('foobar/*.gemspec').returns(['foobar/foobar.gemspec'])

--- a/test/models/shipit/deploy_spec/file_system_test.rb
+++ b/test/models/shipit/deploy_spec/file_system_test.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+require 'test_helper'
+require 'tmpdir'
+
+module Shipit
+  class DeploySpec
+    class FileSystemTest < ActiveSupport::TestCase
+      test 'deploy.pre calls "exit 1" if there is a bare shipit file and Shipit is configured to ignore' do
+        Shipit.expects(:respect_bare_shipit_file?).returns(false).at_least_once
+        deploy_spec = Shipit::DeploySpec::FileSystem.new(Dir.tmpdir, 'env')
+        deploy_spec.expects(:config_file_path).returns(Pathname.new(Dir.tmpdir) + '/shipit.yml').at_least_once
+        deploy_spec.expects(:read_config).returns(SafeYAML.load(deploy_spec_yaml))
+        pre_commands = deploy_spec.send(:config, 'deploy', 'pre')
+        assert pre_commands.include?('exit 1')
+        assert pre_commands.first.include?('configured to ignore')
+        refute pre_commands.include?('test 2')
+      end
+
+      test 'deploy.pre does not call "exit 1" if Shipit is not configured to do so' do
+        Shipit.expects(:respect_bare_shipit_file?).returns(true).at_least_once
+        deploy_spec = Shipit::DeploySpec::FileSystem.new(Dir.tmpdir, 'env')
+        deploy_spec.expects(:config_file_path).returns(Pathname.new(Dir.tmpdir) + '/shipit.yml').at_least_once
+        deploy_spec.expects(:read_config).returns(SafeYAML.load(deploy_spec_yaml))
+        pre_commands = deploy_spec.send(:config, 'deploy', 'pre')
+        refute pre_commands.include?('exit 1')
+        assert pre_commands.include?('test 2')
+      end
+
+      test 'Shipit.respect_bare_shipit_file? has no effect if the file is not a bare file' do
+        [true, false].each do |obey_val|
+          Shipit.expects(:respect_bare_shipit_file?).returns(obey_val).at_least_once
+          deploy_spec = Shipit::DeploySpec::FileSystem.new(Dir.tmpdir, 'env')
+          deploy_spec.expects(:config_file_path).returns(Pathname.new(Dir.tmpdir) + '/shipit.env.yml').at_least_once
+          deploy_spec.expects(:read_config).returns(SafeYAML.load(deploy_spec_yaml))
+          pre_commands = deploy_spec.send(:config, 'deploy', 'pre')
+          refute pre_commands.include?('exit 1')
+          assert pre_commands.include?('test 2')
+        end
+      end
+
+      def deploy_spec_yaml
+        <<~EOYAML
+          deploy:
+            pre:
+              - test 2
+            override:
+              - test 1
+        EOYAML
+      end
+    end
+  end
+end


### PR DESCRIPTION
Resolves https://github.com/Shopify/shipit-next/issues/3563.

# Changes

- Expose a new interface to explicitly disable the handling of bare `shipit.yml` (or `#{app_name}.yml`) files via attribute `Shipit.respect_bare_shipit_file`
   - Behavior is configurable, but **left on by default to avoid breaking changes.**
- Continues to preserve the hierarchy of file naming conventions:
   1. `#{app_name}.#{env}.yml`
   2. `#{app_name}.yml`
   3. `shipit.#{env}.yml`
   4. `shipit.yml`
- Will explicitly override `deploy.pre` with an `exit 1` command and an informative error message when this flag is toggled to off and a deploy is attempted on a Stack with a bare file:

![invalid_shipit_file_message](https://user-images.githubusercontent.com/7741319/162835915-dd858dbf-89c3-49bb-8414-aeb9a2c4a85c.png)



