### PR TITLE
Update octokit_iterator.rb

### DIFF
--- a/lib/shipit/octokit_iterator.rb
+++ b/lib/shipit/octokit_iterator.rb
@@ -16,6 +16,8 @@ module Shipit
       response = @response
 
       loop do
+        return unless response.present?
+
         response.data.each(&block)
         return unless response.rels[:next]
         response = response.rels[:next].get


### PR DESCRIPTION
I came across [this bug here](https://app.bugsnag.com/shopify/shipit/errors/6463bf3584db680008e6c8ad?event_id=6463bf3500bd2d8974680000&i=sk&m=nw). There's only been a few instances so far but fixed it since it was fairly quickly; it resulted from `data` being called on a null `response` object.

I didn't find any unit tests for `OctokitIterator` class, so, I didn't add any test for this bug fix. If you disagree, do lmk!