### PR TITLE
Show both the delayed and external-lock stack banners at once

### DIFF
--- a/app/views/shipit/stacks/_banners.html.erb
+++ b/app/views/shipit/stacks/_banners.html.erb
@@ -80,7 +80,9 @@
       </div>
     </div>
   </div>
-<% elsif !stack.deployment_checks_passed? %>
+<% end %>
+
+<% if !stack.deployment_checks_passed? %>
   <div class="banner banner--orange">
     <div class="banner__inner wrapper">
       <div class="banner__content">

--- a/test/controllers/stacks_controller_test.rb
+++ b/test/controllers/stacks_controller_test.rb
@@ -109,6 +109,26 @@ module Shipit
       assert_select 'a[href="http://google.com"]'
     end
 
+    test "#show renders both the delayed and external-lock banners when both apply" do
+      failing_checks = Class.new do
+        def self.call(_stack)
+          false
+        end
+      end
+      Shipit.deployment_checks = failing_checks
+      @stack.update!(continuous_deployment: true, continuous_delivery_delayed_since: Time.current)
+      assert @stack.continuous_delivery_delayed?
+      refute @stack.deployment_checks_passed?
+
+      get :show, params: { id: @stack.to_param }
+
+      assert_response :ok
+      assert_select '.banner .banner__title', text: 'Continuous Delivery Delayed!'
+      assert_select '.banner--orange .banner__title', text: 'Stack has been locked by external system!'
+    ensure
+      Shipit.deployment_checks = nil
+    end
+
     test "#create creates a Stack, queues a job to setup webhooks and redirects to it" do
       assert_difference "Stack.count" do
         post :create, params: {


### PR DESCRIPTION
## What & why

On a stack's page, two banners can apply at the same time:

- **"Continuous Delivery Delayed!"** (blue) — CD is paused because checks haven't passed.
- **"Stack has been locked by external system!"** (orange) — the stack is failing its external deployment checks.

`app/views/shipit/stacks/_banners.html.erb` rendered these as an `if` / `elsif`, so whenever `continuous_delivery_delayed?` was true the orange banner was suppressed entirely:

```erb
<% if stack.continuous_delivery_delayed? %>
  ...blue...
<% elsif !stack.deployment_checks_passed? %>
  ...orange...
<% end %>
```

These banners convey complementary information. The blue banner only says, generically, that "the pre-deploy checks failed", while the **orange banner is the only place the actual lock reason from the external system is surfaced** (via `deployment_checks_message`, e.g. an Infra Central message explaining *why* deploys are locked). When the blue banner hid the orange one, users lost that reason.

This was observed on `shopify/minerva/production`, where the stack was both CD-delayed and locked by an external system — only the blue banner showed, hiding the lock reason.

## What changed

Split the `elsif` into a separate `if` so the two conditions are evaluated independently and both banners can render when both apply. No change to either banner's content or styling.

## Current behaviour (the two banners involved)

The orange external-lock banner (the one currently being hidden), which carries the actual lock reason:

![External-system lock banner](https://raw.githubusercontent.com/ScottifyShopson/shipit-engine/scottifyshopson/banner-screenshots-assets/.pr-assets/banner-orange-external-lock.png)

The blue continuous-delivery-delayed banner, which currently takes precedence and hides the orange one:

![Continuous Delivery Delayed banner](https://raw.githubusercontent.com/ScottifyShopson/shipit-engine/scottifyshopson/banner-screenshots-assets/.pr-assets/banner-blue-cd-delayed.png)

After this change, both render at once when both conditions hold.

## Testing

- Added a controller test (`StacksControllerTest#show renders both the delayed and external-lock banners when both apply`) that sets up a stack which is simultaneously `continuous_delivery_delayed?` and failing `deployment_checks`, and asserts both banner titles render.
- ERB and Ruby syntax verified locally. I was unable to run the full test suite locally due to a `pg` native-gem build issue in my environment; relying on CI to run the suite.

## Notes

- The screenshots above are hosted on a throwaway branch in my fork (`scottifyshopson/banner-screenshots-assets`) purely so they render here; they are **not** part of this PR's diff and that branch can be deleted after merge.

🤖 Generated with anthropic/claude-opus-4-8 via pi
