### PR TITLE
Ensure all `github_id` columns are 8 bytes

### DIFF
--- a/db/migrate/20250207203053_embiggen_github_ids.rb
+++ b/db/migrate/20250207203053_embiggen_github_ids.rb
@@ -1,0 +1,8 @@
+class EmbiggenGithubIds < ActiveRecord::Migration[7.2]
+  def change
+    change_column(:commit_deployments, :github_id, :bigint)
+    change_column(:github_hooks, :github_id, :bigint)
+    change_column(:teams, :github_id, :bigint)
+    change_column(:users, :github_id, :bigint)
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_08_21_003007) do
+ActiveRecord::Schema[7.2].define(version: 2025_02_07_203053) do
   create_table "api_clients", force: :cascade do |t|
     t.text "permissions", limit: 65535
     t.integer "creator_id", limit: 4
@@ -51,7 +51,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_21_003007) do
   create_table "commit_deployments", force: :cascade do |t|
     t.integer "commit_id"
     t.integer "task_id"
-    t.integer "github_id"
+    t.bigint "github_id"
     t.string "api_url"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
@@ -133,7 +133,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_21_003007) do
 
   create_table "github_hooks", force: :cascade do |t|
     t.integer "stack_id", limit: 4
-    t.integer "github_id", limit: 4
+    t.bigint "github_id"
     t.string "event", limit: 50, null: false
     t.datetime "created_at"
     t.datetime "updated_at"
@@ -340,7 +340,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_21_003007) do
   end
 
   create_table "teams", force: :cascade do |t|
-    t.integer "github_id", limit: 4
+    t.bigint "github_id"
     t.string "api_url", limit: 255
     t.string "slug", limit: 255
     t.string "name", limit: 255
@@ -351,7 +351,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_08_21_003007) do
   end
 
   create_table "users", force: :cascade do |t|
-    t.integer "github_id", limit: 4
+    t.bigint "github_id"
     t.string "name", limit: 255, null: false
     t.string "email", limit: 255
     t.string "login", limit: 39


### PR DESCRIPTION
We are currently getting `ActiveModel::RangeError (2159449066 is out of range for ActiveModel::Type::Integer with limit 4 bytes)` errors in `Shipit::CreateOnGithubJob` which suggests the ID being returned by GitHub is larger than the column we're trying to store it in.

<details>
<summary>Sample backtrace</summary>

