### PR TITLE
Bump nokogiri gem to 1.14.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -215,11 +215,11 @@ GEM
       net-protocol
       timeout
     nio4r (2.5.8)
-    nokogiri (1.13.10-arm64-darwin)
+    nokogiri (1.14.2-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.10-x86_64-darwin)
+    nokogiri (1.14.2-x86_64-darwin)
       racc (~> 1.4)
-    nokogiri (1.13.10-x86_64-linux)
+    nokogiri (1.14.2-x86_64-linux)
       racc (~> 1.4)
     oauth2 (2.0.6)
       faraday (>= 0.17.3, < 3.0)
@@ -253,7 +253,7 @@ GEM
     pubsubstub (0.2.2)
       rack
       redis (~> 4.0)
-    racc (1.6.1)
+    racc (1.6.2)
     rack (2.2.6.3)
     rack-test (2.0.2)
       rack (>= 1.3)


### PR DESCRIPTION
Bumping since https://github.com/Shopify/shipit-engine/pull/1300 failed to deploy with 
```
Your bundle is locked to nokogiri (1.13.10-x86_64-linux) from rubygems
repository https://rubygems.org/ or installed locally, but that version can no
longer be found in that source. That means the author of nokogiri
(1.13.10-x86_64-linux) has removed it.
```

🎩 -ed locally with shipit seems to work fine