### PR TITLE
Improve API tests

### DIFF
--- a/test/controllers/api/base_controller_test.rb
+++ b/test/controllers/api/base_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 
 module Shipit
   module Api
-    class BaseControllerTest < ActionController::TestCase
+    class BaseControllerTest < ApiControllerTestCase
       test "authentication is required" do
         get :index
         assert_response :unauthorized

--- a/test/controllers/api/ccmenu_controller_test.rb
+++ b/test/controllers/api/ccmenu_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 
 module Shipit
   module Api
-    class CCMenuControllerTest < ActionController::TestCase
+    class CCMenuControllerTest < ApiControllerTestCase
       setup do
         authenticate!
         @stack = shipit_stacks(:shipit)

--- a/test/controllers/api/commits_controller_test.rb
+++ b/test/controllers/api/commits_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 
 module Shipit
   module Api
-    class CommitsControllerTest < ActionController::TestCase
+    class CommitsControllerTest < ApiControllerTestCase
       setup do
         @stack = shipit_stacks(:shipit)
         authenticate!

--- a/test/controllers/api/deploys_controller_test.rb
+++ b/test/controllers/api/deploys_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 
 module Shipit
   module Api
-    class DeploysControllerTest < ActionController::TestCase
+    class DeploysControllerTest < ApiControllerTestCase
       setup do
         authenticate!
         @user = shipit_users(:walrus)

--- a/test/controllers/api/hooks_controller_test.rb
+++ b/test/controllers/api/hooks_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 
 module Shipit
   module Api
-    class HooksControllerTest < ActionController::TestCase
+    class HooksControllerTest < ApiControllerTestCase
       setup do
         authenticate!
         @stack = shipit_stacks(:shipit)

--- a/test/controllers/api/locks_controller_test.rb
+++ b/test/controllers/api/locks_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 
 module Shipit
   module Api
-    class LocksControllerTest < ActionController::TestCase
+    class LocksControllerTest < ApiControllerTestCase
       setup do
         authenticate!
         @stack = shipit_stacks(:shipit)

--- a/test/controllers/api/merge_requests_controller_test.rb
+++ b/test/controllers/api/merge_requests_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 
 module Shipit
   module Api
-    class MergeRequestsControllerTest < ActionController::TestCase
+    class MergeRequestsControllerTest < ApiControllerTestCase
       setup do
         @stack = shipit_stacks(:shipit)
         @merge_request = shipit_merge_requests(:shipit_pending)

--- a/test/controllers/api/outputs_controller_test.rb
+++ b/test/controllers/api/outputs_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 
 module Shipit
   module Api
-    class OutputsControllerTest < ActionController::TestCase
+    class OutputsControllerTest < ApiControllerTestCase
       setup do
         @stack = shipit_stacks(:shipit)
         authenticate!

--- a/test/controllers/api/release_statuses_controller_test.rb
+++ b/test/controllers/api/release_statuses_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 
 module Shipit
   module Api
-    class ReleaseStatusesControllerTest < ActionController::TestCase
+    class ReleaseStatusesControllerTest < ApiControllerTestCase
       setup do
         authenticate!
         @stack = shipit_stacks(:shipit_canaries)

--- a/test/controllers/api/rollback_controller_test.rb
+++ b/test/controllers/api/rollback_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 
 module Shipit
   module Api
-    class RollbacksControllerTest < ActionController::TestCase
+    class RollbacksControllerTest < ApiControllerTestCase
       setup do
         authenticate!
         @user = shipit_users(:walrus)

--- a/test/controllers/api/stacks_controller_test.rb
+++ b/test/controllers/api/stacks_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 
 module Shipit
   module Api
-    class StacksControllerTest < ActionController::TestCase
+    class StacksControllerTest < ApiControllerTestCase
       setup do
         authenticate!
         @stack = shipit_stacks(:shipit)

--- a/test/controllers/api/tasks_controller_test.rb
+++ b/test/controllers/api/tasks_controller_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 
 module Shipit
   module Api
-    class TasksControllerTest < ActionController::TestCase
+    class TasksControllerTest < ApiControllerTestCase
       setup do
         @stack = shipit_stacks(:shipit)
         @user = shipit_users(:walrus)

--- a/test/helpers/api_helper.rb
+++ b/test/helpers/api_helper.rb
@@ -8,3 +8,16 @@ module ApiHelper
     request.headers['Authorization'] = "Basic #{Base64.encode64(client.authentication_token)}"
   end
 end
+
+module Shipit
+  class ApiControllerTestCase < ActionController::TestCase
+    private
+
+    def process(_action, **kwargs)
+      if kwargs[:method] != "GET"
+        kwargs[:as] ||= :json
+      end
+      super
+    end
+  end
+end


### PR DESCRIPTION
We need to pass `as: :json` otherwise AC::TestCase will simulate www-form-encoded payloads, which don't support boolean and other rich JSON types.

That bing said, this change still isn't quite representative of what happens in production, but it should be good enough.

FYI @mikailkarimi 