### PR TITLE
Commit Deployments's github_id to Bigint

### DIFF
--- a/db/migrate/20250127175900_change_commit_deployments_github_id_to_bigint.rb
+++ b/db/migrate/20250127175900_change_commit_deployments_github_id_to_bigint.rb
@@ -1,0 +1,5 @@
+class ChangeCommitDeploymentsGithubIdToBigint < ActiveRecord::Migration[7.2]
+  def change
+    change_column :commit_deployments, :github_id, :bigint
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,12 +10,12 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_21_003007) do
+ActiveRecord::Schema[7.2].define(version: 2024_08_21_003007) do
   create_table "api_clients", force: :cascade do |t|
     t.text "permissions", limit: 65535
     t.integer "creator_id", limit: 4
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "name", limit: 255, default: ""
     t.integer "stack_id", limit: 4
     t.index ["creator_id"], name: "index_api_clients_on_creator_id"
@@ -30,9 +30,9 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_21_003007) do
     t.string "title", limit: 1024
     t.string "details_url"
     t.string "html_url"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.datetime "github_updated_at"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.datetime "github_updated_at", precision: nil
     t.index ["commit_id"], name: "index_check_runs_on_commit_id"
     t.index ["github_id", "commit_id"], name: "index_check_runs_on_github_id_and_commit_id", unique: true
     t.index ["stack_id"], name: "index_check_runs_on_stack_id"
@@ -43,8 +43,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_21_003007) do
     t.string "status"
     t.bigint "github_id"
     t.string "api_url"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["commit_deployment_id"], name: "index_commit_deployment_statuses_on_commit_deployment_id"
   end
 
@@ -53,8 +53,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_21_003007) do
     t.integer "task_id"
     t.integer "github_id"
     t.string "api_url"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "sha", limit: 40
     t.index ["commit_id", "task_id"], name: "index_commit_deployments_on_commit_id_and_task_id", unique: true
     t.index ["task_id"], name: "index_commit_deployments_on_task_id"
@@ -66,11 +66,11 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_21_003007) do
     t.integer "committer_id", limit: 4
     t.string "sha", limit: 40, null: false
     t.text "message", limit: 65535, null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.boolean "detached", default: false, null: false
-    t.datetime "authored_at", null: false
-    t.datetime "committed_at", null: false
+    t.datetime "authored_at", precision: nil, null: false
+    t.datetime "committed_at", precision: nil, null: false
     t.integer "additions", limit: 4
     t.integer "deletions", limit: 4
     t.integer "pull_request_number"
@@ -116,17 +116,17 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_21_003007) do
 
   create_table "deliveries", force: :cascade do |t|
     t.integer "hook_id", limit: 4, null: false
-    t.string "status", limit: 50, default: "pending", null: false
+    t.string "status", limit: 50
     t.string "url", limit: 4096, null: false
     t.string "content_type", limit: 255, null: false
-    t.string "event", limit: 50, null: false
+    t.string "event", limit: 50
     t.text "payload", limit: 16777215, null: false
     t.integer "response_code", limit: 4
     t.text "response_headers", limit: 65535
     t.text "response_body", limit: 65535
-    t.datetime "delivered_at"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "delivered_at", precision: nil
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["hook_id", "event", "status"], name: "index_deliveries_on_hook_id_and_event_and_status"
     t.index ["hook_id", "status"], name: "index_deliveries_on_hook_id_and_status"
   end
@@ -135,8 +135,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_21_003007) do
     t.integer "stack_id", limit: 4
     t.integer "github_id", limit: 4
     t.string "event", limit: 50, null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.string "secret", limit: 255
     t.string "api_url", limit: 255
     t.string "type", limit: 255
@@ -152,16 +152,16 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_21_003007) do
     t.string "secret", limit: 255
     t.string "events", limit: 255, default: "", null: false
     t.boolean "insecure_ssl", default: false, null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["stack_id"], name: "index_hooks_on_stack_id"
   end
 
   create_table "memberships", force: :cascade do |t|
     t.integer "team_id", limit: 4
     t.integer "user_id", limit: 4
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["team_id", "user_id"], name: "index_memberships_on_team_id_and_user_id", unique: true
     t.index ["user_id"], name: "index_memberships_on_user_id"
   end
@@ -179,13 +179,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_21_003007) do
     t.integer "deletions", default: 0, null: false
     t.string "merge_status", limit: 30, null: false
     t.string "rejection_reason"
-    t.datetime "merge_requested_at", null: false
+    t.datetime "merge_requested_at", precision: nil, null: false
     t.integer "merge_requested_by_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.string "branch"
-    t.datetime "revalidated_at"
-    t.datetime "merged_at"
+    t.datetime "revalidated_at", precision: nil
+    t.datetime "merged_at", precision: nil
     t.string "base_ref", limit: 1024
     t.integer "base_commit_id"
     t.index ["head_id"], name: "index_merge_requests_on_head_id"
@@ -200,8 +200,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_21_003007) do
   create_table "output_chunks", force: :cascade do |t|
     t.integer "task_id", limit: 4
     t.text "text", limit: 16777215
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.index ["task_id"], name: "index_output_chunks_on_task_id"
   end
 
@@ -224,8 +224,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_21_003007) do
     t.integer "user_id"
     t.text "labels"
     t.integer "head_id"
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["head_id"], name: "index_pull_requests_on_head_id"
     t.index ["stack_id", "github_id"], name: "index_pull_requests_on_stack_id_and_github_id", unique: true
     t.index ["stack_id", "number"], name: "index_pull_requests_on_stack_id_and_number", unique: true
@@ -240,18 +240,18 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_21_003007) do
     t.string "description", limit: 1024
     t.string "target_url", limit: 1024
     t.bigint "github_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["commit_id", "github_id"], name: "index_deploy_statuses_on_commit_id_and_github_id"
