### PR TITLE
Make --quiet flag dynamic in git commands

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -220,7 +220,7 @@ GEM
     multi_xml (0.6.0)
     multipart-post (2.3.0)
     mutex_m (0.2.0)
-    mysql2 (0.5.3)
+    mysql2 (0.5.6)
     net-imap (0.4.12)
       date
       net-protocol

--- a/docs/setup.md
+++ b/docs/setup.md
@@ -164,6 +164,13 @@ production:
   update_latest_deployed_ref: true
 ```
 
+**`git_progress_output`** enables git commands verbosity in the deploys.
+
+```yml
+production:
+  git_progress_output: true
+```
+
 ### Using Multiple Github Applications
 
 A Github application can only authenticate to the Github organization it's installed in. If you want to deploy code from multiple Github organizations the `github` section of your `config/secrets.yml` will need to be formatted differently. The top-level keys should be the name of each Github organization, and the following sub-keys are the Github app details for that particular organization.

--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -220,6 +220,10 @@ module Shipit
     secrets.update_latest_deployed_ref
   end
 
+  def git_progress_output
+    secrets.git_progress_output || false
+  end
+
   def enforce_publish_config
     secrets.enforce_publish_config.presence
   end

--- a/lib/shipit/stack_commands.rb
+++ b/lib/shipit/stack_commands.rb
@@ -16,7 +16,7 @@ module Shipit
     def fetch_commit(commit)
       create_directories
       if valid_git_repository?(@stack.git_path)
-        git('fetch', 'origin', '--quiet', '--tags', '--force', commit.sha, env: env, chdir: @stack.git_path)
+        git('fetch', 'origin', *quiet_git_arg, '--tags', '--force', commit.sha, env: env, chdir: @stack.git_path)
       else
         @stack.clear_git_cache!
         git_clone(@stack.repo_git_url, @stack.git_path, branch: @stack.branch, env: env, chdir: @stack.deploys_path)
@@ -26,7 +26,7 @@ module Shipit
     def fetch
       create_directories
       if valid_git_repository?(@stack.git_path)
-        git('fetch', 'origin', '--quiet', '--tags', '--force', @stack.branch, env: env, chdir: @stack.git_path)
+        git('fetch', 'origin', *quiet_git_arg, '--tags', '--force', @stack.branch, env: env, chdir: @stack.git_path)
       else
         @stack.clear_git_cache!
         git_clone(@stack.repo_git_url, @stack.git_path, branch: @stack.branch, env: env, chdir: @stack.deploys_path)
@@ -35,7 +35,7 @@ module Shipit
 
     def fetched?(commit)
       if valid_git_repository?(@stack.git_path)
-        git('rev-parse', '--quiet', '--verify', "#{commit.sha}^{commit}", env: env, chdir: @stack.git_path)
+        git('rev-parse', *quiet_git_arg, '--verify', "#{commit.sha}^{commit}", env: env, chdir: @stack.git_path)
       else
         # When the stack's git cache is not valid, the commit is
         # NOT fetched. To keep the interface of this method
@@ -88,7 +88,7 @@ module Shipit
           '-c',
           'advice.detachedHead=false',
           'checkout',
-          '--quiet',
+          *quiet_git_arg,
           commit.sha,
           chdir: git_dir
         ).run! if commit
@@ -109,7 +109,7 @@ module Shipit
     end
 
     def git_clone(url, path, branch: 'main', **kwargs)
-      git('clone', '--quiet', *modern_git_args, '--recursive', '--branch', branch, url, path, **kwargs)
+      git('clone', *quiet_git_arg, *modern_git_args, '--recursive', '--branch', branch, url, path, **kwargs)
     end
 
     def modern_git_args
@@ -119,6 +119,10 @@ module Shipit
 
     def create_directories
       FileUtils.mkdir_p(@stack.deploys_path)
+    end
+
+    def quiet_git_arg
+      Shipit.git_progress_output ? [] : ['--quiet']
     end
 
     private

--- a/test/unit/deploy_commands_test.rb
+++ b/test/unit/deploy_commands_test.rb
@@ -189,6 +189,15 @@ module Shipit
       assert_equal expected, command.args.map(&:to_s)
     end
 
+    test "#fetch does not use --quit if git_progress_output is enabled" do
+      Shipit.stubs(:git_progress_output).returns(true)
+
+      command = @commands.fetch
+
+      expected = %W(git clone --single-branch --recursive --branch master #{@stack.repo_git_url} #{@stack.git_path})
+      assert_equal expected, command.args.map(&:to_s)
+    end
+
     test "#fetch calls git fetch in base_path directory if repository cache do not exist" do
       @stack.git_path.stubs(:exist?).returns(false)
 


### PR DESCRIPTION
At PowerHRG, we're currently running on a fork which removes `--quiet` from git commands to avoid timing out log collection on long git clone operations.

Other consumers of shipit-engine might make use of progress output as discussed at https://github.com/Shopify/shipit-engine/pull/1278.