### PR TITLE
Cast job `wait` argument to an integer

### DIFF
--- a/app/jobs/shipit/background_job.rb
+++ b/app/jobs/shipit/background_job.rb
@@ -11,7 +11,7 @@ module Shipit
     retry_on(Octokit::BadGateway, Octokit::InternalServerError)
 
     rescue_from(Octokit::TooManyRequests, Octokit::AbuseDetected) do |exception|
-      retry_job wait: exception.response_headers.fetch("Retry-After", DEFAULT_RETRY_TIME_IN_SECONDS)
+      retry_job wait: exception.response_headers.fetch("Retry-After", DEFAULT_RETRY_TIME_IN_SECONDS).to_i
     end
 
     def perform(*)


### PR DESCRIPTION
The `wait` argument must be a number because [`ActiveJob` calls `seconds` on it](https://github.com/rails/rails/blob/f179539206e14111b01b21c05d86f47952cfab77/activejob/lib/active_job/core.rb#L166), but HTTP headers are strings.