### PR TITLE
Add lock and archive functionality to the stack update API call

### DIFF
--- a/app/controllers/shipit/api/stacks_controller.rb
+++ b/app/controllers/shipit/api/stacks_controller.rb
@@ -46,9 +46,13 @@ module Shipit
         accepts :ignore_ci, Boolean
         accepts :merge_queue_enabled, Boolean
         accepts :continuous_deployment, Boolean
+        accepts :archived, Boolean
       end
       def update
-        stack.update(params)
+        stack.update(update_params)
+
+        update_archived
+
         render_resource(stack)
       end
 
@@ -76,6 +80,26 @@ module Shipit
 
       def stack
         @stack ||= stacks.from_param!(params[:id])
+      end
+
+      def update_archived
+        if key?(:archived)
+          if params[:archived]
+            stack.archive!(nil)
+          elsif stack.archived?
+            stack.unarchive!
+          end
+        end
+      end
+
+      def key?(key)
+        params.to_h.key?(key)
+      end
+
+      def update_params
+        params.select do |key, _|
+          %i(environment branch deploy_url ignore_ci merge_queue_enabled continuous_deployment).include?(key)
+        end
       end
 
       def repository


### PR DESCRIPTION
### 🤷 What are you trying to accomplish?
We need API support for archive/lock a stack for our project.
Modifying the API to be able to perform archive and lock functionalities on one stack. This includes unarchiving and unlocking functionalities as well. 

### 🛠️ How did you accomplish this and why did you choose this approach?

Modified the api/stacks_controller.rb to align with the current stacks_controller.rb. In order to avoid modification to the API behaviour, when the keys are not provided, we do not perform any modification to the stack. I added testing to the testing file to accommodate this change. 

### 🎩 Tophat
In order to run tests in local, I installed redis.
```
brew install redis
redis-server

# another terminal tab
redis-cli
> ping
```

Then because I'm using M1, so I need to follow the [instruction](https://github.com/Shopify/shipit-engine/pull/1279#issue-1333802477) to install `libpq` before I can `bundle install`
```
brew install libpq
export PATH="/opt/homebrew/opt/libpq/bin:$PATH"
bundle install
```
 
Then all tests should pass.