### PR TITLE
More explicit wording when failing on missing shipit.yml stanzas

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -60,9 +60,9 @@ en:
       locked: Locked
   deploy_spec:
     hint:
-      deploy: Impossible to detect how to deploy this application. Please define `deploy.override` in your shipit.yml
-      rollback: Impossible to detect how to rollback this application. Please define `rollback.override` in your shipit.yml
-      fetch: Impossible to detect how to fetch the deployed revision for this application. Please define `fetch` in your shipit.yml
+      deploy: Impossible to detect how to deploy this application. Please define `deploy.override` in your shipit.$SHIPIT_ENVIRONMENT.yml
+      rollback: Impossible to detect how to rollback this application. Please define `rollback.override` in your shipit.$SHIPIT_ENVIRONMENT.yml
+      fetch: Impossible to detect how to fetch the deployed revision for this application. Please define `fetch` in your shipit.$SHIPIT_ENVIRONMENT.yml
   missing_status:
     description: "%{context} is required for deploy but was not sent yet."
   deploys:


### PR DESCRIPTION
Makes explicit that you should be looking at a _specific_ `shipit.yml` when a deploy fails to locate an appropriate stanza