### PR TITLE
Add --quiet switches to checkouts

### DIFF
--- a/lib/shipit/stack_commands.rb
+++ b/lib/shipit/stack_commands.rb
@@ -72,7 +72,14 @@ module Shipit
         ).run!
 
         git_dir = File.join(dir, @stack.repo_name)
-        git('-c', 'advice.detachedHead=false', 'checkout', commit.sha, chdir: git_dir).run! if commit
+        git(
+          '-c',
+          'advice.detachedHead=false',
+          'checkout',
+          '--quiet',
+          commit.sha,
+          chdir: git_dir
+        ).run! if commit
         yield Pathname.new(git_dir)
       end
     end

--- a/lib/shipit/task_commands.rb
+++ b/lib/shipit/task_commands.rb
@@ -47,7 +47,14 @@ module Shipit
     end
 
     def checkout(commit)
-      git('-c', 'advice.detachedHead=false', 'checkout', commit.sha, chdir: @task.working_directory)
+      git(
+        '-c',
+        'advice.detachedHead=false',
+        'checkout',
+        '--quiet',
+        commit.sha,
+        chdir: @task.working_directory
+      )
     end
 
     def clone

--- a/test/unit/deploy_commands_test.rb
+++ b/test/unit/deploy_commands_test.rb
@@ -134,7 +134,11 @@ module Shipit
 
     test "#checkout checks out the deployed commit" do
       command = @commands.checkout(@deploy.until_commit)
-      assert_equal ['git', '-c', 'advice.detachedHead=false', 'checkout', @deploy.until_commit.sha], command.args
+      checkout_args = [
+        'git', '-c', 'advice.detachedHead=false', 'checkout', '--quiet',
+        @deploy.until_commit.sha,
+      ]
+      assert_equal checkout_args, command.args
     end
 
     test "#checkout checks out the deployed commit from the working directory" do


### PR DESCRIPTION
Follow-up to #1219 and #1225. Missed a spot.

Output is garbled due to progress feedback of `checkout`:

<img width="818" alt="image" src="https://user-images.githubusercontent.com/50832/183556274-44543711-44f1-4e43-b120-31b74db8f1f6.png">

Tophatted locally:

```
git -c advice.detachedHead=false checkout --quiet 05f5b2e2b72a80491d8ebe3e91a350a7ae09dc5e
```