### PR TITLE
Record Github Auth in Session when Successful

### DIFF
--- a/app/controllers/shipit/github_authentication_controller.rb
+++ b/app/controllers/shipit/github_authentication_controller.rb
@@ -12,6 +12,11 @@ module Shipit
 
       session[:user_id] = sign_in_github(auth)
 
+      # We need to set this so that the /events and /sidekiq endpoint
+      # which leverage `UserRequiredMiddleware` will recognize the user
+      # is authenticated.
+      session[:authenticated] = true
+
       redirect_to(return_url)
     end
 

--- a/test/controllers/github_authentication_controller_test.rb
+++ b/test/controllers/github_authentication_controller_test.rb
@@ -29,6 +29,7 @@ module Shipit
       user = User.find_by(login: 'shipit-user')
       assert_equal 's3cr3t', user.github_access_token
       assert_equal 44, user.github_id
+      assert session[:authenticated], "Expected session[:authenticated] to be true"
     end
   end
 end


### PR DESCRIPTION
## Changes
- Added `session[:authenticated] = true` in the GitHub authentication callback
- Added test coverage to verify this behaviour

## Testing
- Added test assertion to verify `session[:authenticated]` is set correctly
- Existing authentication flow tests continue to pass
