### PR TITLE
Make RefreshCheckRunsJob and RefreshStatusesJob enqueue one of themselves per commit

### DIFF
--- a/app/jobs/shipit/refresh_check_runs_job.rb
+++ b/app/jobs/shipit/refresh_check_runs_job.rb
@@ -8,7 +8,9 @@ module Shipit
         Commit.find(params[:commit_id]).refresh_check_runs!
       else
         stack = Stack.find(params[:stack_id])
-        stack.commits.order(id: :desc).limit(30).each(&:refresh_check_runs!)
+        stack.commits.order(id: :desc).limit(30).each do |commit|
+          RefreshCheckRunsJob.perform_later(commit_id: commit.id)
+        end
       end
     end
   end

--- a/app/jobs/shipit/refresh_statuses_job.rb
+++ b/app/jobs/shipit/refresh_statuses_job.rb
@@ -8,7 +8,9 @@ module Shipit
         Commit.find(params[:commit_id]).refresh_statuses!
       else
         stack = Stack.find(params[:stack_id])
-        stack.commits.order(id: :desc).limit(30).each(&:refresh_statuses!)
+        stack.commits.order(id: :desc).limit(30).each do |commit|
+          RefreshStatusesJob.perform_later(commit_id: commit.id)
+        end
       end
     end
   end

--- a/test/jobs/refresh_check_runs_job_test.rb
+++ b/test/jobs/refresh_check_runs_job_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module Shipit
+  class RefreshCheckRunsJobTest < ActiveSupport::TestCase
+    setup do
+      @stack = shipit_stacks(:shipit)
+      @job = RefreshCheckRunsJob.new
+    end
+
+    test "#perform enqueues RefreshCheckRunsJob for the last 30 commits on the stack" do
+      assert_enqueued_jobs @stack.commits.count, only: RefreshCheckRunsJob do
+        @job.perform(stack_id: @stack.id)
+      end
+    end
+
+    test "if :commit_id param is present only this commit is refreshed" do
+      Commit.any_instance.expects(:refresh_check_runs!).once
+
+      @job.perform(stack_id: @stack.id, commit_id: shipit_commits(:first).id)
+    end
+  end
+end

--- a/test/jobs/refresh_statuses_job_test.rb
+++ b/test/jobs/refresh_statuses_job_test.rb
@@ -8,10 +8,10 @@ module Shipit
       @job = RefreshStatusesJob.new
     end
 
-    test "#perform call #refresh_statuses! on the last 30 commits of the stack" do
-      Commit.any_instance.expects(:refresh_statuses!).times(@stack.commits.count)
-
-      @job.perform(stack_id: @stack.id)
+    test "#perform enqueues RefreshStatusesJob for the last 30 commits on the stack" do
+      assert_enqueued_jobs @stack.commits.count, only: RefreshStatusesJob do
+        @job.perform(stack_id: @stack.id)
+      end
     end
 
     test "if :commit_id param is present only this commit is refreshed" do


### PR DESCRIPTION
We noticed that `RefreshCheckRunsJob` and `RefreshStatusesJob` both could end up being long running if there are a lot of statuses to refresh and GitHub is slow. This changes both of these jobs to re-enqueue itself once per each of the stack's last 30 commits if passed in a stack as an argument.