### PR TITLE
[Feature] Continuous Deployment Hours

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@
 
 # Ignore the default SQLite database.
 /db/*.sqlite3
-/db/*.sqlite3-journal
+/db/*.sqlite3-*
 
 # Ignore all logfiles and tempfiles.
 log/*
@@ -23,7 +23,7 @@ coverage/*
 public/assets/*
 pkg/
 test/dummy/db/*.sqlite3
-test/dummy/db/*.sqlite3-journal
+test/dummy/db/*.sqlite3-*
 test/dummy/db/migrate/*.rb
 test/dummy/log/*.log
 test/dummy/tmp/*

--- a/app/assets/javascripts/shipit/continuous_delivery_schedule.js.coffee
+++ b/app/assets/javascripts/shipit/continuous_delivery_schedule.js.coffee
@@ -1,0 +1,15 @@
+$(document)
+    .on "click", ".continuous-delivery-schedule [data-action='copy-to-all']", (event) -> 
+        form = event.target.closest("form");
+
+        mondayStart = form.elements.namedItem("continuous_delivery_schedule[monday_start]").value
+        mondayEnd = form.elements.namedItem("continuous_delivery_schedule[monday_end]").value
+
+        Array.from(form.elements).forEach (formElement) ->
+            return unless formElement.type == "time"
+
+            if formElement.name.endsWith("_start]")
+                formElement.value = mondayStart
+
+            if formElement.name.endsWith("_end]")
+                formElement.value = mondayEnd

--- a/app/controllers/shipit/continuous_delivery_schedules_controller.rb
+++ b/app/controllers/shipit/continuous_delivery_schedules_controller.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module Shipit
+  class ContinuousDeliverySchedulesController < ShipitController
+    before_action :load_stack
+
+    def show
+      @continuous_delivery_schedule = @stack.continuous_delivery_schedule || @stack.build_continuous_delivery_schedule
+    end
+
+    def update
+      @continuous_delivery_schedule = @stack.continuous_delivery_schedule || @stack.build_continuous_delivery_schedule
+      @continuous_delivery_schedule.assign_attributes(continuous_delivery_schedule_params)
+
+      if @continuous_delivery_schedule.save
+        flash[:success] = "Successfully updated"
+        redirect_to(stack_continuous_delivery_schedule_path)
+      else
+        flash.now[:warning] = "Check form for errors"
+        render(:show, status: :unprocessable_entity)
+      end
+    end
+
+    private
+
+    def load_stack
+      @stack = Stack.from_param!(params[:id])
+    end
+
+    def continuous_delivery_schedule_params
+      params.require(:continuous_delivery_schedule).permit(
+        :timezone_name,
+        *Shipit::ContinuousDeliverySchedule::DAYS.flat_map do |day|
+          [
+            "#{day}_start",
+            "#{day}_end",
+            "#{day}_enabled",
+          ]
+        end
+      )
+    end
+
+    def operation_param
+      params.require(:continuous_delivery_schedule).permit(:_operation)[:_operation]
+    end
+  end
+end

--- a/app/jobs/shipit/continuous_delivery_job.rb
+++ b/app/jobs/shipit/continuous_delivery_job.rb
@@ -9,6 +9,12 @@ module Shipit
     def perform(stack)
       return unless stack.continuous_deployment?
 
+      # If there is a schedule defined for this stack, make sure we are within a
+      # deployment window before proceeding.
+      if stack.continuous_delivery_schedule
+        return unless stack.continuous_delivery_schedule.can_deploy?
+      end
+
       # checks if there are any tasks running, including concurrent tasks
       return if stack.occupied?
 

--- a/app/models/shipit/continuous_delivery_schedule.rb
+++ b/app/models/shipit/continuous_delivery_schedule.rb
@@ -4,6 +4,53 @@ module Shipit
   class ContinuousDeliverySchedule < Record
     belongs_to(:stack)
 
-    DAYS = %w[sunday monday tuesday wednesday thursday friday saturday]
+    DAYS = %w[sunday monday tuesday wednesday thursday friday saturday].freeze
+
+    DeploymentWindow = Struct.new(:starts_at, :ends_at, :enabled) do
+      alias_method :enabled?, :enabled
+    end
+
+    def can_deploy?(now = Time.current)
+      # Make sure time is in the default time zone so weekdays match what is
+      # stored in the database.
+      now = now.in_time_zone(Time.zone)
+
+      deployment_window = get_deployment_window(now.to_date)
+
+      deployment_window.enabled? &&
+        now >= deployment_window.starts_at &&
+        now <= deployment_window.ends_at
+    end
+
+    def get_deployment_window(date)
+      wday_name = DAYS.fetch(date.wday)
+
+      enabled = read_attribute("#{wday_name}_enabled")
+
+      starts_at, ends_at = [:start, :end].map do |bound|
+        raw_time = read_attribute("#{wday_name}_#{bound}")
+
+        # `ActiveRecord::Type::Time` attributes are stored as timestamps
+        # normalized to 2000-01-01 so they can't be used for comparisons without
+        # having their dates adjusted.
+        # https://github.com/rails/rails/blob/ec667e5f114df58087493096253541f1034815af/activemodel/lib/active_model/type/time.rb#L23
+        Time.zone.local(
+          date.year,
+          date.month,
+          date.day,
+          raw_time.hour,
+          raw_time.min,
+        )
+      end
+
+      DeploymentWindow.new(
+        starts_at,
+        # Includes the full minute in the configured range. This is required so
+        # that a window configured to end at 17:59 actually ends at 17:59:59
+        # instead of 17:59:00.
+        ends_at.at_end_of_minute,
+        enabled,
+      )
+    end
   end
 end

--- a/app/models/shipit/continuous_delivery_schedule.rb
+++ b/app/models/shipit/continuous_delivery_schedule.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module Shipit
+  class ContinuousDeliverySchedule < Record
+    belongs_to(:stack)
+
+    DAYS = %w[sunday monday tuesday wednesday thursday friday saturday]
+  end
+end

--- a/app/models/shipit/continuous_delivery_schedule.rb
+++ b/app/models/shipit/continuous_delivery_schedule.rb
@@ -6,6 +6,16 @@ module Shipit
 
     DAYS = %w[sunday monday tuesday wednesday thursday friday saturday].freeze
 
+    validates(
+      *DAYS.map { |day| "#{day}_enabled" },
+      inclusion: [true, false],
+    )
+
+    validates(
+      *DAYS.product([:start, :end]).map { |parts| parts.join("_") },
+      presence: true
+    )
+
     DeploymentWindow = Struct.new(:starts_at, :ends_at, :enabled) do
       alias_method :enabled?, :enabled
     end

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -38,6 +38,7 @@ module Shipit
     has_many :github_hooks, dependent: :destroy, class_name: 'Shipit::GithubHook::Repo'
     has_many :hooks, dependent: :destroy
     has_many :api_clients, dependent: :destroy
+    has_one :continuous_delivery_schedule
     belongs_to :lock_author, class_name: :User, optional: true
     belongs_to :repository
     validates_associated :repository

--- a/app/views/shipit/continuous_delivery_schedules/show.html.erb
+++ b/app/views/shipit/continuous_delivery_schedules/show.html.erb
@@ -1,0 +1,59 @@
+<%= render partial: 'shipit/stacks/header', locals: { stack: @stack } %>
+
+<div class="wrapper continuous-delivery-schedule">
+    <section>
+        <header class="section-header">
+            <h2>Continuous Delivery Schedule (Stack #<%= @stack.id %>)</h2>
+        </header>
+    </section>
+    <div class="setting-section">
+        <% if @continuous_delivery_schedule.errors.any? %>
+            <div class="validation-errors">
+                <p>Validation errors prevented your schedule from being saved</p>
+                <ul>
+                    <% @continuous_delivery_schedule.errors.full_messages.each do |full_message| %>
+                        <li><%= full_message %></li>
+                    <% end %>
+                </ul>
+            </div>
+        <% end %>
+        <%= form_for(@continuous_delivery_schedule, url: stack_continuous_delivery_schedule_path, method: :patch) do |f| %>
+            <table class="field-wrapper">
+                <tbody>
+                    <% Shipit::ContinuousDeliverySchedule::DAYS.rotate.each do |day| %>
+                        <tr>
+                            <td>
+                                <%= f.check_box("#{day}_enabled") %>
+                            </td>
+                            <td>
+                                <%= f.label("#{day}_enabled", day.titlecase) %>
+                            </td>
+                            <td>
+                                <%= f.time_field("#{day}_start", include_seconds: false) %>
+                            </td>
+                            <td>&rarr;</td>
+                            <td>
+                                <%= f.time_field("#{day}_end", include_seconds: false) %>
+                            </td>
+                            <td>
+                                <% if day == "monday" %>
+                                    <button data-action="copy-to-all" type="button">Copy to all &darr;</button>
+                                <% end %>
+                            </td>
+                        </tr>
+                    <% end %>
+                </tbody>
+            </table>
+            
+            <p>
+                &#x2139;&#xFE0F; 
+                All times are in <%= Time.zone.name %>
+                (the <a href="https://guides.rubyonrails.org/configuring.html#config-time-zone">default time zone</a>).
+            </p>
+
+            <div class="field-wrapper">
+                <%= f.submit("Save", class: "btn") %>
+            </div>
+        <% end %>
+    </div>
+</div>

--- a/app/views/shipit/stacks/_settings_form.erb
+++ b/app/views/shipit/stacks/_settings_form.erb
@@ -17,6 +17,7 @@
 		<div class="field-wrapper">
 			<%= f.check_box :continuous_deployment %>
 			<%= f.label :continuous_deployment, 'Enable continuous deployment' %>
+			(<%= link_to("Edit schedule", stack_continuous_delivery_schedule_path) %>)
 		</div>
 
 		<div class="field-wrapper">

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -81,6 +81,7 @@ en:
     messages:
       subset: "is not a strict subset of %{of}"
       ascii: "contains non-ASCII characters"
+      must_be_after_start: "must be after start (%{start})"
   deployment_description:
     deploy:
       in_progress: "%{author} triggered the deploy of %{stack} to %{sha}"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -84,6 +84,8 @@ Shipit::Engine.routes.draw do
     post :refresh, controller: :stacks
     get :refresh, controller: :stacks # For easier design, sorry :/
     post :clear_git_cache, controller: :stacks
+
+    resource :continuous_delivery_schedule, only: %i(show update)
   end
 
   scope '/task/:id', controller: :tasks do

--- a/db/migrate/20240821003007_add_continuous_delivery_schedules.rb
+++ b/db/migrate/20240821003007_add_continuous_delivery_schedules.rb
@@ -1,0 +1,13 @@
+class AddContinuousDeliverySchedules < ActiveRecord::Migration[7.1]
+  def change
+    create_table(:continuous_delivery_schedules) do |t|
+      t.references(:stack, null: false, index: { unique: true })
+      %w[sunday monday tuesday wednesday thursday friday saturday].each do |day|
+        t.boolean("#{day}_enabled", null: false, default: true)
+        t.time("#{day}_start", null: false, default: "00:00")
+        t.time("#{day}_end", null: false, default: "23:59")
+      end
+      t.timestamps
+    end
+  end
+end

--- a/test/controllers/continuous_delivery_schedules_controller_test.rb
+++ b/test/controllers/continuous_delivery_schedules_controller_test.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module Shipit
+  class ContinuousDeliverySchedulesControllerTest < ActionController::TestCase
+    setup do
+      @routes = Shipit::Engine.routes
+      @stack = shipit_stacks(:shipit)
+      session[:user_id] = shipit_users(:walrus).id
+    end
+
+    def valid_params
+      Shipit::ContinuousDeliverySchedule::DAYS.each_with_object({}) do |day, hash|
+        hash[:"#{day}_enabled"] = "0"
+        hash[:"#{day}_start"] = "09:00"
+        hash[:"#{day}_end"] = "17:00"
+      end
+    end
+
+    test "#show returns a 200 response" do
+      get(:show, params: { id: @stack.to_param })
+
+      assert(response.ok?)
+    end
+
+    test "#update" do
+      patch(:update, params: {
+        id: @stack.to_param,
+        continuous_delivery_schedule: {
+          **valid_params,
+        },
+      })
+
+      assert_redirected_to(stack_continuous_delivery_schedule_path(@stack))
+      assert_equal("Successfully updated", flash[:success])
+
+      schedule = @stack.continuous_delivery_schedule
+
+      Shipit::ContinuousDeliverySchedule::DAYS.each do |day|
+        refute(schedule.read_attribute("#{day}_enabled"))
+
+        day_start = schedule.read_attribute("#{day}_start")
+        assert_equal("09:00:00 AM", day_start.strftime("%r"))
+
+        day_end = schedule.read_attribute("#{day}_end")
+        assert_equal("05:00:00 PM", day_end.strftime("%r"))
+      end
+    end
+
+    test "#update renders validation errors" do
+      patch(:update, params: {
+        id: @stack.to_param,
+        continuous_delivery_schedule: {
+          # Make Sunday end before it starts
+          **valid_params.merge(sunday_end: "08:00"),
+        },
+      })
+
+      assert_response(:unprocessable_entity)
+      assert_equal("Check form for errors", flash[:warning])
+      elements = assert_select(".validation-errors")
+      assert_includes(elements.sole.inner_text, "Sunday end must be after start (09:00 AM)")
+    end
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_07_03_181143) do
-
+ActiveRecord::Schema[7.1].define(version: 2024_08_21_003007) do
   create_table "api_clients", force: :cascade do |t|
     t.text "permissions", limit: 65535
     t.integer "creator_id", limit: 4
@@ -85,6 +84,34 @@ ActiveRecord::Schema.define(version: 2023_07_03_181143) do
     t.index ["created_at"], name: "index_commits_on_created_at"
     t.index ["sha", "stack_id"], name: "index_commits_on_sha_and_stack_id", unique: true
     t.index ["stack_id"], name: "index_commits_on_stack_id"
+  end
+
+  create_table "continuous_delivery_schedules", force: :cascade do |t|
+    t.integer "stack_id", null: false
+    t.boolean "sunday_enabled", default: true, null: false
+    t.time "sunday_start", default: "2000-01-01 00:00:00", null: false
+    t.time "sunday_end", default: "2000-01-01 23:59:00", null: false
+    t.boolean "monday_enabled", default: true, null: false
+    t.time "monday_start", default: "2000-01-01 00:00:00", null: false
+    t.time "monday_end", default: "2000-01-01 23:59:00", null: false
+    t.boolean "tuesday_enabled", default: true, null: false
+    t.time "tuesday_start", default: "2000-01-01 00:00:00", null: false
+    t.time "tuesday_end", default: "2000-01-01 23:59:00", null: false
+    t.boolean "wednesday_enabled", default: true, null: false
+    t.time "wednesday_start", default: "2000-01-01 00:00:00", null: false
+    t.time "wednesday_end", default: "2000-01-01 23:59:00", null: false
+    t.boolean "thursday_enabled", default: true, null: false
+    t.time "thursday_start", default: "2000-01-01 00:00:00", null: false
+    t.time "thursday_end", default: "2000-01-01 23:59:00", null: false
+    t.boolean "friday_enabled", default: true, null: false
+    t.time "friday_start", default: "2000-01-01 00:00:00", null: false
+    t.time "friday_end", default: "2000-01-01 23:59:00", null: false
+    t.boolean "saturday_enabled", default: true, null: false
+    t.time "saturday_start", default: "2000-01-01 00:00:00", null: false
+    t.time "saturday_end", default: "2000-01-01 23:59:00", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["stack_id"], name: "index_continuous_delivery_schedules_on_stack_id", unique: true
   end
 
   create_table "deliveries", force: :cascade do |t|

--- a/test/jobs/shipit/continuous_delivery_job_test.rb
+++ b/test/jobs/shipit/continuous_delivery_job_test.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+require 'test_helper'
+
+module Shipit
+  class ContinuousDeliveryJobTest < ActiveSupport::TestCase
+    test "calls trigger_continous_delivery" do
+      stack = shipit_stacks(:shipit)
+      stack.stubs(:continuous_deployment?).returns(true).once
+      stack.stubs(:occupied).returns(false).once
+      stack.expects(:trigger_continuous_delivery).once
+
+      Shipit::ContinuousDeliveryJob.new.perform(stack)
+    end
+
+    test "does not call trigger_continuous_delivery if outside of schedule" do
+      freeze_time do
+        monday_9am = Date.current.monday.at_beginning_of_day.advance(hours: 9)
+        travel_to(monday_9am)
+
+        stack = shipit_stacks(:shipit)
+        stack.create_continuous_delivery_schedule!(monday_start: "09:30")
+
+        stack.stubs(:continuous_deployment?).returns(true).once
+        stack.expects(:trigger_continuous_delivery).never
+
+        Shipit::ContinuousDeliveryJob.new.perform(stack)
+      end
+    end
+  end
+end

--- a/test/models/shipit/continuous_delivery_schedule_test.rb
+++ b/test/models/shipit/continuous_delivery_schedule_test.rb
@@ -74,6 +74,17 @@ module Shipit
       refute(schedule.can_deploy?(wednesday.advance(hours: 17, minutes: 31)))
     end
 
+    test "validates that end times must come after start times" do
+      schedule = Shipit::ContinuousDeliverySchedule.new(
+        thursday_start: "15:00",
+        thursday_end: "14:00"
+      )
+
+      schedule.validate
+      assert(schedule.errors.include?(:thursday_end))
+      assert_equal(["must be after start (03:00 PM)"], schedule.errors.messages_for(:thursday_end))
+    end
+
     test "validates `*_enabled` fields" do
       schedule = Shipit::ContinuousDeliverySchedule.new(
         friday_enabled: nil,

--- a/test/models/shipit/continuous_delivery_schedule_test.rb
+++ b/test/models/shipit/continuous_delivery_schedule_test.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+require "test_helper"
+
+module Shipit
+  class ContinuousDeliveryScheduleTest < ActiveSupport::TestCase
+  end
+end

--- a/test/models/shipit/continuous_delivery_schedule_test.rb
+++ b/test/models/shipit/continuous_delivery_schedule_test.rb
@@ -3,5 +3,72 @@ require "test_helper"
 
 module Shipit
   class ContinuousDeliveryScheduleTest < ActiveSupport::TestCase
+    test "defaults to all the time" do
+      schedule = Shipit::ContinuousDeliverySchedule.new
+
+      Shipit::ContinuousDeliverySchedule::DAYS.each_with_index do |day|
+        assert(schedule.read_attribute("#{day}_enabled"))
+
+        day_start = schedule.read_attribute("#{day}_start")
+        assert_equal(day_start.at_beginning_of_day, day_start)
+
+        day_end = schedule.read_attribute("#{day}_end")
+        assert_equal(day_end.at_end_of_day.at_beginning_of_minute, day_end)
+      end
+    end
+
+    test "#get_deployment_window" do
+      schedule = Shipit::ContinuousDeliverySchedule.new(
+        monday_enabled: false,
+        monday_start: "09:15",
+        monday_end: "17:30",
+      )
+
+      monday = Date.current.monday
+
+      deployment_window = schedule.get_deployment_window(monday)
+
+      refute(deployment_window.enabled?)
+
+      starts_at = deployment_window.starts_at
+      assert_equal(monday, starts_at.to_date)
+      assert_equal(9, starts_at.hour)
+      assert_equal(15, starts_at.min)
+      assert_equal(starts_at.at_beginning_of_minute, starts_at)
+
+      ends_at = deployment_window.ends_at
+      assert_equal(monday, ends_at.to_date)
+      assert_equal(17, ends_at.hour)
+      assert_equal(30, ends_at.min)
+      assert_equal(ends_at.at_end_of_minute, ends_at)
+    end
+
+    test "#can_deploy? is false if the day is disabled" do
+      schedule = Shipit::ContinuousDeliverySchedule.new(
+        tuesday_enabled: false,
+        tuesday_start: "00:00",
+        tuesday_end: "23:59",
+      )
+
+      tuesday = Date.current.monday.advance(days: 1).beginning_of_day
+
+      refute(schedule.can_deploy?(tuesday))
+    end
+
+    test "#can_deploy? is true when the current time is within the window" do
+      schedule = Shipit::ContinuousDeliverySchedule.new(
+        wednesday_enabled: true,
+        wednesday_start: "09:15",
+        wednesday_end: "17:30",
+      )
+
+      wednesday = Date.current.monday.advance(days: 2).beginning_of_day
+
+      refute(schedule.can_deploy?(wednesday))
+      assert(schedule.can_deploy?(wednesday.advance(hours: 9, minutes: 15)))
+      assert(schedule.can_deploy?(wednesday.advance(hours: 12)))
+      assert(schedule.can_deploy?(wednesday.advance(hours: 17, minutes: 30).at_end_of_minute))
+      refute(schedule.can_deploy?(wednesday.advance(hours: 17, minutes: 31)))
+    end
   end
 end


### PR DESCRIPTION
Implements https://github.com/Shopify/shipit-engine/issues/1100.

## User-visible changes

Adds a new settings page where the continuous deployment schedule can be configured.

Stacks settings | Schedule
---- | ----
![CleanShot 2024-08-24 at 15 51 35@2x](https://github.com/user-attachments/assets/623f5c18-c959-4d94-ba95-c99f4f385ebe) | ![CleanShot 2024-08-24 at 15 51 43@2x](https://github.com/user-attachments/assets/8b8a0fb5-798e-41a4-8ca0-6e134503f8a5)

## Code changes

- Adds a new `continuous_delivery_schedules` table, structured as a series of `*_enabled`, `*_start`, and `*_end` fields for each day of the week. 
    - By default every day is enabled with a time window that covers the whole day
- Adds a new `ContinuousDeliverySchedule` model which wraps the logic to determine whether a deploy should be allowed
- `Stack` records can have one or zero associated `ContinuousDeliverySchedule` records (enforced via unique index)
- Adds new routes, a controller, and a view to render the UI
    - Also adds a little bit of coffeescript to power the <kbd>Copy to all</kbd> button
- Adds a check in `ContinuousDeliveryJob` to bail out if we are currently outside of a deployment window
    -  From what I can tell this job runs every minute so I deemed this sufficient (one might imagine wanting to pause the job until the next deployment window but that'd likely be overkill)

## Notes

- The UI is largely inspired by Google Calendar's settings for working hours
    ![CleanShot 2024-08-24 at 16 01 16@2x](https://github.com/user-attachments/assets/52162b19-112c-4ae9-84d9-970a6d88a1b8)
- I considered allowing the timezone to be configured per-schedule as this would be useful for cross-timezone teams. 
    - Howewer
        -  Doing this with `ActiveRecord::Type::Time` would require very localized timezone overrides (e.g. when parsing form data) which would be tricky to get right, easy to break, and may cause unintended consequences elsewhere.
        - A more robust approach (IMHO) would involve using a custom type (to basically store "HH:MM" as a string) and control all conversions to and from timestamps.
    - I'm happy to explore either of these options but I figured I would submit the most straightforward route as
        - This config is unlikely to change often
        - In most scenarios I would expect the host app to have to most appropriate timezone configured for the people using it