### PR TITLE
Change `emit_lock_hooks` to not check for `previous_changes` in order to enable it running after "Abort & Rollback" is clicked

### DIFF
--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -642,9 +642,7 @@ module Shipit
     end
 
     def emit_lock_hooks
-      return unless previous_changes.include?('lock_reason')
-
-      lock_details = if previous_changes['lock_reason'].last.blank?
+      lock_details = if previous_changes.include?('lock_reason') && previous_changes['lock_reason'].last.blank?
         { from: previous_changes['locked_since'].first, until: Time.zone.now }
       end
 


### PR DESCRIPTION
**What:**
This gets rid of the automatic return in `emit_lock_hooks` if `previous_changes` doesn't contain a change to `lock_reason`.

**Why:**
Right now, hitting "Abort & Rollback" on a deploy does not actually end up emitting a lock hook. This is because of [this behavior](https://medium.com/ruby-on-rails/activerecord-transaction-gotchas-277c048dc3ca) in ActiveRecord. `previous_changes` was ending up empty when `emit_lock_hooks` was actually called in the callbacks.

**Risks:**
This does mean we'll be emitting a lot more "lock" webhooks, even when the lock has not changed. Are we okay with this, or would we prefer one of the alternatives below?

**Alternatives:**
- Changing `emit_lock_hooks` to run on `after_save` fixes this bug as well, but is a change in behavior that risks us emitting a "lock" hook before the lock actually gets committed to the DB.
- There's a gem in the link above that we could add to keep track of transaction changes