### PR TITLE
Destroy stack relations in batches

### DIFF
--- a/app/jobs/shipit/destroy_stack_job.rb
+++ b/app/jobs/shipit/destroy_stack_job.rb
@@ -20,16 +20,16 @@ module Shipit
       commits_ids = Shipit::Commit.where(stack_id: stack.id).pluck(:id)
       tasks_ids = Shipit::Task.where(stack_id: stack.id).pluck(:id)
       commit_deployments_ids = Shipit::CommitDeployment.where(task_id: tasks_ids).pluck(:id)
-      Shipit::CommitDeploymentStatus.where(commit_deployment_id: commit_deployments_ids).delete_all
-      Shipit::CommitDeployment.where(id: commit_deployments_ids).delete_all
-      Shipit::Status.where(commit_id: commits_ids).delete_all
-      Shipit::Commit.where(id: commits_ids).delete_all
+      Shipit::CommitDeploymentStatus.where(commit_deployment_id: commit_deployments_ids).in_batches(&:delete_all)
+      Shipit::CommitDeployment.where(id: commit_deployments_ids).in_batches(&:delete_all)
+      Shipit::Status.where(commit_id: commits_ids).in_batches(&:delete_all)
+      Shipit::Commit.where(id: commits_ids).in_batches(&:delete_all)
       Shipit::GithubHook.where(stack_id: stack.id).destroy_all
-      Shipit::Hook.where(stack_id: stack.id).delete_all
-      Shipit::MergeRequest.where(stack_id: stack.id).delete_all
+      Shipit::Hook.where(stack_id: stack.id).in_batches(&:delete_all)
+      Shipit::MergeRequest.where(stack_id: stack.id).in_batches(&:delete_all)
       tasks_ids.each_slice(100) do |ids|
-        Shipit::OutputChunk.where(task_id: ids).delete_all
-        Shipit::Task.where(id: ids).delete_all
+        Shipit::OutputChunk.where(task_id: ids).in_batches(&:delete_all)
+        Shipit::Task.where(id: ids).in_batches(&:delete_all)
       end
       stack.destroy!
     end


### PR DESCRIPTION
We've observed lock timeouts trying to destroy stacks with very large histories, this PR will batch delete the various relations instead of trying to do everything in one go.