### PR TITLE
Skip submodule clones in CacheDeploySpecJob

### DIFF
--- a/app/jobs/shipit/cache_deploy_spec_job.rb
+++ b/app/jobs/shipit/cache_deploy_spec_job.rb
@@ -11,7 +11,7 @@ module Shipit
       return if stack.inaccessible?
 
       commands = Commands.for(stack)
-      commands.with_temporary_working_directory(commit: stack.commits.reachable.last) do |path|
+      commands.with_temporary_working_directory(commit: stack.commits.reachable.last, recursive: false) do |path|
         stack.update!(cached_deploy_spec: DeploySpec::FileSystem.new(path, stack))
       end
     end

--- a/test/jobs/cache_deploy_spec_job_test.rb
+++ b/test/jobs/cache_deploy_spec_job_test.rb
@@ -14,7 +14,8 @@ module Shipit
       @stack.update!(cached_deploy_spec: DeploySpec.new('review' => { 'checklist' => %w[foo bar] }))
 
       dir = Pathname(Dir.tmpdir)
-      StackCommands.any_instance.expects(:with_temporary_working_directory).with(commit: @last_commit).yields(dir)
+      StackCommands.any_instance.expects(:with_temporary_working_directory)
+        .with(commit: @last_commit, recursive: false).yields(dir)
 
       assert_equal %w[foo bar], @stack.checklist
       @job.perform(@stack)

--- a/test/jobs/cache_deploy_spec_job_test.rb
+++ b/test/jobs/cache_deploy_spec_job_test.rb
@@ -15,7 +15,7 @@ module Shipit
 
       dir = Pathname(Dir.tmpdir)
       StackCommands.any_instance.expects(:with_temporary_working_directory)
-        .with(commit: @last_commit, recursive: false).yields(dir)
+                   .with(commit: @last_commit, recursive: false).yields(dir)
 
       assert_equal %w[foo bar], @stack.checklist
       @job.perform(@stack)


### PR DESCRIPTION
## What

Pass `recursive: false` to `with_temporary_working_directory` in `CacheDeploySpecJob`, so caching a deploy spec no longer clones the repo's submodules.

## Why

`CacheDeploySpecJob` runs on every `GithubSyncJob` completion (every push webhook, per stack on the branch). Each run creates a temporary working directory via `git clone --recursive`:

- The **superproject** clone is cheap — it comes from the worker's local git cache on the same filesystem (hardlinked object store).
- The **submodules** are not in that cache, so `--recursive` fetches every one of them **from their remotes over the network, on every run**, into the tmpdir on the worker's ephemeral disk.

The `--recursive` default exists for the *other* users of this helper (deploys, commit checks, fetch-deployed-revision), which execute user-defined commands that may genuinely need submodule content (CHANGELOG 0.33.0, #1110). Spec caching executes nothing: the complete file-access surface of `DeploySpec::FileSystem#cacheable` (verified across all seven discovery modules) is config candidates (`shipit*.yml` at root/`.shipit/`), `inherit_from` chains, and single-level discovery probes (`Gemfile`, `package.json`, `setup.py`, `*.gemspec`, …) resolved against the superproject tree — optionally re-rooted under `machine.directory`.

## Risk

The only way this change can alter a spec is a stack whose `machine.directory` (or an `inherit_from` target) resolves **inside a submodule** — such a stack would get a silently different spec, not an error.

Verified empirically against production (2026-08-12), instead of by inference — an earlier revision of this description leaned on `build_cacheable_deploy_spec` as an already-`recursive: false` precedent, which review correctly identified as **dead code** (orphaned by 2841e174; no callers in this engine, the host app, or any indexed Shopify repo):

- **3** non-archived stacks set `machine.directory` in their cached spec.
- **2** verified safe: no `.gitmodules` overlap with the configured directory.
- **1** (`shopify/extension-points/eps_gem`) is a zombie: the repository was renamed (`Shopify/scripts-apis`) and the configured directory `eps_gem` no longer exists on the branch — this change cannot alter its (already broken) evaluation. Flagged for archiving/fixing independently.
- **0** stacks whose spec evaluation depends on submodule content.

Known limitation of the query: cached specs are post-merge, so `inherit_from` targets are not directly queryable; an inherit-target-inside-a-submodule would be invisible to it. #1497's shadow mode provides the empirical backstop for any residual case before the checkout-less path trusts its own results.

## Impact

For deployments with many stacks and busy branches (e.g. Shopify's shipit-production during the 2026-08-11 incident), this cuts per-run network egress, ephemeral disk usage, job runtime, and memory pressure from the highest-volume git-touching job in the system. Shorter runtimes also narrow the duplicate-admission window that #1494 closes fully.

Test updated to expect the new argument; `deploy_commands_test`, `commit_checks_test`, and `background_job_test` pass unchanged.
