### PR TITLE
Check deployment checks before CD delayed

### DIFF
--- a/app/views/shipit/stacks/_banners.html.erb
+++ b/app/views/shipit/stacks/_banners.html.erb
@@ -63,6 +63,17 @@
 <% end %>
 
 <% if !stack.deployment_checks_passed? %>
+<div class="banner banner--orange">
+    <div class="banner__inner wrapper">
+      <div class="banner__content">
+        <h2 class="banner__title">Stack has been locked by external system!</h2>
+        <p class = "banner__text">
+          <%= simple_format(deployment_checks_message(stack)) %>
+        </p>
+      </div>
+    </div>
+  </div>
+<% elsif stack.continuous_delivery_delayed? %>
   <div class="banner">
     <div class="banner__inner wrapper">
       <div class="banner__content">
@@ -72,17 +83,6 @@
 
           <%= link_to_if stack.deployment_checks_passed?, 'the pre-deploy checks failed', stack_commit_checks_path(stack, sha: stack.next_commit_to_deploy.sha) %>.
           You can either wait for them to pass, or trigger a deploy manually.
-        </p>
-      </div>
-    </div>
-  </div>
-<% elsif stack.continuous_delivery_delayed? %>
-  <div class="banner banner--orange">
-    <div class="banner__inner wrapper">
-      <div class="banner__content">
-        <h2 class="banner__title">Stack has been locked by external system!</h2>
-        <p class = "banner__text">
-          <%= simple_format(deployment_checks_message(stack)) %>
         </p>
       </div>
     </div>


### PR DESCRIPTION
<img width="1687" height="579" alt="image" src="https://github.com/user-attachments/assets/ecff1faf-ff7a-426b-a8d3-6c910bb34cf9" />

When the global lock is active, it appears we are hitting a conditional for `Continuous Delivery Delayed`, even though the cause of that is that deploys are locked. In this scenario, we should *only* display the lock banner and not the `Continuous Deliver Delayed` banner, as well.

This looks like we just need to change the `if/elsif` order of the check