### PR TITLE
Add a `safeties_enforced` param to rollback and deploy API endpoints which prevents `ignored_safeties` from being set

### DIFF
--- a/app/controllers/shipit/api/deploys_controller.rb
+++ b/app/controllers/shipit/api/deploys_controller.rb
@@ -13,12 +13,14 @@ module Shipit
         accepts :force, Boolean, default: false
         accepts :require_ci, Boolean, default: false
         accepts :env, Hash, default: {}
+        accepts :safeties_enforced, Boolean, default: false
       end
       def create
         commit = stack.commits.by_sha(params.sha) || param_error!(:sha, 'Unknown revision')
         param_error!(:force, "Can't deploy a locked stack") if !params.force && stack.locked?
         param_error!(:require_ci, "Commit is not deployable") if params.require_ci && !commit.deployable?
-        deploy = stack.trigger_deploy(commit, current_user, env: params.env, force: params.force)
+        deploy = stack.trigger_deploy(commit, current_user, env: params.env, force: params.force,
+          safeties_enforced: params.safeties_enforced)
         render_resource(deploy, status: :accepted)
       end
     end

--- a/app/controllers/shipit/api/rollbacks_controller.rb
+++ b/app/controllers/shipit/api/rollbacks_controller.rb
@@ -9,6 +9,7 @@ module Shipit
         accepts :force, Boolean, default: false
         accepts :env, Hash, default: {}
         accepts :lock, Boolean, default: true
+        accepts :safeties_enforced, Boolean, default: false
       end
       def create
         commit = stack.commits.by_sha(params.sha) || param_error!(:sha, 'Unknown revision')
@@ -24,7 +25,8 @@ module Shipit
           active_task.abort!(aborted_by: current_user, rollback_once_aborted_to: deploy, rollback_once_aborted: true)
           response = active_task
         else
-          response = deploy.trigger_rollback(current_user, env: deploy_env, force: params.force, lock: params.lock)
+          response = deploy.trigger_rollback(current_user, env: deploy_env, force: params.force, lock: params.lock,
+            safeties_enforced: params.safeties_enforced)
         end
 
         render_resource(response, status: :accepted)

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -150,7 +150,7 @@ module Shipit
       task
     end
 
-    def build_deploy(until_commit, user, env: nil, force: false)
+    def build_deploy(until_commit, user, env: nil, force: false, safeties_enforced: false)
       since_commit = last_deployed_commit.presence || commits.first
       deploys.build(
         user_id: user.id,
@@ -158,7 +158,7 @@ module Shipit
         since_commit: since_commit,
         env: filter_deploy_envs(env&.to_h || {}),
         allow_concurrency: force,
-        ignored_safeties: force || !until_commit.deployable?,
+        ignored_safeties: safeties_enforced ? false : (force || !until_commit.deployable?),
         max_retries: retries_on_deploy,
       )
     end

--- a/test/controllers/api/deploys_controller_test.rb
+++ b/test/controllers/api/deploys_controller_test.rb
@@ -119,6 +119,24 @@ module Shipit
         assert_response :accepted
         assert_json 'status', 'pending'
       end
+
+      test "#create marks the deploy as ignored_safeties if force mode is enabled" do
+        assert_difference -> { @stack.deploys.count }, 1 do
+          post :create, params: { stack_id: @stack.to_param, sha: @commit.sha, force: 'true' }
+        end
+
+        deploy = Deploy.last
+        assert_predicate deploy, :ignored_safeties?
+      end
+
+      test "#create doesn't mark a forced rollback as ignored_safeties if `safeties_enforced` is true" do
+        assert_difference -> { @stack.deploys.count }, 1 do
+          post :create, params: { stack_id: @stack.to_param, sha: @commit.sha, force: 'true', safeties_enforced: 'true' }
+        end
+
+        deploy = Deploy.last
+        refute_predicate deploy, :ignored_safeties?
+      end
     end
   end
 end

--- a/test/models/deploys_test.rb
+++ b/test/models/deploys_test.rb
@@ -839,6 +839,11 @@ module Shipit
       assert_predicate rollback, :ignored_safeties?
     end
 
+    test "#trigger_rollback doesn't mark a forced deploy as `ignored_safeties` if `safeties_enforced` is true" do
+      rollback = @deploy.trigger_rollback(@user, force: true, safeties_enforced: true)
+      refute_predicate rollback, :ignored_safeties?
+    end
+
     test "abort! transition to `aborting`" do
       @deploy.ping
       @deploy.abort!(aborted_by: @user)

--- a/test/models/shipit/stacks_test.rb
+++ b/test/models/shipit/stacks_test.rb
@@ -144,6 +144,13 @@ module Shipit
       refute_predicate deploy, :ignored_safeties?
     end
 
+    test "#trigger_deploy doesn't mark a forced deploy as `ignored_safeties` if `safeties_enforced` is true" do
+      last_commit = shipit_commits(:third)
+
+      deploy = @stack.trigger_deploy(last_commit, AnonymousUser.new, force: true, safeties_enforced: true)
+      refute_predicate deploy, :ignored_safeties?
+    end
+
     test "#update_deployed_revision bail out if there is an active deploy" do
       @stack.deploys_and_rollbacks.last.update_columns(status: 'running')
       assert_no_difference 'Deploy.count' do


### PR DESCRIPTION
This adds a `safeties_enforced` parameter to the rollbacks and deploys API endpoints. If you pass this in, even if you also pass `force=true`, `ignored_safeties` will be set to `false`. This is for systems that may use Shipit's API and require some of the powers that `force` enables, but have their own safeties requirements that may differ from Shipit's.

**Note:** there is an existing bug in which rolling back using `force` when there is an active task running does not lead to the rollback being marked as `ignored_safeties: true`. Right now, if you force a rollback, the rollback will _only_ be marked as `ignored_safeties: true` if there was not a task already in process. This pull request does not fix that bug.