### PR TITLE
Support for Redis connection without SSL certificate verification #2

### DIFF
--- a/lib/shipit.rb
+++ b/lib/shipit.rb
@@ -102,15 +102,26 @@ module Shipit
   def redis
     @redis ||= Redis.new(
       url: redis_url.to_s.presence,
+      ssl: redis_ssl_params,
       logger: Rails.logger,
       reconnect_attempts: 3,
       reconnect_delay: 0.5,
-      reconnect_delay_max: 1
+      reconnect_delay_max: 1,
     )
   end
 
   def redis=(client)
     @redis ||= client
+  end
+
+  def redis_ssl_params
+    if(ENV['REDIS_SSL_VERIFY'] == 'false')
+      {
+        verify_mode: OpenSSL::SSL::VERIFY_NONE
+      }
+    else
+      {}
+    end
   end
 
   module SafeJSON


### PR DESCRIPTION
A twin of https://github.com/byroot/pubsubstub/pull/2

Context: on Heroku Key-Value addon (Valkey fork of Redis), they use TLS but with a self-signed certificate, as described here:
* https://devcenter.heroku.com/articles/connecting-heroku-redis#external-connections
* https://devcenter.heroku.com/articles/heroku-redis#security-and-compliance

This PR adds `REDIS_SSL_VERIFY` environment variable to make it work without patching Shipit's top-level module in-application.

No test coverage because no existing spec covers Redis connection.