### PR TITLE
Hide API tokens

### DIFF
--- a/app/helpers/shipit/api_clients_helper.rb
+++ b/app/helpers/shipit/api_clients_helper.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+module Shipit
+  module ApiClientsHelper
+    def api_client_token(api_client)
+      if api_client.created_at >= 5.minutes.ago && current_user == api_client.creator
+        api_client.authentication_token
+      else
+        "#{api_client.authentication_token[0..5]}************************"
+      end
+    end
+  end
+end

--- a/app/views/shipit/api_clients/show.html.erb
+++ b/app/views/shipit/api_clients/show.html.erb
@@ -10,7 +10,7 @@
   <section>
     <h3>Authentication token:</h3>
     <code style="background-color: yellow">
-      <b><%= @api_client.authentication_token %></b>
+      <b><%= api_client_token(@api_client) %></b>
     </code>
   </section>
 


### PR DESCRIPTION
### What

Small tweak to hide API tokens from the FE. Rather than bring in some fancy JS on the form, I just made it so that the token is only visible to the creator of the API client and only if it is less than 5 minutes old. 

### Why

Just a bit of a security enhancement.

<img width="352" alt="image" src="https://user-images.githubusercontent.com/6502883/221061365-1c78b538-aa85-485a-896f-65118b177e0a.png">
