### PR TITLE
[Doc] Organise permissions in Github App creation

### DIFF
--- a/docs/setup.md
+++ b/docs/setup.md
@@ -28,22 +28,26 @@ You can create a new one for your organization at `https://github.com/organizati
   - Setup URL: Leave it empty.
   - Webhook URL: It must be set to `<homepage>/webhooks`, e.g. `https://example.com/webhooks`.
   - Webhook secret (optional): Fill it with some randomly generated string, and *keep it in clear on the side, you'll need it later*.
-  - Permissions:
-    - Repository metadata: Read-only
-    - Commit statuses: Read-only
+  - Repository permissions:
     - Checks: Read & write
+    - Commit statuses: Read-only
+    - Contents: Read & write (to allow merging)
     - Deployments: Read & write
-    - Pull requests: Read & write
-    - Organization members: Read-only
-    - Repository contents: Read & write (to allow merging)
     - Issues: Read & write (to allow closing related issues on merge)
+    - Metadata: Read-only
+    - Pull requests: Read & write
+
+  - Organization permissions:
+    - Members: Read-only
+    
   - Events:
-    - Status
+    - Check run
+    - Check suite
+    - Membership
     - Pull request
     - Push
-    - Membership
-    - Check suite
-    - Check run
+    - Status
+
 
 ## Installing the GitHub App on your organization
 


### PR DESCRIPTION
Hi,

I was creating the Github app and have seen that the permissions listed are not in the good order, with the same label than Github, so we have to search for them in the page.

This PR just fixes it, so it'll be easier to follow the instructions.

Thanks!