### PR TITLE
Use deep_merge! versus direct access

### DIFF
--- a/app/models/shipit/deploy_spec/file_system.rb
+++ b/app/models/shipit/deploy_spec/file_system.rb
@@ -96,7 +96,7 @@ module Shipit
         return if loaded_config&.empty?
 
         if !Shipit.respect_bare_shipit_file? && config_file_path.to_s.end_with?(*bare_shipit_filenames)
-          loaded_config["deploy"]["pre"] = [shipit_not_obeying_bare_file_echo_command, "exit 1"]
+          loaded_config.deep_merge!({ 'deploy' => { 'pre' => [shipit_not_obeying_bare_file_echo_command, 'exit 1'] } })
         end
         loaded_config
       end


### PR DESCRIPTION
# Changes

- Fixes the edge case where a deployment attempt occurs with `respect_bare_shipit_yml` set to false, but the `shipit.yml` does not contain a `deploy:` top level key.