### PR TITLE
Migrate to Credentials + Remove Other Deprecation Warnings 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,10 @@
 # Unreleased
+* Upgraded Octokit to 5.6.1 (#1327)
+* Migrate from legacy Rails secrets to credentials (#1326)
+  * Rails secrets were [deprecated in Rails 7.1](https://github.com/rails/rails/pull/48472)
+  * [Guide on credentials](https://guides.rubyonrails.org/security.html#custom-credentials)
+
+# 0.39.0
 
 * Upgraded to Rails 7.1.1
 

--- a/Gemfile
+++ b/Gemfile
@@ -3,6 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'sqlite3'
+gem 'ejson-rails', require: 'ejson/rails/skip_secrets'
 
 group :ci do
   gem 'mysql2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -144,6 +144,10 @@ GEM
     docile (1.4.0)
     drb (2.2.0)
       ruby2_keywords
+    ejson (1.4.1)
+    ejson-rails (0.2.1)
+      ejson
+      railties (>= 5.2)
     equalizer (0.0.11)
     erubi (1.12.0)
     execjs (2.8.1)
@@ -416,6 +420,7 @@ PLATFORMS
 
 DEPENDENCIES
   byebug
+  ejson-rails
   faker
   mocha
   mysql2

--- a/app/models/shipit/api_client.rb
+++ b/app/models/shipit/api_client.rb
@@ -8,7 +8,7 @@ module Shipit
 
     validates :creator, :name, presence: true
 
-    serialize :permissions, Shipit.serialized_column(:permissions, type: Array)
+    serialize :permissions, coder: Shipit.serialized_column(:permissions, type: Array)
     PERMISSIONS = %w(
       read:stack
       write:stack

--- a/app/models/shipit/delivery.rb
+++ b/app/models/shipit/delivery.rb
@@ -9,7 +9,7 @@ module Shipit
     validates :url, presence: true, url: { no_local: true, allow_blank: true }
     validates :content_type, presence: true
 
-    serialize :response_headers, SafeJSON
+    serialize :response_headers, coder: SafeJSON
 
     after_commit :purge_old_deliveries, on: :create
 

--- a/app/models/shipit/hook.rb
+++ b/app/models/shipit/hook.rb
@@ -87,7 +87,7 @@ module Shipit
     validates :content_type, presence: true, inclusion: { in: CONTENT_TYPES.keys }
     validates :events, presence: true, subset: { of: EVENTS }
 
-    serialize :events, Shipit::CSVSerializer
+    serialize :events, coder: Shipit::CSVSerializer
 
     scope :global, -> { where(stack_id: nil) }
     scope :scoped_to, ->(stack) { where(stack_id: stack.id) }

--- a/app/models/shipit/pull_request.rb
+++ b/app/models/shipit/pull_request.rb
@@ -11,7 +11,7 @@ module Shipit
     has_many :pull_request_assignments
     has_many :assignees, class_name: :User, through: :pull_request_assignments, source: :user
 
-    serialize :labels, Shipit.serialized_column(:labels, type: Array)
+    serialize :labels, coder: Shipit.serialized_column(:labels, type: Array)
 
     after_create_commit :emit_create_hooks
     after_update_commit :emit_update_hooks

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -101,7 +101,7 @@ module Shipit
 
     validates :lock_reason, length: { maximum: 4096 }
 
-    serialize :cached_deploy_spec, DeploySpec
+    serialize :cached_deploy_spec, coder: DeploySpec
     delegate(
       :provisioning_handler_name,
       :find_task_definition,

--- a/app/models/shipit/task.rb
+++ b/app/models/shipit/task.rb
@@ -58,8 +58,8 @@ module Shipit
       end
     end
 
-    serialize :definition, TaskDefinition
-    serialize :env, Shipit.serialized_column(:env, coder: EnvHash)
+    serialize :definition, coder: TaskDefinition
+    serialize :env, coder: Shipit.serialized_column(:env, coder: EnvHash)
 
     scope :success, -> { where(status: 'success') }
     scope :completed, -> { where(status: COMPLETED_STATUSES) }

--- a/app/views/shipit/missing_settings.html.erb
+++ b/app/views/shipit/missing_settings.html.erb
@@ -22,7 +22,7 @@
 
     <p id="github_app">
       Config:
-    <% if Rails.application.secrets.github.present? %>
+    <% if Rails.application.credentials.github.present? %>
        Success!
     <% else %>
       <span class="missing">

--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -291,7 +291,7 @@ module Shipit
   end
 
   def secrets
-    Rails.application.secrets
+    Rails.application.credentials
   end
 end
 

--- a/lib/shipit/engine.rb
+++ b/lib/shipit/engine.rb
@@ -21,7 +21,7 @@ module Shipit
       Shipit::Engine.routes.default_url_options[:host] = Shipit.host
       Pubsubstub.redis_url = Shipit.redis_url.to_s
 
-      Rails.application.secrets.deep_symbolize_keys!
+      Rails.application.credentials.deep_symbolize_keys!
 
       app.config.assets.paths << Emoji.images_path
       app.config.assets.precompile += %w(

--- a/test/controllers/stacks_controller_test.rb
+++ b/test/controllers/stacks_controller_test.rb
@@ -10,7 +10,7 @@ module Shipit
     end
 
     test "validates that Shipit.github is present" do
-      Rails.application.secrets.stubs(:github).returns(nil)
+      Rails.application.credentials.stubs(:github).returns(nil)
       get :index
       assert_select "#github_app .missing"
       assert_select ".missing", count: 1

--- a/test/dummy/config/initializers/0_load_development_secrets.rb
+++ b/test/dummy/config/initializers/0_load_development_secrets.rb
@@ -2,8 +2,8 @@ local_secrets = Shipit::Engine.root.join('config/secrets.development.yml')
 if local_secrets.exist?
   secrets = YAML.load(local_secrets.read).deep_symbolize_keys
   if Rails.env.development?
-    Rails.application.secrets.deep_merge!(secrets)
+    Rails.application.credentials.deep_merge!(secrets)
   elsif Rails.env.test?
-    Rails.application.secrets.merge!(redis_url: secrets[:redis_url])
+    Rails.application.credentials.merge!(redis_url: secrets[:redis_url])
   end
 end

--- a/test/dummy/config/secrets.development.json
+++ b/test/dummy/config/secrets.development.json
@@ -1,0 +1,3 @@
+{
+  "secret_key_base": "s3cr3ts3cr3ts3cr3ts3cr3ts3cr3ts3cr3t"
+}

--- a/test/dummy/config/secrets.test.json
+++ b/test/dummy/config/secrets.test.json
@@ -1,0 +1,21 @@
+{
+  "host": "shipit.com",
+  "secret_key_base": "s3cr3ts3cr3ts3cr3ts3cr3ts3cr3ts3cr3t",
+  "github_api": {
+    "token": "t0k3n"
+  },
+  "github": {
+    "domain": null,
+    "app_id": 42,
+    "installation_id": 43,
+    "bot_login": "shipit[bot]",
+    "webhook_secret": null,
+    "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIEpAIBAAKCAQEA7iUQC2uUq/gtQg0gxtyaccuicYgmq1LUr1mOWbmwM1Cv63+S\n73qo8h87FX+YyclY5fZF6SMXIys02JOkImGgbnvEOLcHnImCYrWs03msOzEIO/pG\nM0YedAPtQ2MEiLIu4y8htosVxeqfEOPiq9kQgFxNKyETzjdIA9q1md8sofuJUmPv\nibacW1PecuAMnn+P8qf0XIDp7uh6noB751KvhCaCNTAPtVE9NZ18OmNG9GOyX/pu\npQHIrPgTpTG6KlAe3r6LWvemzwsMtuRGU+K+KhK9dFIlSE+v9rA32KScO8efOh6s\nGu3rWorV4iDu14U62rzEfdzzc63YL94sUbZxbwIDAQABAoIBADLJ8r8MxZtbhYN1\nu0zOFZ45WL6v09dsBfITvnlCUeLPzYUDIzoxxcBFittN6C744x3ARS6wjimw+EdM\nTZALlCSb/sA9wMDQzt7wchhz9Zh2H5RzDu+2f54sjDh38KqancdT8PO2fAFGxX/b\nqicOVyeZB9gv6MJtJc20olBbuXAeBNfcDABF9oxF+0i+Ssg7B4VXiqgcjtGbr/Og\nqRll7AqyTArVx2xEcVfZxeZ4zGnigzcJq4te7yYpxzwk+RxblkPh54Yt4WxZ+8DI\nRsn3r6ajlpwzpwvsJFU2Txq7xBTzGQMFmy/Pnjk83kP2cogxB2+tRyjITGqTwD8b\ngg9PFCkCgYEA+7u8A0l0Cz6p0SI6c7ftVePVRiIhpawWN7og/wEmI6zUjm/3rA+R\nhrhaVKuOD8QF/HdDsqTck5gjGAjTmJz6r33/cl1Tz+pr62znsrB4r0yMKvQbKN81\nWGaWOsi2+ZXqLNv5h5wpUF0MTKlXHeKnwP5kuEvGwVn6WURFCh6PhLMCgYEA8i5e\nJjulJVGyd5HuoY3xyO7E6DjidsqRnVRq+hYpORjnHvTmSwe4+tH4ha2p9Kv2Y6k3\nC1NYY/fSMQoYCCRaYyJleI+la/9tsZqAmtms4ZB8KhFmPHf9fW75i6G0xKWyZ8K+\nE2Ft/UaEiM282593cguV6+Kt5uExnyPxLLK4FlUCgYEAwRJ/JGI8/7bjFkTTYheq\nj5q75BufhOrU6471acAe2XPgXxLfefdC3Xodxh0CS3NESBvNL4Ikr4sbN37lk4Kq\n/th7iOKtuqUIeru/hZy2I3VpeDRbdGCmEJQ2GwYA2LKztg5Nd0Y9paaIHXAwIfrK\nQUqcQ4HTAk8ZpUeoUBeaaeMCgYANLmbjb9WiPVsYVPIHCwHA7PX8qbPxwT7BsGmO\nKQyfVfKmZa/vH4F67Vi4deZNMdrcO8aKMEQcVM2065a5QrlEsgeR00eupB1lUEJ1\nqylUsZeAdqf43JMIc7TTW77KATa/nQLZbTEeWus1wvTngztuEqFbUGAks9cOkVc8\nFpIcbQKBgQDVIL8gPLmn0f+4oLF8MBC+oxtKpz14X5iJ1saGFkzW5I+nIEskpS0S\nqtirnTCnJFGdCrFwctnxiuiCmyGwpBYdjIfHyvYAHnqAtMnESzCUyeSFZiquVW5W\nMvbMmDPoV27XOHU9kIq6NXtfrkpufiyo6/VEYWozXalxKLNuqLYfPQ==\n-----END RSA PRIVATE KEY-----\n",
+    "oauth": {
+      "id": "Iv1.bf2c2c45b449bfd9",
+      "secret": "ef694cd6e45223075d78d138ef014049052665f1",
+      "teams": null
+    }
+  },
+  "redis_url": "redis://127.0.0.1:6379/7"
+}

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -23,7 +23,7 @@ require 'spy/integration'
 
 # Load fixtures from the engine
 if ActiveSupport::TestCase.respond_to?(:fixture_path=)
-  ActiveSupport::TestCase.fixture_path = File.expand_path("../fixtures", __FILE__)
+  ActiveSupport::TestCase.fixture_paths << File.expand_path("../fixtures", __FILE__)
   ActiveSupport::TestCase.fixtures(:all)
 end
 
@@ -71,7 +71,7 @@ module ActiveSupport
       end
     end
 
-    ActiveRecord::Migration.check_pending!
+    ActiveRecord::Migration.check_all_pending!
 
     # Setup all fixtures in test/fixtures/*.yml for all tests in alphabetical order.
     #

--- a/test/unit/github_app_test.rb
+++ b/test/unit/github_app_test.rb
@@ -202,7 +202,7 @@ module Shipit
     end
 
     def default_config
-      Rails.application.secrets.github.deep_dup
+      Rails.application.credentials.github.deep_dup
     end
   end
 end


### PR DESCRIPTION
In attempts to use the recent shipit-engine release, I noticed the following exception being thrown in CI checks:
```
ActiveSupport::DeprecationException: DEPRECATION WARNING: `Rails.application.secrets` is deprecated in favor of `Rails.application.credentials` and will be removed in Rails 7.2. (called from block in <class:Engine> at /tmp/bundle/ruby/3.2.0/bundler/gems/shipit-engine-03a10e90a389/[redacted]) (ActiveSupport::DeprecationException)
```

This PR seeks to avoid this exception by migrating to credentials as instructed here: https://github.com/Shopify/ejson-rails?tab=readme-ov-file#migrating-to-credentials.

There were 3 other deprecation warnings that were being reported during unit tests. Those have been addressed as well.