### PR TITLE
Added support for config files nested in .shipit/

### DIFF
--- a/app/models/shipit/deploy_spec/file_system.rb
+++ b/app/models/shipit/deploy_spec/file_system.rb
@@ -101,7 +101,16 @@ module Shipit
       end
 
       def shipit_file_names_in_priority_order
-        ["#{app_name}.#{@env}.yml", "#{app_name}.yml", "shipit.#{@env}.yml", "shipit.yml"].uniq
+        [
+          "#{app_name}.#{@env}.yml",
+          "#{app_name}.yml",
+          "shipit.#{@env}.yml",
+          "shipit.yml",
+          ".shipit/#{app_name}.#{@env}.yml",
+          ".shipit/#{app_name}.yml",
+          ".shipit/#{@env}.yml",
+          ".shipit/shipit.yml",
+        ].uniq
       end
 
       def bare_shipit_filenames

--- a/app/models/shipit/deploy_spec/file_system.rb
+++ b/app/models/shipit/deploy_spec/file_system.rb
@@ -103,18 +103,21 @@ module Shipit
       def shipit_file_names_in_priority_order
         [
           "#{app_name}.#{@env}.yml",
-          "#{app_name}.yml",
-          "shipit.#{@env}.yml",
-          "shipit.yml",
           ".shipit/#{app_name}.#{@env}.yml",
+
+          "#{app_name}.yml",
           ".shipit/#{app_name}.yml",
+
+          "shipit.#{@env}.yml",
           ".shipit/#{@env}.yml",
+
+          "shipit.yml",
           ".shipit/shipit.yml",
         ].uniq
       end
 
       def bare_shipit_filenames
-        ["#{app_name}.yml", "shipit.yml"].uniq
+        ["#{app_name}.yml", "shipit.yml", ".shipit/#{app_name}.yml", ".shipit/shipit.yml"].uniq
       end
 
       def config_file_path


### PR DESCRIPTION
[Shopify/web](https://github.com/Shopify/web) has so many shipit configuration files in its root, they are creating noise and polluting the root folder. Added support for nesting config files in `.shipit/`. 

<img width="894" alt="Screenshot 2023-09-12 at 10 12 04 PM" src="https://github.com/Shopify/shipit-engine/assets/334285/88b9461c-afa3-4218-872a-86a7e2ad1a6d">
