### PR TITLE
Call `emit_lock_hook` from `trigger_revert`

### DIFF
--- a/app/models/shipit/deploy.rb
+++ b/app/models/shipit/deploy.rb
@@ -128,6 +128,7 @@ module Shipit
       lock_reason = "A rollback for #{until_commit.sha} has been triggered. " \
         "Please make sure the reason for the rollback has been addressed before deploying again."
       stack.update!(lock_reason: lock_reason, lock_author_id: user_id)
+      stack.emit_lock_hooks
       rollback
     end
 

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -608,6 +608,16 @@ module Shipit
       Shipit.deployment_checks.call(self)
     end
 
+    def emit_lock_hooks
+      return unless previous_changes.include?('lock_reason')
+
+      lock_details = if previous_changes['lock_reason'].last.blank?
+        { from: previous_changes['locked_since'].first, until: Time.zone.now }
+      end
+
+      Hook.emit(:lock, self, locked: locked?, lock_details: lock_details, stack: self)
+    end
+
     private
 
     def clear_cache
@@ -639,16 +649,6 @@ module Shipit
       if lock_reason_previously_changed? && lock_reason.blank?
         schedule_merges
       end
-    end
-
-    def emit_lock_hooks
-      return unless previous_changes.include?('lock_reason')
-
-      lock_details = if previous_changes['lock_reason'].last.blank?
-        { from: previous_changes['locked_since'].first, until: Time.zone.now }
-      end
-
-      Hook.emit(:lock, self, locked: locked?, lock_details: lock_details, stack: self)
     end
 
     def emit_added_hooks

--- a/test/models/deploys_test.rb
+++ b/test/models/deploys_test.rb
@@ -459,6 +459,32 @@ module Shipit
       end
     end
 
+    test "transitioning to aborted locks the stack if a rollback is scheduled" do
+      refute @stack.locked?
+
+      @deploy = shipit_deploys(:shipit_running)
+      @deploy.ping
+      @deploy.pid = 42
+      @deploy.abort!(rollback_once_aborted: true, aborted_by: @user)
+      @deploy.aborted!
+
+      assert_predicate @stack.reload, :locked?
+      assert_equal @user, @stack.lock_author
+    end
+
+    test "transitioning to aborted emits a lock hook if a rollback is scheduled" do
+      refute_predicate @stack, :locked?
+
+      @deploy = shipit_deploys(:shipit_running)
+      @deploy.ping
+      @deploy.pid = 42
+      @deploy.abort!(rollback_once_aborted: true, aborted_by: @user)
+
+      expect_hook(:lock, @stack, locked: true, lock_details: nil, stack: @stack) do
+        @deploy.aborted!
+      end
+    end
+
     test "#build_rollback returns an unsaved record" do
       assert @deploy.build_rollback.new_record?
     end


### PR DESCRIPTION
**What:**
This calls `emit_lock_hook` from within `trigger_revert` to ensure it is actually called.

**Why:**
Right now, hitting "Abort & Rollback" on a deploy does not actually end up emitting a lock hook. This is because of [this behavior](https://medium.com/ruby-on-rails/activerecord-transaction-gotchas-277c048dc3ca) in ActiveRecord. `previous_changes` was ending up empty when `emit_lock_hooks` was actually called in the callbacks. Calling it manually within `trigger_revert` means that `previous_changes` is still valid. 

This was based on feedback provided in #1270 