### PR TITLE
Give `ConcurrentTaskRunning` a clear error message

### DIFF
--- a/app/controllers/shipit/api/base_controller.rb
+++ b/app/controllers/shipit/api/base_controller.rb
@@ -93,8 +93,8 @@ module Shipit
         render(status: :not_found, json: { status: '404', error: 'Not Found' })
       end
 
-      def conflict(_error)
-        render(status: :conflict, json: { status: '409', error: 'Conflict' })
+      def conflict(error)
+        render(status: :conflict, json: { status: '409', error: error.message })
       end
     end
   end

--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -3,7 +3,11 @@ module Shipit
   class Task < Record
     include DeferredTouch
 
-    ConcurrentTaskRunning = Class.new(StandardError)
+    class ConcurrentTaskRunning < StandardError
+      def message
+        "A task is already running."
+      end
+    end
 
     PRESENCE_CHECK_TIMEOUT = 30
     ACTIVE_STATUSES = %w(pending running aborting).freeze

--- a/test/controllers/api/deploys_controller_test.rb
+++ b/test/controllers/api/deploys_controller_test.rb
@@ -81,6 +81,7 @@ module Shipit
         end
 
         assert_response :conflict
+        assert_json 'error', 'A task is already running.'
       end
 
       test "#create refuses to deploy unsuccessful commits if the require_ci flag is passed" do


### PR DESCRIPTION
### What

- Updates `ConcurrentTaskRunning` error to have a clear error message

### Why

- The error name itself is clear, but "Conflict" is not, this way api users can pass along the message