### PR TITLE
Add fetch_commit during checkout_repository

### DIFF
--- a/app/models/shipit/task_execution_strategy/default.rb
+++ b/app/models/shipit/task_execution_strategy/default.rb
@@ -70,7 +70,6 @@ module Shipit
           @task.acquire_git_cache_lock do
             @task.ping
             unless @commands.fetched?(@task.until_commit).tap(&:run).success?
-              capture!(@commands.fetch)
               capture!(@commands.fetch_commit(@task.until_commit))
             end
           end

--- a/lib/shipit/stack_commands.rb
+++ b/lib/shipit/stack_commands.rb
@@ -13,19 +13,13 @@ module Shipit
       super.merge(@stack.env)
     end
 
-    def fetch
+    def fetch_commit(commit)
       create_directories
       if valid_git_repository?(@stack.git_path)
-        git('fetch', 'origin', '--quiet', '--tags', @stack.branch, env: env, chdir: @stack.git_path)
+        git('fetch', 'origin', '--quiet', '--tags', commit.sha, env: env, chdir: @stack.git_path)
       else
         @stack.clear_git_cache!
         git_clone(@stack.repo_git_url, @stack.git_path, branch: @stack.branch, env: env, chdir: @stack.deploys_path)
-      end
-    end
-
-    def fetch_commit(commit)
-      if valid_git_repository?(@stack.git_path)
-        git('fetch', 'origin', '--quiet', '--tags', commit.sha, env: env, chdir: @stack.git_path)
       end
     end
 

--- a/lib/shipit/task_commands.rb
+++ b/lib/shipit/task_commands.rb
@@ -2,7 +2,7 @@
 # rubocop:disable Lint/MissingSuper
 module Shipit
   class TaskCommands < Commands
-    delegate :fetch, :fetched?, :fetch_commit, to: :stack_commands
+    delegate :fetch_commit, :fetched?, to: :stack_commands
 
     def initialize(task)
       @task = task

--- a/test/unit/deploy_commands_test.rb
+++ b/test/unit/deploy_commands_test.rb
@@ -25,15 +25,6 @@ module Shipit
       @stack.git_path.stubs(:exist?).returns(true)
       @stack.git_path.stubs(:empty?).returns(false)
 
-      command = @commands.fetch
-
-      assert_equal %w(git fetch origin --quiet --tags master), command.args
-    end
-
-    test "#fetch_commit calls git fetch commit if repository cache already exist" do
-      @stack.git_path.stubs(:exist?).returns(true)
-      @stack.git_path.stubs(:empty?).returns(false)
-
       command = @commands.fetch_commit(@deploy.until_commit)
 
       assert_equal %W(git fetch origin --quiet --tags #{@deploy.until_commit.sha}), command.args
@@ -43,7 +34,7 @@ module Shipit
       @stack.git_path.stubs(:exist?).returns(true)
       @stack.git_path.stubs(:empty?).returns(false)
 
-      command = @commands.fetch
+      command = @commands.fetch_commit(@deploy.until_commit)
 
       assert_equal @stack.git_path.to_s, command.chdir
     end
@@ -51,7 +42,7 @@ module Shipit
     test "#fetch calls git clone if repository cache do not exist" do
       @stack.git_path.stubs(:exist?).returns(false)
 
-      command = @commands.fetch
+      command = @commands.fetch_commit(@deploy.until_commit)
 
       expected = %W(git clone --quiet --single-branch --recursive --branch master #{@stack.repo_git_url} #{@stack.git_path})
       assert_equal expected, command.args.map(&:to_s)
@@ -61,7 +52,7 @@ module Shipit
       @stack.git_path.stubs(:exist?).returns(true)
       @stack.git_path.stubs(:empty?).returns(true)
 
-      command = @commands.fetch
+      command = @commands.fetch_commit(@deploy.until_commit)
 
       expected = %W(git clone --quiet --single-branch --recursive --branch master #{@stack.repo_git_url} #{@stack.git_path})
       assert_equal expected, command.args
@@ -74,7 +65,7 @@ module Shipit
         .with(@stack.git_path)
         .returns(false)
 
-      command = @commands.fetch
+      command = @commands.fetch_commit(@deploy.until_commit)
 
       expected = %W(git clone --quiet --single-branch --recursive --branch master #{@stack.repo_git_url} #{@stack.git_path})
       assert_equal expected, command.args
@@ -88,7 +79,7 @@ module Shipit
         .with(@stack.git_path)
         .returns(false)
 
-      command = @commands.fetch
+      command = @commands.fetch_commit(@deploy.until_commit)
 
       expected = %W(git clone --quiet --single-branch --recursive --branch master #{@stack.repo_git_url} #{@stack.git_path})
       assert_equal expected, command.args
@@ -98,7 +89,7 @@ module Shipit
       @stack.git_path.stubs(:exist?).returns(false)
       StackCommands.stubs(git_version: Gem::Version.new('1.7.2.30'))
 
-      command = @commands.fetch
+      command = @commands.fetch_commit(@deploy.until_commit)
 
       expected = %W(git clone --quiet --recursive --branch master #{@stack.repo_git_url} #{@stack.git_path})
       assert_equal expected, command.args.map(&:to_s)
@@ -107,20 +98,20 @@ module Shipit
     test "#fetch calls git fetch in base_path directory if repository cache do not exist" do
       @stack.git_path.stubs(:exist?).returns(false)
 
-      command = @commands.fetch
+      command = @commands.fetch_commit(@deploy.until_commit)
 
       assert_equal @stack.deploys_path.to_s, command.chdir
     end
 
     test "#fetch merges Shipit.env in ENVIRONMENT" do
       Shipit.stubs(:env).returns("SPECIFIC_CONFIG" => 5)
-      command = @commands.fetch
+      command = @commands.fetch_commit(@deploy.until_commit)
       assert_equal '5', command.env["SPECIFIC_CONFIG"]
     end
 
     test "#env uses the correct Github token for a stack" do
       Shipit.github(organization: 'shopify').stubs(:token).returns('aS3cr3Tt0kEn')
-      command = @commands.fetch
+      command = @commands.fetch_commit(@deploy.until_commit)
       assert_equal 'aS3cr3Tt0kEn', command.env["GITHUB_TOKEN"]
     end
 


### PR DESCRIPTION
We've been seeing numerous accounts of `fatal: reference is not a tree:<commit-sha>` error  while checking out the [commit](https://github.com/Shopify/shipit-engine/blob/master/lib/shipit/task_commands.rb#L55), even though we fetch the [branch ref](https://github.com/Shopify/shipit-engine/blob/master/lib/shipit/task_commands.rb#L55) before hand.

Reproducing it locally, fetching the commit before the checkout resolves the error. 
