### PR TITLE
Make api refresh action match non api refresh action for stacks (aka also refresh statuses and checkruns)

### DIFF
--- a/app/controllers/shipit/api/stacks_controller.rb
+++ b/app/controllers/shipit/api/stacks_controller.rb
@@ -62,6 +62,8 @@ module Shipit
       end
 
       def refresh
+        RefreshStatusesJob.perform_later(stack_id: stack.id)
+        RefreshCheckRunsJob.perform_later(stack_id: stack.id)
         GithubSyncJob.perform_later(stack_id: stack.id)
         render_resource(stack, status: :accepted)
       end

--- a/test/controllers/api/stacks_controller_test.rb
+++ b/test/controllers/api/stacks_controller_test.rb
@@ -214,6 +214,15 @@ module Shipit
         end
         assert_response :accepted
       end
+
+      test "#refresh queues a RefreshStatusesJob and RefreshCheckRunsJob" do
+        assert_enqueued_with(job: RefreshStatusesJob, args: [stack_id: @stack.id]) do
+          assert_enqueued_with(job: RefreshCheckRunsJob, args: [stack_id: @stack.id]) do
+            post :refresh, params: { id: @stack.to_param }
+          end
+        end
+        assert_response :accepted
+      end
     end
   end
 end


### PR DESCRIPTION
### What

- Right now hitting the `stacks/:id/refresh` endpoint refreshes commits, statuses and checkruns
- Hitting the `api/stacks/:id/refresh` endpoint only refreshes commits
- This brings them in line so they perform the same action

### Why

https://github.com/Shopify/shipit-engine/pull/1227 This is where we added the endpoint, my understanding from that is that it was intended to extend the functionality of the refresh button to apps using the api.