### PR TITLE
Rescue forbidden user GitHub error

### DIFF
--- a/app/models/shipit/user.rb
+++ b/app/models/shipit/user.rb
@@ -95,6 +95,8 @@ module Shipit
       update!(github_user: Shipit.github.api.user(github_id))
     rescue Octokit::NotFound
       identify_renamed_user!
+    rescue Octokit::Forbidden
+      Rails.logger.info("User #{name}, github_id #{github_id} has forbidden access to their GitHub, likely deleted.")
     end
 
     def github_user=(github_user)

--- a/test/models/users_test.rb
+++ b/test/models/users_test.rb
@@ -203,6 +203,14 @@ module Shipit
       assert_equal 'george@cyclim.se', user.email
     end
 
+    test "#refresh_from_github! logs deleted users" do
+      Shipit.github.api.expects(:user).with(@user.github_id).raises(Octokit::Forbidden)
+
+      Rails.logger.expects(:info).with("User #{@user.name}, github_id #{@user.github_id} has forbidden access to their GitHub, likely deleted.")
+
+      @user.refresh_from_github!
+    end
+
     test "#github_api uses the user's access token" do
       assert_equal @user.github_access_token, @user.github_api.access_token
     end


### PR DESCRIPTION
**What:**

This PR adds a rescue to catch `Octokit::Forbidden`.

What is going on is we have a chron rake task that runs hourly which refreshes GitHub users via `RefreshGithubUserJob`, which calls the modified method in this PR. Certain users within our db have been deleted (or at least I cannot find or access them using either the GitHub UI or API calls), and when this job tries to call those users, we see an influx of this error as the job continues to retry and then is enqueued again an hour later. These users link to deactivated Slack accounts as well.

Other options I considered were deleting these users from our db when we see this response code, but I don't think that is the call here as a `Forbidden` can also come from things like hitting the secondary rate limit (the reason for this PR is not that case though).

In our case, there are only a set number of users that cause this, so it would be easy enough to also just delete them from the db manually, but I figured there will probably continue to be situations where users end up in this state over time and it was better to just rescue and log what was happening, with the possibility of deleting later too.

Does anyone disagree with this approach?