### PR TITLE
[BUG FIX] Bypass max_commits directive if no deployable commit is found within the range

### DIFF
--- a/test/models/shipit/stack_test.rb
+++ b/test/models/shipit/stack_test.rb
@@ -3,7 +3,7 @@ require 'test_helper'
 require 'securerandom'
 
 module Shipit
-  class StacksTest < ActiveSupport::TestCase
+  class StackTest < ActiveSupport::TestCase
     def setup
       @stack = shipit_stacks(:shipit)
       @expected_base_path = Rails.root.join('data', 'stacks', @stack.to_param).to_s

--- a/test/models/shipit/stack_test.rb
+++ b/test/models/shipit/stack_test.rb
@@ -704,16 +704,29 @@ module Shipit
       assert_equal shipit_commits(:fifth), @stack.next_commit_to_deploy
     end
 
-    test "#next_commit_to_deploy respects the deploy.max_commits directive" do
+    test "#next_commit_to_deploy respects the deploy.max_commits directive given the commit is deployable" do
       @stack.tasks.destroy_all
 
-      fifth_commit = shipit_commits(:third)
-      fifth_commit.statuses.create!(stack_id: @stack.id, state: 'success', context: 'ci/travis')
-      assert_predicate fifth_commit, :deployable?
+      third_commit = shipit_commits(:third)
+      third_commit.statuses.create!(stack_id: @stack.id, state: 'success', context: 'ci/travis')
+      assert_predicate third_commit, :deployable?
 
       assert_equal shipit_commits(:third), @stack.next_commit_to_deploy
 
       @stack.expects(:maximum_commits_per_deploy).returns(3).at_least_once
+      assert_equal shipit_commits(:third), @stack.next_commit_to_deploy
+    end
+
+    test "#next_commit_to_deploy deploys the first deployable commit when deploy.max_commits directive fails to find a deployable commit" do
+      @stack.tasks.destroy_all
+
+      third_commit = shipit_commits(:third)
+      third_commit.statuses.create!(stack_id: @stack.id, state: 'success', context: 'ci/travis')
+      assert_predicate third_commit, :deployable?
+
+      assert_equal shipit_commits(:third), @stack.next_commit_to_deploy
+
+      @stack.expects(:maximum_commits_per_deploy).returns(1).at_least_once
       assert_equal shipit_commits(:third), @stack.next_commit_to_deploy
     end
 


### PR DESCRIPTION
This PR ensures that when no deployable commit is found within the range up to the `max_commits` directive, it finds a deployable commit beyond that.