### PR TITLE
Make "Previous Deploys" wording consistent

### DIFF
--- a/app/views/shipit/stacks/show.html.erb
+++ b/app/views/shipit/stacks/show.html.erb
@@ -33,7 +33,7 @@
   <% cache [@stack, params[:force]] do %>
     <section>
       <header class="section-header">
-        <h2>Previous Deploys</h2>
+        <h2>Previously Deployed Commits</h2>
       </header>
       <ul class="commit-list">
         <%= render @tasks %>


### PR DESCRIPTION
The other sections on this page refer to "commits", this PR updates the wording of the previously deployed commits to be consistent to avoid confusion. 