-    t.index ["stack_id", "commit_id"], name: "index_deploy_statuses_on_stack_id_and_commit_id"
-    t.index ["user_id"], name: "index_deploy_statuses_on_user_id"
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
+    t.index ["commit_id", "github_id"], name: "index_release_statuses_on_commit_id_and_github_id"
+    t.index ["stack_id", "commit_id"], name: "index_release_statuses_on_stack_id_and_commit_id"
+    t.index ["user_id"], name: "index_release_statuses_on_user_id"
   end
 
   create_table "repositories", force: :cascade do |t|
     t.string "owner", limit: 39, null: false
     t.string "name", limit: 100, null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.boolean "review_stacks_enabled", default: false
     t.string "provisioning_behavior", default: "allow_all"
     t.string "provisioning_label_name"
@@ -260,8 +260,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_21_003007) do
 
   create_table "stacks", force: :cascade do |t|
     t.string "environment", limit: 50, default: "production", null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.string "branch", limit: 255, null: false
     t.string "deploy_url", limit: 255
     t.string "lock_reason", limit: 4096
@@ -271,14 +271,14 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_21_003007) do
     t.text "cached_deploy_spec", limit: 65535
     t.integer "lock_author_id", limit: 4
     t.boolean "ignore_ci"
-    t.datetime "inaccessible_since"
+    t.datetime "inaccessible_since", precision: nil
     t.integer "estimated_deploy_duration", default: 1, null: false
-    t.datetime "continuous_delivery_delayed_since"
-    t.datetime "locked_since"
+    t.datetime "continuous_delivery_delayed_since", precision: nil
+    t.datetime "locked_since", precision: nil
     t.boolean "merge_queue_enabled", default: false, null: false
-    t.datetime "last_deployed_at"
+    t.datetime "last_deployed_at", precision: nil
     t.integer "repository_id", null: false
-    t.datetime "archived_since"
+    t.datetime "archived_since", precision: nil
     t.string "provision_status", default: "deprovisioned", null: false
     t.string "type", default: "Shipit::Stack"
     t.boolean "awaiting_provision", default: false, null: false
@@ -296,8 +296,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_21_003007) do
     t.text "description", limit: 65535
     t.string "context", limit: 255, default: "default", null: false
     t.integer "commit_id", limit: 4
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.integer "stack_id", null: false
     t.index ["commit_id"], name: "index_statuses_on_commit_id"
   end
@@ -307,8 +307,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_21_003007) do
     t.integer "since_commit_id", limit: 4
     t.integer "until_commit_id", limit: 4
     t.string "status", limit: 10, default: "pending", null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.integer "user_id", limit: 4
     t.boolean "rolled_up", default: false, null: false
     t.string "type", limit: 20
@@ -316,13 +316,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_21_003007) do
     t.integer "additions", limit: 4, default: 0
     t.integer "deletions", limit: 4, default: 0
     t.text "definition", limit: 65535
-    t.binary "gzip_output"
+    t.binary "gzip_output", limit: 16777215
     t.boolean "rollback_once_aborted", default: false, null: false
     t.text "env"
     t.integer "confirmations", default: 0, null: false
     t.boolean "allow_concurrency", default: false, null: false
-    t.datetime "started_at"
-    t.datetime "ended_at"
+    t.datetime "started_at", precision: nil
+    t.datetime "ended_at", precision: nil
     t.boolean "ignored_safeties", default: false, null: false
     t.integer "aborted_by_id"
     t.integer "rollback_once_aborted_to_id"
@@ -345,8 +345,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_21_003007) do
     t.string "slug", limit: 255
     t.string "name", limit: 255
     t.string "organization", limit: 39
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at", precision: nil, null: false
+    t.datetime "updated_at", precision: nil, null: false
     t.index ["organization", "slug"], name: "index_teams_on_organization_and_slug", unique: true
   end
 
@@ -356,8 +356,8 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_21_003007) do
     t.string "email", limit: 255
     t.string "login", limit: 39
     t.string "api_url", limit: 255
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at", precision: nil
+    t.datetime "updated_at", precision: nil
     t.string "avatar_url", limit: 255
     t.string "encrypted_github_access_token"
     t.string "encrypted_github_access_token_iv"
@@ -366,4 +366,13 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_21_003007) do
     t.index ["updated_at"], name: "index_users_on_updated_at"
   end
 
+  add_foreign_key "commit_deployment_statuses", "commit_deployments"
+  add_foreign_key "commit_deployments", "commits"
+  add_foreign_key "commit_deployments", "tasks"
+  add_foreign_key "memberships", "teams"
+  add_foreign_key "memberships", "users"
+  add_foreign_key "merge_requests", "commits", column: "base_commit_id"
+  add_foreign_key "merge_requests", "commits", column: "head_id"
+  add_foreign_key "merge_requests", "stacks"
+  add_foreign_key "merge_requests", "users", column: "merge_requested_by_id"
 end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_08_21_003007) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_27_175900) do
   create_table "api_clients", force: :cascade do |t|
     t.text "permissions", limit: 65535
     t.integer "creator_id", limit: 4
@@ -51,7 +51,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_08_21_003007) do
   create_table "commit_deployments", force: :cascade do |t|
     t.integer "commit_id"
     t.integer "task_id"
-    t.integer "github_id"
+    t.bigint "github_id"
     t.string "api_url"
     t.datetime "created_at", precision: nil, null: false
     t.datetime "updated_at", precision: nil, null: false


### PR DESCRIPTION
We're seeing overflows of this value akin to what required the fix from the `db/migrate/20230703181143_change_commit_deployment_statuses_github_id_to_big_int.rb` migration.