### PR TITLE
Exclude archived stacks from the scheduler loops

### DIFF
--- a/app/models/shipit/stack.rb
+++ b/app/models/shipit/stack.rb
@@ -117,11 +117,17 @@ module Shipit
     )
 
     def self.refresh_deployed_revisions
-      find_each.select(&:supports_fetch_deployed_revision?).each(&:async_refresh_deployed_revision)
+      # where.not avoids deserializing every stack's cached_deploy_spec each
+      # minute: a stack without a cached spec cannot have fetch steps.
+      not_archived
+        .where.not(cached_deploy_spec: nil)
+        .find_each
+        .select(&:supports_fetch_deployed_revision?)
+        .each(&:async_refresh_deployed_revision)
     end
 
     def self.schedule_continuous_delivery
-      where(continuous_deployment: true).find_each do |stack|
+      not_archived.where(continuous_deployment: true).find_each do |stack|
         ContinuousDeliveryJob.perform_later(stack)
       end
     end

--- a/test/models/shipit/stack_test.rb
+++ b/test/models/shipit/stack_test.rb
@@ -11,6 +11,38 @@ module Shipit
       GithubHook.any_instance.stubs(:teardown!)
     end
 
+    test ".schedule_continuous_delivery skips archived stacks" do
+      archived = shipit_stacks(:archived_6hours_ago)
+      archived.update!(continuous_deployment: true)
+      @stack.update!(continuous_deployment: true)
+
+      Stack.schedule_continuous_delivery
+
+      enqueued_args = enqueued_jobs
+                      .select { |job| job[:job] == ContinuousDeliveryJob }
+                      .map { |job| job[:args].to_s }
+      assert enqueued_args.any? { |args| args.include?("Stack/#{@stack.id}") },
+             "expected a ContinuousDeliveryJob for the active stack"
+      refute enqueued_args.any? { |args| args.include?("Stack/#{archived.id}") },
+             "archived stacks must not trigger continuous delivery"
+    end
+
+    test ".refresh_deployed_revisions skips archived stacks" do
+      archived = shipit_stacks(:archived_6hours_ago)
+      archived.update!(cached_deploy_spec: DeploySpec.new('fetch' => ['echo 1']))
+      @stack.update!(cached_deploy_spec: DeploySpec.new('fetch' => ['echo 1']))
+
+      Stack.refresh_deployed_revisions
+
+      enqueued_args = enqueued_jobs
+                      .select { |job| job[:job] == FetchDeployedRevisionJob }
+                      .map { |job| job[:args].to_s }
+      assert enqueued_args.any? { |args| args.include?("Stack/#{@stack.id}") },
+             "expected a FetchDeployedRevisionJob for the active stack with fetch steps"
+      refute enqueued_args.any? { |args| args.include?("Stack/#{archived.id}") },
+             "archived stacks must not refresh deployed revisions"
+    end
+
     test "branch defaults to default branch name" do
       @stack.branch = ""
       Shipit.github.api.expects(:repo).with("shopify/shipit-engine").returns(


### PR DESCRIPTION
Stacked on #1495 (→ #1494 → #1493).

## What

Add `.not_archived` to the two per-minute scheduler scopes:

- `Stack.schedule_continuous_delivery` — was `where(continuous_deployment: true)` over **all** stacks
- `Stack.refresh_deployed_revisions` — was `find_each` over **all** stacks

## Why

Both are driven every 60 seconds by the host app's scheduler. Archived stacks are locked (`archive!` sets `lock_reason`), so the enqueued jobs are guaranteed no-ops:

- `ContinuousDeliveryJob` exits at the lock check — but in shipit-production ~1300 archived stacks were enqueuing **~2,000 no-op jobs/minute** (~70% of all CD triggers) onto the `deploys` queue shared with real deploys. This was mitigated by hand during the 2026-08-11 incident; this makes the fix structural.
- `FetchDeployedRevisionJob` is worse than a no-op for archived stacks with `fetch` steps: it performs a **full clone + checkout** via `with_temporary_working_directory` every minute to refresh a revision display nobody can act on.

## Behavior notes

- Unarchiving already re-triggers `GithubSyncJob` via the `sync_github_if_necessary` callback, so revived stacks re-enter both loops with fresh state on the next tick — no gap.
- No behavior change for active stacks.

## Tests

- `.schedule_continuous_delivery` enqueues for an active CD stack, not for an archived one with `continuous_deployment: true`
- `.refresh_deployed_revisions` still enqueues for active stacks with fetch steps, not for an archived one