### PR TITLE
Correct param argument for refresh controller

### DIFF
--- a/app/controllers/shipit/api/stacks_controller.rb
+++ b/app/controllers/shipit/api/stacks_controller.rb
@@ -62,7 +62,7 @@ module Shipit
       end
 
       def refresh
-        GithubSyncJob.perform_later(id: stack.id)
+        GithubSyncJob.perform_later(stack_id: stack.id)
         render_resource(stack, status: :accepted)
       end
 

--- a/test/controllers/api/stacks_controller_test.rb
+++ b/test/controllers/api/stacks_controller_test.rb
@@ -191,7 +191,7 @@ module Shipit
       end
 
       test "#refresh queues a GithubSyncJob" do
-        assert_enqueued_with(job: GithubSyncJob, args: [id: @stack.id]) do
+        assert_enqueued_with(job: GithubSyncJob, args: [stack_id: @stack.id]) do
           post :refresh, params: { id: @stack.to_param }
         end
         assert_response :accepted


### PR DESCRIPTION
Related to https://github.com/Shopify/shipit/issues/1988

This endpoint was exposed a while ago but was passing the wrong param argument