### PR TITLE
Update local redis secrets to use correct URL

### DIFF
--- a/config/secrets.development.shopify.yml
+++ b/config/secrets.development.shopify.yml
@@ -1,5 +1,5 @@
 host: 'shipit-engine.myshopify.io'
-redis_url: 'redis://shipit-engine.railgun:6379'
+redis_url: 'redis://shipit-engine.root.shopify.dev.internal:6379/7'
 
 # For creating an app see: https://github.com/Shopify/shipit-engine/blob/main/docs/setup.md#creating-the-github-app
 

--- a/test/dummy/config/secrets.test.json
+++ b/test/dummy/config/secrets.test.json
@@ -17,5 +17,5 @@
       "teams": null
     }
   },
-  "redis_url": "redis://127.0.0.1:6379/7"
+  "redis_url": "redis://shipit-engine.root.shopify.dev.internal:6379/7"
 }

--- a/test/dummy/config/secrets.yml
+++ b/test/dummy/config/secrets.yml
@@ -44,4 +44,4 @@ test:
       id: Iv1.bf2c2c45b449bfd9
       secret: ef694cd6e45223075d78d138ef014049052665f1
       teams:
-  redis_url: "redis://127.0.0.1:6379/7"
+  redis_url: "redis://shipit-engine.root.shopify.dev.internal:6379/7"


### PR DESCRIPTION
Local dev environments have changed and we need to update the Redis URL used in both development and test environments in order for them to be reachable.

**Testing**

On main, try running `dev test` and observe that Redis fails to connect. Checkout this branch and try again and observe the tests now pass.