### PR TITLE
Only cache the deploy spec when the sync changed something

### DIFF
--- a/app/controllers/shipit/api/stacks_controller.rb
+++ b/app/controllers/shipit/api/stacks_controller.rb
@@ -69,7 +69,12 @@ module Shipit
       def refresh
         RefreshStatusesJob.perform_later(stack_id: stack.id)
         RefreshCheckRunsJob.perform_later(stack_id: stack.id)
-        GithubSyncJob.perform_later(stack_id: stack.id)
+        # force_spec_cache: explicit refreshes always recompute the cached deploy
+        # spec, even when the head hasn't moved: refreshing is how a stale or
+        # broken cached spec is fixed. Threading it through the sync job (rather
+        # than enqueuing CacheDeploySpecJob directly) guarantees the spec is
+        # computed from the post-sync head.
+        GithubSyncJob.perform_later(stack_id: stack.id, force_spec_cache: true)
         render_resource(stack, status: :accepted)
       end
 

--- a/app/controllers/shipit/stacks_controller.rb
+++ b/app/controllers/shipit/stacks_controller.rb
@@ -94,7 +94,12 @@ module Shipit
     def refresh
       RefreshStatusesJob.perform_later(stack_id: @stack.id)
       RefreshCheckRunsJob.perform_later(stack_id: @stack.id)
-      GithubSyncJob.perform_later(stack_id: @stack.id)
+      # force_spec_cache: explicit refreshes always recompute the cached deploy
+      # spec, even when the head hasn't moved: refreshing is how a stale or
+      # broken cached spec is fixed. Threading it through the sync job (rather
+      # than enqueuing CacheDeploySpecJob directly) guarantees the spec is
+      # computed from the post-sync head.
+      GithubSyncJob.perform_later(stack_id: @stack.id, force_spec_cache: true)
       flash[:success] = 'Refresh scheduled'
       redirect_to(request.referer.presence || stack_path(@stack))
     end

--- a/app/jobs/shipit/github_sync_job.rb
+++ b/app/jobs/shipit/github_sync_job.rb
@@ -19,6 +19,8 @@ module Shipit
       @stack = Stack.find(params[:stack_id])
       expected_head_sha = params[:expected_head_sha]
       retry_count = params[:retry_count] || 0
+      head_before_sync = spec_cache_target
+      appended_commits = []
 
       handle_github_errors do
         new_commits, shared_parent = fetch_missing_commits { stack.github_commits }
@@ -38,6 +40,11 @@ module Shipit
           stack.lock_reverted_commits! if appended_commits.any?(&:revert?)
         end
       end
+      sync_changed_nothing = appended_commits.empty? &&
+                             spec_cache_target == head_before_sync &&
+                             stack.cached_deploy_spec.present?
+      return if sync_changed_nothing && !params[:force_spec_cache]
+
       CacheDeploySpecJob.perform_later(stack)
     end
 
@@ -62,6 +69,13 @@ module Shipit
     end
 
     protected
+
+    # The commit CacheDeploySpecJob would check out: the newest reachable one.
+    # If it didn't change during the sync (no appends, no detaches), the cached
+    # spec is still accurate and doesn't need to be recomputed.
+    def spec_cache_target
+      stack.commits.reachable.last&.sha
+    end
 
     def handle_github_errors
       yield

--- a/test/controllers/api/stacks_controller_test.rb
+++ b/test/controllers/api/stacks_controller_test.rb
@@ -260,8 +260,8 @@ module Shipit
         assert_json 'message', 'This operation requires the `write:stack` permission'
       end
 
-      test "#refresh queues a GithubSyncJob" do
-        assert_enqueued_with(job: GithubSyncJob, args: [stack_id: @stack.id]) do
+      test "#refresh queues a GithubSyncJob with force_spec_cache" do
+        assert_enqueued_with(job: GithubSyncJob, args: [stack_id: @stack.id, force_spec_cache: true]) do
           post :refresh, params: { id: @stack.to_param }
         end
         assert_response :accepted

--- a/test/controllers/stacks_controller_test.rb
+++ b/test/controllers/stacks_controller_test.rb
@@ -204,7 +204,7 @@ module Shipit
 
       assert_enqueued_with(job: RefreshStatusesJob, args: [stack_id: @stack.id]) do
         assert_enqueued_with(job: RefreshCheckRunsJob, args: [stack_id: @stack.id]) do
-          assert_enqueued_with(job: GithubSyncJob, args: [stack_id: @stack.id]) do
+          assert_enqueued_with(job: GithubSyncJob, args: [stack_id: @stack.id, force_spec_cache: true]) do
             post :refresh, params: { id: @stack.to_param }
           end
         end

--- a/test/jobs/github_sync_job_test.rb
+++ b/test/jobs/github_sync_job_test.rb
@@ -16,9 +16,49 @@ module Shipit
       @job.perform(stack_id: @stack.id)
     end
 
-    test "#perform finally enqueue a CacheDeploySpecJob" do
+    test "#perform does not enqueue a CacheDeploySpecJob when the sync found nothing new" do
       Stack.any_instance.stubs(:github_commits).returns(@github_commits)
       @job.stubs(:fetch_missing_commits).yields.returns([[], nil])
