### PR TITLE
Update `build_deploy` with `allow_concurrency` keyword argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 * Migrate from legacy Rails secrets to credentials (#1326)
   * Rails secrets were [deprecated in Rails 7.1](https://github.com/rails/rails/pull/48472)
   * [Guide on credentials](https://guides.rubyonrails.org/security.html#custom-credentials)
+* For deployments, `allow_concurrency` defaults to the same value as `force`. If wanted, it can be set separately by passing the intended value for `allow_concurrency` to `build_deploy` method
+
 
 # 0.39.0
 

--- a/README.md
+++ b/README.md
@@ -357,6 +357,11 @@ For example:
 fetch:
   curl --silent https://app.example.com/services/ping/version
 ```
+
+**Note:** Currently, deployments in emergency mode are configured to occur concurrently via [the `build_deploy` method](https://github.com/Shopify/shipit-engine/blob/main/app/models/shipit/stack.rb),
+whose `allow_concurrency` keyword argument defaults to `force`, where `force` is true when emergency mode is enabled. 
+If you'd like to separate these two from one another, override this method as desired in your service.
+
 <h3 id="kubernetes">Kubernetes</h3>
 
 **<code>kubernetes</code>** allows to specify a Kubernetes namespace and context to deploy to.

--- a/app/controllers/shipit/api/deploys_controller.rb
+++ b/app/controllers/shipit/api/deploys_controller.rb
@@ -11,6 +11,7 @@ module Shipit
       params do
         requires :sha, String, length: { in: 6..40 }
         accepts :force, Boolean, default: false
+        accepts :allow_concurrency, Boolean
         accepts :require_ci, Boolean, default: false
         accepts :env, Hash, default: {}
       end
@@ -18,7 +19,10 @@ module Shipit
         commit = stack.commits.by_sha(params.sha) || param_error!(:sha, 'Unknown revision')
         param_error!(:force, "Can't deploy a locked stack") if !params.force && stack.locked?
         param_error!(:require_ci, "Commit is not deployable") if params.require_ci && !commit.deployable?
-        deploy = stack.trigger_deploy(commit, current_user, env: params.env, force: params.force)
+
+        allow_concurrency = params.allow_concurrency.nil? ? params.force : params.allow_concurrency
+        deploy = stack.trigger_deploy(commit, current_user, env: params.env, force: params.force,
+          allow_concurrency: allow_concurrency)
         render_resource(deploy, status: :accepted)
       end
     end

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -150,14 +150,14 @@ module Shipit
       task
     end
 
-    def build_deploy(until_commit, user, env: nil, force: false)
+    def build_deploy(until_commit, user, env: nil, force: false, allow_concurrency: force)
       since_commit = last_deployed_commit.presence || commits.first
       deploys.build(
         user_id: user.id,
         until_commit: until_commit,
         since_commit: since_commit,
         env: filter_deploy_envs(env&.to_h || {}),
-        allow_concurrency: force,
+        allow_concurrency: allow_concurrency,
         ignored_safeties: force || !until_commit.deployable?,
         max_retries: retries_on_deploy,
       )


### PR DESCRIPTION
**1 of 2 PRs (2nd PR will be in an Internal Shopify service)**

There is an internal Shopify ticket that hopes to separate concurrent deploys from `force=true` for the deploy API. To avoid overriding the whole `build_deploy` method in our internal service, I have updated the method signature to accept `allow_concurrency` field but default it to `force` to keep the existing implementation.

Changelog and README.md have been updated in case other users would also like to more control of the concurrency of deployments; note, that this differs from rollback whose concurrency is still limited to `force`.