### PR TITLE
Add changelog entry for the Clusterize CSP spacer-height fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 # Unreleased
+* (bugfix) Fix task output flickering and freezing on long logs. Clusterize sized its virtual-scroll
+  spacers with an inline style attribute produced by `outerHTML`, which a `style-src` Content
+  Security Policy without `'unsafe-inline'` refuses to apply. The spacers collapsed to zero height,
+  so the log viewport oscillated and stopped following new output. Heights are now applied via
+  CSSOM after insertion.
 
 # 0.45.3
 * Retry CreateOnGithubJob on transient GitHub authentication failures.


### PR DESCRIPTION
## Summary <!-- markdownlint-disable MD041 -->

Adds a changelog entry for #1499 (`e308889d`), which is currently undocumented under `# Unreleased`.

That PR fixed the task log flickering reported in
[Shopify/continuous-deployment#2208](https://github.com/Shopify/continuous-deployment/issues/2208)
— open since 2025-10-29, and something people have been living with for a long time. It is worth
being findable in the changelog rather than only in the commit log.

```md
# Unreleased
* (bugfix) Fix task output flickering and freezing on long logs. Clusterize sized its virtual-scroll
  spacers with an inline style attribute produced by `outerHTML`, which a `style-src` Content
  Security Policy without `'unsafe-inline'` refuses to apply. The spacers collapsed to zero height,
  so the log viewport oscillated and stopped following new output. Heights are now applied via
  CSSOM after insertion.
```

Documentation only, no code change.

Co-authored-by: AI (Pi/anthropic/claude-opus-5) <noreply@pi.dev>