### PR TITLE
Paginate check run refresh

### DIFF
--- a/app/models/shipit/commit.rb
+++ b/app/models/shipit/commit.rb
@@ -168,10 +168,26 @@ module Shipit
       end
     end
 
-    def refresh_check_runs!
+    def paginated_check_runs
       response = stack.handle_github_redirections do
-        stack.github_api.check_runs(github_repo_name, sha)
+        stack.github_api.check_runs(github_repo_name, sha, per_page: 100)
       end
+
+      return response if stack.github_api.last_response.rels[:next].nil?
+
+      loop do
+        page = stack.handle_github_redirections do
+          stack.github_api.get(stack.github_api.last_response.rels[:next].href)
+        end
+        response.check_runs.concat(page.check_runs)
+        break if stack.github_api.last_response.rels[:next].nil?
+      end
+
+      response
+    end
+
+    def refresh_check_runs!
+      response = paginated_check_runs
       response.check_runs.each do |check_run|
         create_or_update_check_run_from_github!(check_run)
       end

--- a/test/models/commits_test.rb
+++ b/test/models/commits_test.rb
@@ -353,10 +353,11 @@ module Shipit
         completed_at: Time.now,
         started_at: Time.now - 1.minute,
       )
-      response = mock(
+      response = stub(rels: {}, data: mock(
         check_runs: [check_run],
-      )
-      Shipit.github.api.expects(:check_runs).with(@stack.github_repo_name, @commit.sha).returns(response)
+      ))
+      Shipit.github.api.expects(:check_runs).with(@stack.github_repo_name, @commit.sha, per_page: 100).returns(response.data)
+      Shipit.github.api.expects(:last_response).returns(response)
 
       assert_difference -> { @commit.check_runs.count }, 1 do
         @commit.refresh_check_runs!

--- a/test/models/merge_request_test.rb
+++ b/test/models/merge_request_test.rb
@@ -125,7 +125,7 @@ module Shipit
         created_at: 1.day.ago,
       )])
 
-      Shipit.github.api.expects(:check_runs).with(@stack.github_repo_name, head_sha).returns(stub(
+      response = stub(rels: {}, data: stub(
         check_runs: [stub(
           id: 123456,
           name: 'check run',
@@ -140,6 +140,8 @@ module Shipit
         )]
       ))
 
+      Shipit.github.api.expects(:last_response).returns(response)
+      Shipit.github.api.expects(:check_runs).with(@stack.github_repo_name, head_sha, per_page: 100).returns(response.data)
       merge_request.refresh!
 
       assert_predicate merge_request, :mergeable?


### PR DESCRIPTION
Paginate check runs when fetching from GitHub to handle cases where more than 30 checks exist.  #1323 