### PR TITLE
Fix 404 when removing all permissions from an API client

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Unreleased
 
+# 0.45.2
+* (bugfix) Fix 404 error when removing all permissions from an API client
+
 # 0.45.1
 * Make `PRESENCE_CHECK_TIMEOUT` configurable via environment variable
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    shipit-engine (0.45.1)
+    shipit-engine (0.45.2)
       active_model_serializers (~> 0.9.3)
       ansi_stream (~> 0.0.6)
       autoprefixer-rails (~> 6.4.1)
@@ -431,4 +431,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.6.7
+  4.0.6

--- a/app/controllers/shipit/api_clients_controller.rb
+++ b/app/controllers/shipit/api_clients_controller.rb
@@ -43,7 +43,9 @@ module Shipit
     end
 
     def update_params
-      params.require(:api_client).permit(permissions: [])
+      permitted = params.require(:api_client).permit(permissions: [])
+      permitted[:permissions] = permitted[:permissions].reject(&:blank?)
+      permitted
     end
   end
 end

--- a/app/views/shipit/api_clients/show.html.erb
+++ b/app/views/shipit/api_clients/show.html.erb
@@ -17,6 +17,7 @@
   <section>
     <%= form_for @api_client, url: api_client_path(@api_client) do |f| %>
       <h3> Permissions </h3>
+      <%= hidden_field_tag 'api_client[permissions][]', '' %>
       <ul class="deploy-checklist">
         <% Shipit::ApiClient::PERMISSIONS.each do |permission| %>
           <li class="deploy-checklist__item">

--- a/lib/shipit/version.rb
+++ b/lib/shipit/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Shipit
-  VERSION = '0.45.1'
+  VERSION = '0.45.2'
 end


### PR DESCRIPTION
                                                                                                 
  - When all permission checkboxes are unchecked on the API client edit form, the browser omits the `api_client[permissions][]` parameter entirely, causing `params.require(:api_client)` to raise `ActionController::ParameterMissing` and return a `404`
  - Added a hidden field to ensure the `api_client` parameter is always present in the form submission
  - Filter out the blank hidden field value in the controller so the permissions array is clean
                                                                                                 
 ### Test plan
                                                                                                 
  - Go to `/api_clients/:id` for an existing API client with permissions                           
  - Uncheck all permission checkboxes and click Update
  - Verify the update succeeds and all permissions are removed                                   
  - Verify updating with some permissions checked still works as before