### PR TITLE
Don't show url if No last deployed commit exist

### DIFF
--- a/app/views/shipit/stacks/_banners.html.erb
+++ b/app/views/shipit/stacks/_banners.html.erb
@@ -70,7 +70,12 @@
         <p class="banner__text">
           Continuous Delivery for this stack is currently paused because
 
-          <%= link_to_if stack.deployment_checks_passed?, 'the pre-deploy checks failed', stack_commit_checks_path(stack, sha: stack.next_commit_to_deploy.sha) %>.
+          <% next_commit = stack.next_commit_to_deploy %>
+          <%= if stack.deployment_checks_passed? && next_commit
+                link_to 'the pre-deploy checks failed', stack_commit_checks_path(stack, sha: next_commit.sha)
+              else
+                'the pre-deploy checks failed'
+              end %>.
           You can either wait for them to pass, or trigger a deploy manually.
         </p>
       </div>


### PR DESCRIPTION
Fix https://github.com/shop/issues/issues/1614

Problem:
When user open stack page on shipit, in some state while deploying View tries to get next commit to deploy and add a URL with its `SHA` but it return a `nil` commit, so it doesn't have `SHA` property that raise an `NoMethodError: undefined method `sha' for nil`.

Fix:
- Get the next commit.
- Check if next commit exists, show add its URL to the View.
- Otherwise, show the view without the URL
