### PR TITLE
Add --force to git fetch --tags command

### DIFF
--- a/lib/shipit/stack_commands.rb
+++ b/lib/shipit/stack_commands.rb
@@ -16,7 +16,7 @@ module Shipit
     def fetch_commit(commit)
       create_directories
       if valid_git_repository?(@stack.git_path)
-        git('fetch', 'origin', '--quiet', '--tags', commit.sha, env: env, chdir: @stack.git_path)
+        git('fetch', 'origin', '--quiet', '--tags', '--force', commit.sha, env: env, chdir: @stack.git_path)
       else
         @stack.clear_git_cache!
         git_clone(@stack.repo_git_url, @stack.git_path, branch: @stack.branch, env: env, chdir: @stack.deploys_path)
@@ -26,7 +26,7 @@ module Shipit
     def fetch
       create_directories
       if valid_git_repository?(@stack.git_path)
-        git('fetch', 'origin', '--quiet', '--tags', @stack.branch, env: env, chdir: @stack.git_path)
+        git('fetch', 'origin', '--quiet', '--tags', '--force', @stack.branch, env: env, chdir: @stack.git_path)
       else
         @stack.clear_git_cache!
         git_clone(@stack.repo_git_url, @stack.git_path, branch: @stack.branch, env: env, chdir: @stack.deploys_path)

--- a/test/unit/deploy_commands_test.rb
+++ b/test/unit/deploy_commands_test.rb
@@ -27,7 +27,7 @@ module Shipit
 
       command = @commands.fetch_commit(@deploy.until_commit)
 
-      assert_equal %W(git fetch origin --quiet --tags #{@deploy.until_commit.sha}), command.args
+      assert_equal %W(git fetch origin --quiet --tags --force #{@deploy.until_commit.sha}), command.args
     end
 
     test "#fetch_commit calls git fetch in git_path directory if repository cache already exist" do
@@ -121,7 +121,7 @@ module Shipit
 
       command = @commands.fetch
 
-      assert_equal %w(git fetch origin --quiet --tags master), command.args
+      assert_equal %w(git fetch origin --quiet --tags --force master), command.args
     end
 
     test "#fetch calls git fetch in git_path directory if repository cache already exist" do


### PR DESCRIPTION
When a repository periodically generate GitHub tags using GitHub Actions, they will run into this command failing with the exit code 1. This error seems to happen if remote tags have changed from the local tags. Adding `--force` allows overwriting of the local tags with the remote ones.

Before Git 2.20 (released Dec 2018), --force used to be implicit when using `git fetch --tags`.

Some reference posts:
https://bobcares.com/blog/git-fetch-failed-with-exit-code-1/#:~:text=In%20short%2C%20we%20can%20fix,its%20properness%20in%20case%20sensitivity.


https://github.com/semantic-release/git/issues/136
