### PR TITLE
Cap inherit_from recursion in DeploySpec::FileSystem

### DIFF
--- a/app/models/shipit/deploy_spec/file_system.rb
+++ b/app/models/shipit/deploy_spec/file_system.rb
@@ -151,8 +151,17 @@ module Shipit
       end
 
       SHIPIT_CONFIG_INHERIT_FROM_KEY = "inherit_from"
-      def build_config(path, config_obj)
+      MAX_INHERIT_FROM_DEPTH = 10
+
+      def build_config(path, config_obj, depth = 0)
         return config_obj if config_obj.blank? || !config_obj.key?(SHIPIT_CONFIG_INHERIT_FROM_KEY)
+
+        # An inherit_from cycle (a.yml <-> b.yml) would otherwise recurse until
+        # SystemStackError. Surface a clear configuration error instead.
+        if depth >= MAX_INHERIT_FROM_DEPTH
+          raise Error, "inherit_from chain exceeds #{MAX_INHERIT_FROM_DEPTH} levels " \
+                       "(cycle?) while resolving #{path}"
+        end
 
         inherits_from_path = path.dirname.join(config_obj.delete(SHIPIT_CONFIG_INHERIT_FROM_KEY))
         if inherits_from_path.exist?
@@ -161,7 +170,7 @@ module Shipit
           path = inherits_from_path
         end
 
-        build_config(path, config_obj)
+        build_config(path, config_obj, depth + 1)
       end
 
       def read_config(path)

--- a/app/models/shipit/deploy_spec/git_object_file_system.rb
+++ b/app/models/shipit/deploy_spec/git_object_file_system.rb
@@ -79,7 +79,7 @@ module Shipit
       # file. The old checkout-based path is uncapped (a cycle loops forever)
       # and follows escaping paths onto the worker filesystem; both are hard
       # fallbacks here.
-      def build_config(path, config_obj)
+      def build_config(path, config_obj, depth = 0)
         if config_obj.present? && config_obj.key?(SHIPIT_CONFIG_INHERIT_FROM_KEY)
           @inherit_reads += 1
           raise FallbackRequired.new(:inherit_depth, @inherit_chain.join(' -> ')) if @inherit_reads > MAX_INHERIT_READS

--- a/test/models/deploy_spec_test.rb
+++ b/test/models/deploy_spec_test.rb
@@ -11,6 +11,31 @@ module Shipit
       @spec.stubs(:load_config).returns({})
     end
 
+    test 'an inherit_from cycle raises a clear error instead of recursing forever' do
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, 'shipit.production.yml'), "inherit_from: a.yml\n")
+        File.write(File.join(dir, 'a.yml'), "inherit_from: b.yml\n")
+        File.write(File.join(dir, 'b.yml'), "inherit_from: a.yml\n")
+
+        spec = DeploySpec::FileSystem.new(dir, @stack)
+        error = assert_raises(DeploySpec::Error) { spec.cacheable }
+        assert_match(/inherit_from chain exceeds/, error.message)
+      end
+    end
+
+    test 'an inherit_from chain under the depth cap resolves normally' do
+      Dir.mktmpdir do |dir|
+        File.write(File.join(dir, 'shipit.production.yml'), "inherit_from: a.yml\ndeploy:\n  override:\n    - echo child\n")
+        File.write(File.join(dir, 'a.yml'), "inherit_from: b.yml\n")
+        File.write(File.join(dir, 'b.yml'), "machine:\n  environment:\n    FOO: bar\n")
+
+        spec = DeploySpec::FileSystem.new(dir, @stack)
+        config = spec.cacheable.config
+        assert_equal ['echo child'], config.dig('deploy', 'override')
+        assert_equal 'bar', config.dig('machine', 'environment', 'FOO')
+      end
+    end
+
     test '#supports_fetch_deployed_revision? returns false by default' do
       refute @spec.supports_fetch_deployed_revision?
     end


### PR DESCRIPTION
Stacked on #1497. Extracted from its review (thanks @timothysmith0609 for the catch).

## What

`build_config` recurses through `inherit_from` chains with no bound. A cycle (`a.yml` ↔ `b.yml`) recurses until `SystemStackError` — which is **not** a `StandardError`, so it escapes every rescue in the calling jobs — or, post-#1494, hard-blocks a worker thread until the 15-minute execution cap kills it. Cap the chain at 10 levels and raise a clear `DeploySpec::Error` naming the resolution path, so the broken configuration surfaces to the stack owner instead.

## Why it matters beyond the obvious

- Fixes today's production behavior (the `:disabled` path everyone runs).
- Removes the one case in #1497 where falling back was *worse* than not: `GitObjectFileSystem`'s own inherit-depth guard fell back to this previously-uncapped path, converting a clean `FallbackRequired` into a stack overflow.

10 levels is generous — observed real chains are 2–3 deep. `GitObjectFileSystem#build_config` signature updated to match (extra `depth` param passed through `super`).

## Tests

- Cycle → `DeploySpec::Error` with a clear message (previously: infinite recursion)
- 3-deep legitimate chain resolves normally with correct merge semantics