### PR TITLE
DestroyStackJob: also delete commits

### DIFF
--- a/app/jobs/shipit/destroy_stack_job.rb
+++ b/app/jobs/shipit/destroy_stack_job.rb
@@ -32,6 +32,9 @@ module Shipit
 
       delete(Shipit::OutputChunk.joins(:task).where(task: { stack_id: stack.id }))
       delete(Shipit::Task.where(stack_id: stack.id))
+
+      delete(Shipit::Commit.where(stack_id: stack.id))
+
       stack.destroy!
     end
 

--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -38,7 +38,7 @@ module Shipit
     has_many :github_hooks, dependent: :destroy, class_name: 'Shipit::GithubHook::Repo'
     has_many :hooks, dependent: :destroy
     has_many :api_clients, dependent: :destroy
-    has_one :continuous_delivery_schedule
+    has_one :continuous_delivery_schedule, dependent: :destroy
     belongs_to :lock_author, class_name: :User, optional: true
     belongs_to :repository
     validates_associated :repository


### PR DESCRIPTION
~~Also use `dependent: :delete` rather than destroy for models that don't have an `after_destroy` callback.~~ Actually we can't do that because we need to clear nested models.