+
+      assert_no_enqueued_jobs(only: CacheDeploySpecJob) do
+        @job.perform(stack_id: @stack.id)
+      end
+    end
+
+    test "#perform enqueues a CacheDeploySpecJob when the cached spec is missing" do
+      @stack.update!(cached_deploy_spec: nil)
+      Stack.any_instance.stubs(:github_commits).returns(@github_commits)
+      @job.stubs(:fetch_missing_commits).yields.returns([[], nil])
+
+      assert_enqueued_with(job: CacheDeploySpecJob, args: [@stack]) do
+        @job.perform(stack_id: @stack.id)
+      end
+    end
+
+    test "#perform enqueues a CacheDeploySpecJob when nothing changed but force_spec_cache is set" do
+      Stack.any_instance.stubs(:github_commits).returns(@github_commits)
+      @job.stubs(:fetch_missing_commits).yields.returns([[], nil])
+
+      assert_enqueued_with(job: CacheDeploySpecJob, args: [@stack]) do
+        @job.perform(stack_id: @stack.id, force_spec_cache: true)
+      end
+    end
+
+    test "#perform preserves force_spec_cache across eventual-consistency retries" do
+      expected_sha = "abcd1234"
+      Stack.any_instance.expects(:github_commits).returns(@github_commits)
+      @job.expects(:fetch_missing_commits).yields.returns([[], nil])
+      @job.expects(:commit_exists?).with(expected_sha).returns(false)
+
+      expected_args = { stack_id: @stack.id, expected_head_sha: expected_sha, force_spec_cache: true, retry_count: 1 }
+      assert_enqueued_with(job: GithubSyncJob, args: [expected_args]) do
+        @job.perform(stack_id: @stack.id, expected_head_sha: expected_sha, force_spec_cache: true)
+      end
+    end
+
+    test "#perform enqueues a CacheDeploySpecJob when commits are detached without new commits" do
+      Stack.any_instance.stubs(:github_commits).returns(@github_commits)
+      @job.stubs(:fetch_missing_commits).yields.returns([[], shipit_commits(:third)])
 
       assert_enqueued_with(job: CacheDeploySpecJob, args: [@stack]) do
         @job.perform(stack_id: @stack.id)
@@ -155,7 +195,9 @@ module Shipit
       @job.expects(:fetch_missing_commits).yields.returns([[], nil])
       @job.expects(:commit_exists?).with(expected_sha).returns(true)
 
-      assert_enqueued_with(job: CacheDeploySpecJob, args: [@stack]) do
+      # No retry is scheduled, and since the sync found nothing new,
+      # no spec re-cache is needed either.
+      assert_no_enqueued_jobs(only: [GithubSyncJob, CacheDeploySpecJob]) do
         @job.perform(stack_id: @stack.id, expected_head_sha: expected_sha)
       end
     end


### PR DESCRIPTION
Stacked on #1494 (which stacks on #1493).

## What

- `GithubSyncJob` now skips the `CacheDeploySpecJob` enqueue when the sync changed nothing: no commits appended, newest reachable commit unchanged, and a cached spec already present.
- The explicit refresh endpoints (`stacks#refresh`, UI and API) enqueue `CacheDeploySpecJob` directly and unconditionally.

## Why

Every sync ended with an unconditional spec re-cache — a full clone + checkout + `shipit.yml` evaluation (~65s, disk, memory) — even when the sync was a no-op. No-op syncs are common: refresh button/API hits, duplicate webhook deliveries, and GitHub eventual-consistency double-syncs. The deploy spec is a pure function of the committed files at the stack's newest reachable commit; if that commit didn't change, recomputing the spec is guaranteed wasted work.

This cuts enqueue volume to be proportional to *actual head movement* instead of webhook/API chatter, relieving the `deploys` queue that spec-cache jobs share with real deploys.

## Correctness details

- **Rewind force-pushes** (branch reset to an older commit) append nothing but detach commits — the head still changes. The skip condition compares `commits.reachable.last&.sha` before/after the sync — the exact commit `CacheDeploySpecJob` would check out — so these still refresh the cache. (Deliberately *not* `Stack#head`, which reads `commits.reachable.first` = the oldest reachable commit under Rails' implicit ordering.)
- **Belt and braces:** the condition also checks `appended_commits.any?`, so appends enqueue even if the head comparison were somehow confounded.
- **New / cleared stacks:** `cached_deploy_spec.blank?` forces the enqueue.
- **Human escape hatch preserved (rev 2):** people use *Refresh* precisely to fix a stale or broken cached spec when the head hasn't moved. Both refresh endpoints now pass `force_spec_cache: true` through `GithubSyncJob`, which skips the conditional — threading it through the sync (rather than enqueuing `CacheDeploySpecJob` directly, as the first revision did) guarantees the spec is computed from the *post-sync* head and avoids the cross-queue race where a direct enqueue could cache the pre-sync head and then swallow the sync's follow-up via the dedupe lock. The flag survives eventual-consistency retries.
- **Inaccessible stacks** (404 → `mark_as_inaccessible!`) no longer enqueue a cache job they'd immediately no-op on — when a cached spec is already present. A blank-spec inaccessible stack still enqueues and the job early-returns; harmless.

## Tests

- No-op sync → no `CacheDeploySpecJob`
- Blank cached spec → enqueued
- Detach-only sync (rewind) → enqueued
- New commits (existing test) → enqueued
- EC-retry "processes normally" test updated: no retry **and** no re-cache when nothing changed
- Both refresh controller actions → always enqueue
