### PR TITLE
Fix stack deletion take two

### DIFF
--- a/test/jobs/destroy_stack_job_test.rb
+++ b/test/jobs/destroy_stack_job_test.rb
@@ -24,5 +24,16 @@ module Shipit
         @job.perform(stack)
       end
     end
+
+    test "perform destroys the all Status of related commits" do
+      stack = shipit_stacks(:shipit)
+      Shipit.legacy_github_api.stubs(:remove_hook)
+
+      assert_changes -> { Status.count }, 'Statuses are not deleted' do
+        @job.perform(stack)
+      end
+
+      refute_predicate Status.count, :zero?
+    end
   end
 end


### PR DESCRIPTION
Follow on: #1376 

^ That PR didn't quite work, so I went a little deeper. Before that PR we ran a query that looked something like:

```
delete from `statuses` where `statuses`.`commit_id` in (1, 2, 3, 4, <all of them>)
```

... this is an indexed lookup:

```
id | select_type | table    | partitions | type  | possible_keys               | key                         | key_len | ref   | rows | filtered | Extra
--------------------------------------------------------------------------------------------------------------------------------------------------------------
1  | DELETE      | statuses |            | range | index_statuses_on_commit_id | index_statuses_on_commit_id | 5       | const | 4    | 100.0    | Using where
```

... however given the sheer amount of rows involved, the query times out or hits lock contention. 

My PR changed the query to something like

```
delete from `statuses` where `statuses`.`commit_id` in (...) and `statuses`.`id` in (...)
```

...but that's a table scan:

```
id | select_type | table    | partitions | type | possible_keys                       | key | key_len | ref | rows | filtered | Extra
-------------------------------------------------------------------------------------------------------------------------------------------
1  | DELETE      | statuses |            | ALL  | PRIMARY,index_statuses_on_commit_id |     |         |     | 1    | 100.0    | Using where
```

Which also fails 🙃 

Take two is to split the select and delete into separate, indexed queries, ran in batches. I also pre-emptively do this for `Shipit::Commit` as it uses the same pattern so could be affected in the same way.