### PR TITLE
Bump version 0.41.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+# 0.41.1
+
+* Fix commit statuses (#1424)
+
 # 0.41.0
 
 * Display banner with optional/default message when deployment checks are triggered (#1422)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shipit-engine (0.41.0)
+    shipit-engine (0.41.1)
       active_model_serializers (~> 0.9.3)
       ansi_stream (~> 0.0.6)
       autoprefixer-rails (~> 6.4.1)

--- a/lib/shipit/version.rb
+++ b/lib/shipit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Shipit
-  VERSION = '0.41.0'
+  VERSION = '0.41.1'
 end


### PR DESCRIPTION
I want to release https://github.com/Shopify/shipit-engine/pull/1424, a bug fix. So bumping version to 0.41.1.