### PR TITLE
Round the `finished in` second count

### DIFF
--- a/app/models/shipit/task_execution_strategy/default.rb
+++ b/app/models/shipit/task_execution_strategy/default.rb
@@ -94,7 +94,7 @@ module Shipit
           @task.write(line)
         end
         finished_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-        @task.write("pid: #{command.pid} finished in: #{finished_at - started_at} seconds\n")
+        @task.write("pid: #{command.pid} finished in: #{(finished_at - started_at).round(3)} seconds\n")
         command.success?
       end
 


### PR DESCRIPTION
This amount of precision seems a bit excessive, right? Is there a reason we haven't done this before?

<img width="407" alt="Screenshot 2024-05-20 at 13 49 36" src="https://github.com/Shopify/shipit-engine/assets/398706/4e0b9cfb-2d3f-4898-8d89-157550f5f924">
