### PR TITLE
Convert retry-after header string to seconds

### DIFF
--- a/app/jobs/shipit/background_job.rb
+++ b/app/jobs/shipit/background_job.rb
@@ -11,7 +11,7 @@ module Shipit
     retry_on(Octokit::BadGateway, Octokit::InternalServerError)
 
     rescue_from(Octokit::TooManyRequests, Octokit::AbuseDetected) do |exception|
-      retry_job wait: exception.response_headers.fetch("Retry-After", DEFAULT_RETRY_TIME_IN_SECONDS)
+      retry_job wait: exception.response_headers.fetch("Retry-After", DEFAULT_RETRY_TIME_IN_SECONDS).to_i.seconds
     end
 
     def perform(*)


### PR DESCRIPTION
Retry header returns a string. Convert it to an int and then seconds. Following this: https://api.rubyonrails.org/v4.2.5/classes/ActiveJob/Enqueuing.html guide

Retry header is the number seconds: https://docs.github.com/en/rest/using-the-rest-api/rate-limits-for-the-rest-api?apiVersion=2022-11-28#exceeding-the-rate-limit