### PR TITLE
fix local github auth problem

### DIFF
--- a/lib/shipit/commands.rb
+++ b/lib/shipit/commands.rb
@@ -35,11 +35,18 @@ module Shipit
     private
 
     def base_env
-      @base_env ||= Shipit.env.merge(
-        'GITHUB_DOMAIN' => github.domain,
-        'GITHUB_TOKEN' => github.token,
-        'GIT_ASKPASS' => Shipit::Engine.root.join('lib', 'snippets', 'git-askpass').realpath.to_s
-      )
+      @base_env ||= begin
+        env = Shipit.env.merge(
+          'GITHUB_DOMAIN' => github.domain,
+          'GITHUB_TOKEN' => github.token
+        )
+
+        unless Rails.env.development? || Rails.env.test?
+          env['GIT_ASKPASS'] = Shipit::Engine.root.join('lib', 'snippets', 'git-askpass').realpath.to_s
+        end
+
+        env
+      end
     end
 
     def github


### PR DESCRIPTION
### Problem:
When triggering a deploy locally, the underlying git CLI commands fail to generate proper auth:

<img width="2500" height="736" alt="image" src="https://github.com/user-attachments/assets/c33f4393-d4d1-469d-af6c-c6315535c346" />

### Solution:
Only set `GIT_ASKPASS` in production environments. In development and test environments, allow Git to use the developer's existing authentication setup.