```
 [ActiveJob] [Shipit::CreateOnGithubJob] [e2819ec7-e24e-4270-8462-0032ad38e4c0] Error performing Shipit::CreateOnGithubJob (Job ID: e2819ec7-e24e-4270-8462-0032ad38e4c0) from Sidekiq(default) in 484.55ms: ActiveModel::RangeError (2159449066 is out of range for ActiveModel::Type::Integer with limit 4 bytes):
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activemodel-7.1.4/lib/active_model/type/integer.rb:95:in `ensure_in_range'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activemodel-7.1.4/lib/active_model/type/integer.rb:71:in `serialize_cast_value'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activemodel-7.1.4/lib/active_model/type/serialize_cast_value.rb:31:in `serialize'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activemodel-7.1.4/lib/active_model/attribute.rb:208:in `_value_for_database'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activemodel-7.1.4/lib/active_model/attribute.rb:57:in `value_for_database'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/connection_adapters/abstract/quoting.rb:237:in `block in type_casted_binds'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/connection_adapters/abstract/quoting.rb:235:in `map'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/connection_adapters/abstract/quoting.rb:235:in `type_casted_binds'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/connection_adapters/postgresql_adapter.rb:891:in `exec_no_cache'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/connection_adapters/postgresql_adapter.rb:872:in `execute_and_clear'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/connection_adapters/postgresql/database_statements.rb:77:in `exec_delete'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/connection_adapters/abstract/database_statements.rb:202:in `update'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/connection_adapters/abstract/query_cache.rb:25:in `update'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/persistence.rb:608:in `_update_record'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/persistence.rb:1212:in `_update_row'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/locking/optimistic.rb:93:in `_update_row'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/persistence.rb:1234:in `_update_record'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/attribute_methods/dirty.rb:234:in `_update_record'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/callbacks.rb:449:in `block (2 levels) in _update_record'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/timestamp.rb:140:in `record_update_timestamps'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/callbacks.rb:449:in `block in _update_record'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/callbacks.rb:110:in `run_callbacks'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/callbacks.rb:952:in `_run_update_callbacks'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/callbacks.rb:449:in `_update_record'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/timestamp.rb:122:in `_update_record'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/persistence.rb:1221:in `create_or_update'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/callbacks.rb:441:in `block in create_or_update'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/callbacks.rb:121:in `block in run_callbacks'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/autosave_association.rb:375:in `around_save_collection_association'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/callbacks.rb:130:in `block in run_callbacks'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/callbacks.rb:141:in `run_callbacks'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/callbacks.rb:952:in `_run_save_callbacks'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/callbacks.rb:441:in `create_or_update'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/timestamp.rb:127:in `create_or_update'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/persistence.rb:751:in `save!'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/validations.rb:55:in `save!'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/transactions.rb:313:in `block in save!'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/transactions.rb:365:in `block in with_transaction_returning_status'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/connection_adapters/abstract/database_statements.rb:342:in `transaction'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/transactions.rb:361:in `with_transaction_returning_status'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/transactions.rb:313:in `save!'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/suppressor.rb:56:in `save!'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/persistence.rb:906:in `block in update!'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/transactions.rb:365:in `block in with_transaction_returning_status'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/connection_adapters/abstract/transaction.rb:535:in `block in within_new_transaction'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/concurrency/null_lock.rb:9:in `synchronize'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/connection_adapters/abstract/transaction.rb:532:in `within_new_transaction'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/connection_adapters/abstract/database_statements.rb:344:in `transaction'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/transactions.rb:361:in `with_transaction_returning_status'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/persistence.rb:904:in `update!'
 /var/app/current/vendor/bundle/ruby/3.2.0/bundler/gems/shipit-engine-33bdf108f72d/app/models/shipit/commit_deployment.rb:33:in `create_deployment_on_github!'
 /var/app/current/vendor/bundle/ruby/3.2.0/bundler/gems/shipit-engine-33bdf108f72d/app/models/shipit/commit_deployment.rb:12:in `create_on_github!'
 /var/app/current/vendor/bundle/ruby/3.2.0/bundler/gems/shipit-engine-33bdf108f72d/app/jobs/shipit/create_on_github_job.rb:14:in `perform'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activejob-7.1.4/lib/active_job/execution.rb:68:in `block in _perform_job'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/callbacks.rb:121:in `block in run_callbacks'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/redis-objects-1.7.0/lib/redis/lock.rb:56:in `lock'
 /var/app/current/vendor/bundle/ruby/3.2.0/bundler/gems/shipit-engine-33bdf108f72d/app/jobs/shipit/background_job/unique.rb:23:in `acquire_lock'
 /var/app/current/vendor/bundle/ruby/3.2.0/bundler/gems/shipit-engine-33bdf108f72d/app/jobs/shipit/background_job/unique.rb:11:in `block (2 levels) in <module:Unique>'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/callbacks.rb:130:in `instance_exec'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/callbacks.rb:130:in `block in run_callbacks'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/i18n-1.14.5/lib/i18n.rb:351:in `with_locale'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activejob-7.1.4/lib/active_job/translation.rb:9:in `block (2 levels) in <module:Translation>'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/callbacks.rb:130:in `instance_exec'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/callbacks.rb:130:in `block in run_callbacks'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/core_ext/time/zones.rb:65:in `use_zone'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activejob-7.1.4/lib/active_job/timezones.rb:9:in `block (2 levels) in <module:Timezones>'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/callbacks.rb:130:in `instance_exec'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/callbacks.rb:130:in `block in run_callbacks'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/callbacks.rb:141:in `run_callbacks'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activejob-7.1.4/lib/active_job/execution.rb:67:in `_perform_job'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activejob-7.1.4/lib/active_job/instrumentation.rb:32:in `_perform_job'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activejob-7.1.4/lib/active_job/execution.rb:51:in `perform_now'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activejob-7.1.4/lib/active_job/instrumentation.rb:26:in `block in perform_now'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/railties/job_runtime.rb:13:in `block in instrument'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activejob-7.1.4/lib/active_job/instrumentation.rb:40:in `block in instrument'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/notifications.rb:206:in `block in instrument'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/notifications/instrumenter.rb:58:in `instrument'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/notifications.rb:206:in `instrument'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activejob-7.1.4/lib/active_job/instrumentation.rb:39:in `instrument'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activerecord-7.1.4/lib/active_record/railties/job_runtime.rb:11:in `instrument'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activejob-7.1.4/lib/active_job/instrumentation.rb:26:in `perform_now'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activejob-7.1.4/lib/active_job/logging.rb:18:in `block in perform_now'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/tagged_logging.rb:139:in `block in tagged'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/tagged_logging.rb:39:in `tagged'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/tagged_logging.rb:139:in `tagged'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/broadcast_logger.rb:241:in `method_missing'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activejob-7.1.4/lib/active_job/logging.rb:25:in `tag_logger'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activejob-7.1.4/lib/active_job/logging.rb:18:in `perform_now'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activejob-7.1.4/lib/active_job/execution.rb:29:in `block in execute'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/callbacks.rb:121:in `block in run_callbacks'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activejob-7.1.4/lib/active_job/railtie.rb:67:in `block (4 levels) in <class:Railtie>'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/reloader.rb:77:in `block in wrap'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/execution_wrapper.rb:88:in `wrap'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/reloader.rb:74:in `wrap'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activejob-7.1.4/lib/active_job/railtie.rb:66:in `block (3 levels) in <class:Railtie>'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/callbacks.rb:130:in `instance_exec'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/callbacks.rb:130:in `block in run_callbacks'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/callbacks.rb:141:in `run_callbacks'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activejob-7.1.4/lib/active_job/execution.rb:27:in `execute'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activejob-7.1.4/lib/active_job/queue_adapters/sidekiq_adapter.rb:70:in `perform'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/sidekiq-6.5.12/lib/sidekiq/processor.rb:202:in `execute_job'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/sidekiq-6.5.12/lib/sidekiq/processor.rb:170:in `block (2 levels) in process'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/sidekiq-6.5.12/lib/sidekiq/middleware/chain.rb:172:in `invoke'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/sidekiq-6.5.12/lib/sidekiq/processor.rb:169:in `block in process'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/sidekiq-6.5.12/lib/sidekiq/processor.rb:136:in `block (6 levels) in dispatch'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/sidekiq-6.5.12/lib/sidekiq/job_retry.rb:113:in `local'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/sidekiq-6.5.12/lib/sidekiq/processor.rb:135:in `block (5 levels) in dispatch'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/sidekiq-6.5.12/lib/sidekiq/rails.rb:14:in `block in call'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/reloader.rb:77:in `block in wrap'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/execution_wrapper.rb:92:in `wrap'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/activesupport-7.1.4/lib/active_support/reloader.rb:74:in `wrap'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/sidekiq-6.5.12/lib/sidekiq/rails.rb:13:in `call'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/sidekiq-6.5.12/lib/sidekiq/processor.rb:131:in `block (4 levels) in dispatch'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/sidekiq-6.5.12/lib/sidekiq/processor.rb:263:in `stats'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/sidekiq-6.5.12/lib/sidekiq/processor.rb:126:in `block (3 levels) in dispatch'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/sidekiq-6.5.12/lib/sidekiq/job_logger.rb:13:in `call'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/sidekiq-6.5.12/lib/sidekiq/processor.rb:125:in `block (2 levels) in dispatch'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/sidekiq-6.5.12/lib/sidekiq/job_retry.rb:80:in `global'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/sidekiq-6.5.12/lib/sidekiq/processor.rb:124:in `block in dispatch'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/sidekiq-6.5.12/lib/sidekiq/job_logger.rb:39:in `prepare'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/sidekiq-6.5.12/lib/sidekiq/processor.rb:123:in `dispatch'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/sidekiq-6.5.12/lib/sidekiq/processor.rb:168:in `process'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/sidekiq-6.5.12/lib/sidekiq/processor.rb:78:in `process_one'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/sidekiq-6.5.12/lib/sidekiq/processor.rb:68:in `run'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/sidekiq-6.5.12/lib/sidekiq/component.rb:8:in `watchdog'
 /var/app/current/vendor/bundle/ruby/3.2.0/gems/sidekiq-6.5.12/lib/sidekiq/component.rb:17:in `block in safe_thread'

```

</details>

While the backtrace suggests we're hitting this issue with `CommitDeploy`, out of an abundance of precaution I went ahead and audited the entire schema to make sure all `github_id` columns were either `integer(8)` or `bigint` (which AFAIK are identical from an SQL standpoint). These were the outliers.