### PR TITLE
Schedule individual CreateOnGithubJobs for each CommitDeploymentStatus that needs to be created

### DIFF
--- a/app/models/shipit/commit_deployment.rb
+++ b/app/models/shipit/commit_deployment.rb
@@ -10,7 +10,7 @@ module Shipit
 
     def create_on_github!
       create_deployment_on_github!
-      statuses.order(id: :asc).each(&:create_on_github!)
+      statuses.order(id: :asc).each { |status| CreateOnGithubJob.perform_later(status) }
     rescue Octokit::NotFound, Octokit::Forbidden => error
       Rails.logger.warn("Got #{error.class.name} creating deployment or statuses: #{error.message}")
       # If no one can create the deployment we can only give up

--- a/test/models/commit_deployment_test.rb
+++ b/test/models/commit_deployment_test.rb
@@ -32,5 +32,15 @@ module Shipit
       assert_equal deployment_response.id, @deployment.github_id
       assert_equal deployment_response.url, @deployment.api_url
     end
+
+    test "#create_on_github! enqueues creation job for each associated status" do
+      deployment_response = stub(id: 42, url: 'https://example.com')
+      @author.github_api.expects(:create_deployment).returns(deployment_response)
+      status = @deployment.statuses.create!(status: "in_progress")
+
+      assert_enqueued_with(job: CreateOnGithubJob, args: [status]) do
+        @deployment.create_on_github!
+      end
+    end
   end
 end


### PR DESCRIPTION
Similar to https://github.com/Shopify/shipit-engine/pull/1341.

`CreateOnGithubJob` also can run for a long time. This breaks it up so that when it's called on a CommitDeployment, we schedule individual jobs to create each of that deployment's statuses on GitHub instead of doing all of that within the initial `CreateOnGithubJob` that was called on the CommitDeployment.