### PR TITLE
Evan/address empty file edge case

### DIFF
--- a/app/models/shipit/deploy_spec/file_system.rb
+++ b/app/models/shipit/deploy_spec/file_system.rb
@@ -92,13 +92,12 @@ module Shipit
 
       def load_config
         return if config_file_path.nil?
-        loaded_config = read_config(config_file_path)
-        return if loaded_config&.empty?
 
         if !Shipit.respect_bare_shipit_file? && config_file_path.to_s.end_with?(*bare_shipit_filenames)
-          loaded_config.deep_merge!({ 'deploy' => { 'pre' => [shipit_not_obeying_bare_file_echo_command, 'exit 1'] } })
+          return { 'deploy' => { 'pre' => [shipit_not_obeying_bare_file_echo_command, 'exit 1'] } }
         end
-        loaded_config
+
+        read_config(config_file_path)
       end
 
       def shipit_file_names_in_priority_order

--- a/dev.yml
+++ b/dev.yml
@@ -21,6 +21,7 @@ commands:
   bootstrap: bin/bootstrap shopify
   console: test/dummy/bin/rails console
   test: bin/rails test "$@"
+  style: bin/rubocop --auto-correct
 
 open:
   app: https://shipit-engine.myshopify.io


### PR DESCRIPTION
Fixes https://github.com/Shopify/shipit/issues/1989, an edge case when the file Shipit file exists, but is blank.

# Changes

- Simplify `FileSystem.load_config` to mirror more closely the previous behavior of returning the result of `read_config`.
- Now simply returns echo & exit commands as part of `deploy.pre` when a disrespected bare `shipit.yml` file is detected instead of attempting to merge it with the rest of the config.
   - Too many edge cases were cropping up when attempting to be smartly merging the config together, so now simply override the entire config with our echo & exit commands.