### PR TITLE
Add symlinks to missing files for ActionView caching

### DIFF
--- a/app/views/statuses/_status.html.erb
+++ b/app/views/statuses/_status.html.erb
@@ -1,0 +1,1 @@
+../shipit/statuses/_status.html.erb

--- a/app/views/tasks/_task.html.erb
+++ b/app/views/tasks/_task.html.erb
@@ -1,0 +1,1 @@
+../shipit/tasks/_task.html.erb


### PR DESCRIPTION
Fixes https://github.com/Shopify/shipit-engine/issues/1412. A workaround to suppress these warnings and fix a potential caching bug.