### PR TITLE
Set dedupe lock timeout on CacheDeploySpecJob

### DIFF
--- a/app/jobs/shipit/cache_deploy_spec_job.rb
+++ b/app/jobs/shipit/cache_deploy_spec_job.rb
@@ -7,6 +7,12 @@ module Shipit
 
     queue_as :deploys
 
+    # Caps job execution AND sets the dedupe lock expiration to match.
+    # Without it the lock falls back to Unique::DEFAULT_TIMEOUT (10s), which is
+    # far shorter than the job's runtime, letting duplicate jobs for the same
+    # stack run concurrently once the lock expires mid-run.
+    self.timeout = 15.minutes.to_i
+
     def perform(stack)
       return if stack.inaccessible?
 

--- a/app/jobs/shipit/cache_deploy_spec_job.rb
+++ b/app/jobs/shipit/cache_deploy_spec_job.rb
@@ -16,10 +16,16 @@ module Shipit
     def perform(stack)
       return if stack.inaccessible?
 
+      commit = stack.commits.reachable.last
       commands = Commands.for(stack)
-      commands.with_temporary_working_directory(commit: stack.commits.reachable.last, recursive: false) do |path|
+      commands.with_temporary_working_directory(commit:, recursive: false) do |path|
         stack.update!(cached_deploy_spec: DeploySpec::FileSystem.new(path, stack))
       end
+
+      # A duplicate enqueued while this job held the dedupe lock was dropped;
+      # if the head moved under us, that dropped job's work is still
+      # outstanding, so hand it off rather than leaving the spec stale.
+      CacheDeploySpecJob.perform_later(stack) if stack.commits.reachable.last&.id != commit&.id
     end
   end
 end

--- a/test/jobs/cache_deploy_spec_job_test.rb
+++ b/test/jobs/cache_deploy_spec_job_test.rb
@@ -21,5 +21,24 @@ module Shipit
       @job.perform(@stack)
       assert_equal [], @stack.reload.checklist
     end
+
+    test "the dedupe lock expiration covers the job runtime" do
+      assert_operator CacheDeploySpecJob.timeout, :>, BackgroundJob::Unique::DEFAULT_TIMEOUT
+      assert_equal 15.minutes.to_i, CacheDeploySpecJob.timeout
+    end
+
+    test "a duplicate job for the same stack is dropped while the lock is held" do
+      job = CacheDeploySpecJob.new(@stack)
+      duplicate = CacheDeploySpecJob.new(@stack)
+      duplicate_ran = false
+
+      job.acquire_lock do
+        duplicate.acquire_lock do
+          duplicate_ran = true
+        end
+      end
+
+      refute duplicate_ran, "duplicate should have been dropped, not executed"
+    end
   end
 end

--- a/test/jobs/cache_deploy_spec_job_test.rb
+++ b/test/jobs/cache_deploy_spec_job_test.rb
@@ -27,6 +27,42 @@ module Shipit
       assert_equal 15.minutes.to_i, CacheDeploySpecJob.timeout
     end
 
+    test "the redis lock is created with the job timeout as its expiration" do
+      mutex = mock
+      mutex.expects(:lock).yields
+      Redis::Lock.expects(:new)
+                 .with(anything, anything, expiration: 15.minutes.to_i, timeout: 0)
+                 .returns(mutex)
+
+      executed = false
+      CacheDeploySpecJob.new(@stack).acquire_lock { executed = true }
+      assert executed
+    end
+
+    test "#perform re-enqueues itself when the head moves during the run" do
+      moved_head = @stack.commits.reachable.first
+      reachable = mock
+      reachable.stubs(:last).returns(@last_commit, moved_head)
+      @stack.stubs(:commits).returns(stub(reachable:))
+      @stack.stubs(:update!) # side-effect callbacks are irrelevant to this test
+
+      StackCommands.any_instance.expects(:with_temporary_working_directory)
+                   .with(commit: @last_commit, recursive: false).yields(Pathname(Dir.tmpdir))
+
+      assert_enqueued_with(job: CacheDeploySpecJob, args: [@stack]) do
+        @job.perform(@stack)
+      end
+    end
+
+    test "#perform does not re-enqueue itself when the head is unchanged" do
+      StackCommands.any_instance.expects(:with_temporary_working_directory)
+                   .with(commit: @last_commit, recursive: false).yields(Pathname(Dir.tmpdir))
+
+      assert_no_enqueued_jobs(only: CacheDeploySpecJob) do
+        @job.perform(@stack)
+      end
+    end
+
     test "a duplicate job for the same stack is dropped while the lock is held" do
       job = CacheDeploySpecJob.new(@stack)
       duplicate = CacheDeploySpecJob.new(@stack)


### PR DESCRIPTION
Stacked on #1493.

## What

Set `self.timeout = 15.minutes.to_i` on `CacheDeploySpecJob`.

## Why

The job declares `on_duplicate :drop`, but the dedupe is backed by a Redis lock whose expiration is `self.class.timeout || DEFAULT_TIMEOUT` — and this job never set a timeout, so the lock evaporates after **10 seconds** while the job's median runtime is **~65 seconds**.

Result: the dedupe only protects the first 10 seconds of every run. After that, each newly enqueued job for the same stack finds the lock free and starts a full clone *alongside* the still-running one. Under sustained push volume this is unbounded per-stack concurrency — in shipit-production this job piled up to **~130 concurrent worker threads** (from <1 in healthy state), starving `PerformTaskJob` on the shared `deploys` queue and driving the workers' memory to the cgroup limit (chronic OOMKills, ~48 restarts/hour).

With the lock outliving the runtime, duplicates arriving mid-run are dropped in microseconds and at most one spec-cache job runs per stack, which is all the freshness this cache needs.

## The dual effect of `timeout`

`BackgroundJob#perform` also uses `timeout` as a `Timeout.timeout` execution cap, so this change additionally hard-caps runs at 15 minutes. That's the same invariant `GithubSyncJob` already maintains (`self.timeout = 60`): **execution can never outlive the lock**, which is what makes the dedupe sound. It also stops pathological runs (p99 was 42 minutes under contention) from squatting on worker threads.

## Trade-offs

- A worker killed mid-run (OOM, eviction) leaves the lock held until expiry: that stack's spec refresh is delayed by up to 15 minutes. Benign — specs rarely change and the next push re-enqueues.
- A legitimately slow run (e.g. cold-cache full clone of a very large repo) gets killed at 15 minutes and retried. With #1493 removing submodule clones, healthy runtime is dominated by a local hardlinked clone, so 15 minutes is a comfortable ceiling.

## Tests

- Asserts the timeout exceeds `Unique::DEFAULT_TIMEOUT` and equals 15 minutes.
- Asserts a duplicate job for the same stack is dropped (block not executed) while the lock is held.