### PR TITLE
Fix commit status

### DIFF
--- a/app/views/shipit/commits/_commit.html.erb
+++ b/app/views/shipit/commits/_commit.html.erb
@@ -4,7 +4,11 @@
       <%= render 'shipit/shared/author', author: commit.author %>
     <% end %>
 
-    <%= render 'shipit/statuses/status', status: commit.status %>
+    <% if commit.status.group? %>
+      <%= render 'shipit/statuses/group', group: commit.status %>
+    <% else %>
+      <%= render 'shipit/statuses/status', status: commit.status %>
+    <% end %>
     <div class="commit-details">
       <span class="commit-title"><%= render_commit_message_with_link commit %></span>
       <p class="commit-meta">


### PR DESCRIPTION
https://github.com/Shopify/shipit-engine/pull/1414 introduced changes to be explicit about the partial to render. However, `commit.status` can also be a group, which in those instances would render the group partial. In the current state, we cannot view a set of build status's when hovering. This fix hopes to correct this.