### PR TITLE
Retry GithubSyncJob if new commit sha is missing in Github response on push from target branch

### DIFF
--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -602,8 +602,8 @@ module Shipit
       tasks.where(type: 'Shipit::Deploy').success.order(id: :desc).limit(100).durations
     end
 
-    def sync_github
-      GithubSyncJob.perform_later(stack_id: id)
+    def sync_github(expected_head_sha: nil)
+      GithubSyncJob.perform_later(stack_id: id, expected_head_sha:)
     end
 
     def links

--- a/app/models/shipit/webhooks/handlers/push_handler.rb
+++ b/app/models/shipit/webhooks/handlers/push_handler.rb
@@ -6,12 +6,14 @@ module Shipit
       class PushHandler < Handler
         params do
           requires :ref
+          requires :after
         end
+
         def process
           stacks
             .not_archived
             .where(branch:)
-            .find_each(&:sync_github)
+            .find_each { |stack| stack.sync_github(expected_head_sha: params.after) }
         end
 
         private

--- a/test/controllers/webhooks_controller_test.rb
+++ b/test/controllers/webhooks_controller_test.rb
@@ -23,9 +23,11 @@ module Shipit
     test ":push with the target branch queues a GithubSyncJob" do
       request.headers['X-Github-Event'] = 'push'
 
-      body = JSON.parse(payload(:push_master)).to_json
-      assert_enqueued_with(job: GithubSyncJob, args: [stack_id: @stack.id]) do
-        post :create, body:, as: :json
+      parsed_body = JSON.parse(payload(:push_master))
+      expected_head_sha = parsed_body["after"]
+
+      assert_enqueued_with(job: GithubSyncJob, args: [stack_id: @stack.id, expected_head_sha:]) do
+        post :create, body: parsed_body.to_json, as: :json
       end
     end
 

--- a/test/models/shipit/review_stack_test.rb
+++ b/test/models/shipit/review_stack_test.rb
@@ -70,7 +70,7 @@ module Shipit
         stack.archive!(shipit_users(:codertocat))
       end
 
-      assert_enqueued_with(job: GithubSyncJob, args: [stack_id: stack.id]) do
+      assert_enqueued_with(job: GithubSyncJob, args: [stack_id: stack.id, expected_head_sha: nil]) do
         stack.unarchive!
       end
     end

--- a/test/models/shipit/stack_test.rb
+++ b/test/models/shipit/stack_test.rb
@@ -997,13 +997,13 @@ module Shipit
         @stack.archive!(shipit_users(:codertocat))
       end
 
-      assert_enqueued_with(job: GithubSyncJob, args: [stack_id: @stack.id]) do
+      assert_enqueued_with(job: GithubSyncJob, args: [stack_id: @stack.id, expected_head_sha: nil]) do
         @stack.unarchive!
       end
     end
 
     test "#update that changes the branch name triggers a GithubSync job" do
-      assert_enqueued_with(job: GithubSyncJob, args: [stack_id: @stack.id]) do
+      assert_enqueued_with(job: GithubSyncJob, args: [stack_id: @stack.id, expected_head_sha: nil]) do
         @stack.update!(branch: 'test')
       end
     end

--- a/test/models/shipit/webhooks/handlers/pull_request/review_stack_adapter_test.rb
+++ b/test/models/shipit/webhooks/handlers/pull_request/review_stack_adapter_test.rb
@@ -26,7 +26,7 @@ module Shipit
               scope: stack.repository.stacks
             )
 
-            assert_enqueued_with(job: GithubSyncJob, args: [stack_id: stack.id]) do
+            assert_enqueued_with(job: GithubSyncJob, args: [stack_id: stack.id, expected_head_sha: nil]) do
               review_stack.unarchive!
             end
           end


### PR DESCRIPTION
### What you trying to accomplish?
Part of https://github.com/Shopify/deploys/issues/2000

In this PR, we address a critical race condition where commits ready to deploy are missing from the list. This occurrs when GitHub sends push webhooks to Shipit, but GithubSyncJob queries the GitHub API which hasn't yet updated with the new commits. The job will find 0 new commits and complete successfully, leaving deployable commits missing from the system.

We solve this by passing the expected HEAD SHA from the webhook payload through to the sync job, allowing it to detect when the API hasn't caught up yet and retry with exponential backoff. 

This ensures that commits are properly synchronized even when GitHub's API experiences eventual consistency delays.
